### PR TITLE
fix(datetime-picker): `getConfigValue` is deprecated on iOS

### DIFF
--- a/.changeset/plenty-chicken-repeat.md
+++ b/.changeset/plenty-chicken-repeat.md
@@ -1,0 +1,5 @@
+---
+"@capawesome-team/capacitor-datetime-picker": patch
+---
+
+fix(ios): `getConfigValue` is deprecated

--- a/packages/datetime-picker/ios/Plugin/DatetimePickerPlugin.swift
+++ b/packages/datetime-picker/ios/Plugin/DatetimePickerPlugin.swift
@@ -84,7 +84,7 @@ public class DatetimePickerPlugin: CAPPlugin {
     private func getDatetimePickerConfig() -> DatetimePickerConfig {
         var config = DatetimePickerConfig()
 
-        if let theme = getConfigValue("theme") as? String {
+        if let theme = getConfig().getString("theme") {
             if let convertedTheme = DatetimePickerHelper.convertStringToTheme(theme) {
                 config.theme = convertedTheme
             }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).

Close #19