### PR TITLE
Update build.gradle

### DIFF
--- a/packages/app-update/android/build.gradle
+++ b/packages/app-update/android/build.gradle
@@ -39,8 +39,8 @@ android {
         abortOnError false
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 


### PR DESCRIPTION
Using `JavaVersion.VERSION_17` was breaking the build:

```
> Task :capawesome-capacitor-app-update:compileReleaseJavaWithJavac FAILED
Execution failed for task ':capawesome-capacitor-app-update:compileReleaseJavaWithJavac'.
> error: invalid source release: 17
```

Using `JavaVersion.VERSION_1_7` was breaking the build:
```
/node_modules/@capawesome/capacitor-app-update/android/src/main/java/io/capawesome/capacitorjs/plugins/appupdate/AppUpdatePlugin.java:71: error: lambda expressions are not supported in -source 7
                appUpdateInfo -> {
                              ^
  (use -source 8 or higher to enable lambda expressions)
```

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).
