### PR TITLE
feat(file-picker): add persistent ContentUrl functionality to pickFile on Android

### DIFF
--- a/.changeset/gold-readers-eat.md
+++ b/.changeset/gold-readers-eat.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-file-picker': minor
+---
+
+feat(android): add persistent ContentUrl functionality to pickFile

--- a/package-lock.json
+++ b/package-lock.json
@@ -6149,7 +6149,7 @@
     },
     "packages/cloudinary": {
       "name": "@capawesome/capacitor-cloudinary",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "funding": [
         {
           "type": "github",
@@ -6194,7 +6194,7 @@
     },
     "packages/datetime-picker": {
       "name": "@capawesome-team/capacitor-datetime-picker",
-      "version": "5.0.0",
+      "version": "5.1.1",
       "funding": [
         {
           "type": "github",
@@ -6280,7 +6280,7 @@
     },
     "packages/file-opener": {
       "name": "@capawesome-team/capacitor-file-opener",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "funding": [
         {
           "type": "github",
@@ -6366,7 +6366,7 @@
     },
     "packages/file-picker": {
       "name": "@capawesome/capacitor-file-picker",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "funding": [
         {
           "type": "github",

--- a/packages/file-picker/README.md
+++ b/packages/file-picker/README.md
@@ -264,11 +264,12 @@ Remove all listeners for this plugin.
 
 #### PickFilesOptions
 
-| Prop           | Type                  | Description                                                                                                                                                                                                                       | Default            |
-| -------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| **`types`**    | <code>string[]</code> | List of accepted file types. Look at [IANA Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml) for a complete list of standard media types. This option cannot be used with `multiple: true` on Android. |                    |
-| **`multiple`** | <code>boolean</code>  | Whether multiple files may be selected.                                                                                                                                                                                           | <code>false</code> |
-| **`readData`** | <code>boolean</code>  | Whether to read the file data.                                                                                                                                                                                                    | <code>false</code> |
+| Prop                    | Type                  | Description                                                                                                                                                                                                                       | Default            | Since |
+| ----------------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
+| **`persistContentUri`** | <code>boolean</code>  | Request persistent file access for reusing received path after app restart or system reboot. Only available on Android, iOS paths are persistent by default.                                                                      | <code>false</code> | 5.1.2 |
+| **`types`**             | <code>string[]</code> | List of accepted file types. Look at [IANA Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml) for a complete list of standard media types. This option cannot be used with `multiple: true` on Android. |                    |       |
+| **`multiple`**          | <code>boolean</code>  | Whether multiple files may be selected.                                                                                                                                                                                           | <code>false</code> |       |
+| **`readData`**          | <code>boolean</code>  | Whether to read the file data.                                                                                                                                                                                                    | <code>false</code> |       |
 
 
 #### PickMediaOptions

--- a/packages/file-picker/src/definitions.ts
+++ b/packages/file-picker/src/definitions.ts
@@ -92,6 +92,15 @@ export interface ConvertHeicToJpegResult {
 
 export interface PickFilesOptions {
   /**
+   * Request persistent file access for reusing received path after app restart or system reboot.
+   *
+   * Only available on Android, iOS paths are persistent by default.
+   *
+   * @since 5.1.2
+   * @default false
+   */
+  persistContentUri?: boolean;
+  /**
    * List of accepted file types.
    * Look at [IANA Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml) for a complete list of standard media types.
    *


### PR DESCRIPTION
## Change reasons
I use the plugin in an app where usage of file picker and consumption of the returned path are not at the same moment. After restarting the app or rebooting the device, the path is invalidated on Android, while it works fine on iOS.

With the provided changes and my little understanding of native Android code, in pickFile(...) it is possible to optionally use a different Intent which grants persistence permission, which will be taken later inside the activity callback.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
