### PR TITLE
fix(screen-orientation): `None of the requested orientations are supported by the view controller` error on iOS

### DIFF
--- a/.changeset/smart-trainers-pump.md
+++ b/.changeset/smart-trainers-pump.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-screen-orientation': patch
+---
+
+fix(ios): `None of the requested orientations are supported by the view controller` error

--- a/packages/screen-orientation/ios/Plugin/ScreenOrientation.swift
+++ b/packages/screen-orientation/ios/Plugin/ScreenOrientation.swift
@@ -30,7 +30,9 @@ import Capacitor
             strongSelf.requestGeometryUpdate(orientationValue: nextOrientationValue, orientationMask: nextOrientationMask)
             ScreenOrientation.supportedInterfaceOrientations = nextOrientationMask
             UINavigationController.attemptRotationToDeviceOrientation()
-            strongSelf.requestGeometryUpdate(orientationValue: currentOrientationValue, orientationMask: currentOrientationMask)
+            if #unavailable(iOS 16) {
+                strongSelf.requestGeometryUpdate(orientationValue: currentOrientationValue, orientationMask: currentOrientationMask)
+            }
             strongSelf.notifyOrientationChangeListeners(orientationType)
             completion()
         }
@@ -55,7 +57,7 @@ import Capacitor
         }
         completion(cachedOrientationType)
     }
-
+    
     @objc private func requestGeometryUpdate(orientationValue: Int, orientationMask: UIInterfaceOrientationMask) {
         if #available(iOS 16, *) {
             let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
@@ -98,7 +100,7 @@ import Capacitor
         self.currentOrientationType = orientationType
         self.plugin.notifyOrientationChangeListeners(orientationType)
     }
-
+    
     @objc private func convertOrientationValueToMask(_ orientationValue: Int) -> UIInterfaceOrientationMask {
         switch orientationValue {
         case UIInterfaceOrientation.landscapeLeft.rawValue:


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

Close #100