### PR TITLE
fix(badge): import `UserNotifications` to support MacOS

### DIFF
--- a/.changeset/tender-kids-notice.md
+++ b/.changeset/tender-kids-notice.md
@@ -1,0 +1,5 @@
+---
+"@capawesome/capacitor-badge": patch
+---
+
+fix(badge): add UserNotifications import to fix build on Mac OS

--- a/.changeset/tender-kids-notice.md
+++ b/.changeset/tender-kids-notice.md
@@ -2,4 +2,4 @@
 "@capawesome/capacitor-badge": patch
 ---
 
-fix(badge): add UserNotifications import to fix build on Mac OS
+fix(badge): import `UserNotifications` to support MacOS

--- a/packages/badge/ios/Plugin/Badge.swift
+++ b/packages/badge/ios/Plugin/Badge.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Capacitor
+import UserNotifications
 
 @objc public class Badge: NSObject {
     private var config: BadgeConfig


### PR DESCRIPTION
## Description

We're maintaining a private fork of Capacitor with slight changes for Mac OS compatibility with WKWebView (works great, actually), and the Badge plugin works well with one small tweak: need to import `UserNotifications` explicitly since it's not imported by default by Mac OS (as it is in iOS). I realize you're not attempting to support Mac OS here but it's a small, harmless addition that would be great to get in—otherwise we'll have to maintain our own fork of this repo.

## Pull request checklist

- [ ] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
