### PR TITLE
fix(file-picker): `pickFiles (...)` doesn't work first time on Safari

### DIFF
--- a/.changeset/funny-taxis-tie.md
+++ b/.changeset/funny-taxis-tie.md
@@ -1,5 +1,5 @@
 ---
-'@capawesome/capacitor-file-picker': minor
+'@capawesome/capacitor-file-picker': patch
 ---
 
-bug(file-picker): pickFiles on Safari web does not bring up file picker on first call #14
+fix(web): `pickFiles (...)` doesn't work first time on Safari

--- a/.changeset/funny-taxis-tie.md
+++ b/.changeset/funny-taxis-tie.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-file-picker': minor
+---
+
+bug(file-picker): pickFiles on Safari web does not bring up file picker on first call #14

--- a/packages/file-picker/src/index.ts
+++ b/packages/file-picker/src/index.ts
@@ -4,7 +4,7 @@ import type { FilePickerPlugin } from './definitions';
 import * as web from './web';
 
 const FilePicker = registerPlugin<FilePickerPlugin>('FilePicker', {
-    web:  () => new web.FilePickerWeb()
+  web: () => new web.FilePickerWeb(),
 });
 
 export * from './definitions';

--- a/packages/file-picker/src/index.ts
+++ b/packages/file-picker/src/index.ts
@@ -2,7 +2,6 @@ import { registerPlugin } from '@capacitor/core';
 
 import type { FilePickerPlugin } from './definitions';
 // See https://github.com/capawesome-team/capacitor-plugins/issues/14
-// See https://github.com/capawesome-team/capacitor-plugins/issues/14
 import * as web from './web';
 
 const FilePicker = registerPlugin<FilePickerPlugin>('FilePicker', {

--- a/packages/file-picker/src/index.ts
+++ b/packages/file-picker/src/index.ts
@@ -1,9 +1,10 @@
 import { registerPlugin } from '@capacitor/core';
 
 import type { FilePickerPlugin } from './definitions';
+import * as web from './web';
 
 const FilePicker = registerPlugin<FilePickerPlugin>('FilePicker', {
-  web: () => import('./web').then(m => new m.FilePickerWeb()),
+    web:  () => new web.FilePickerWeb()
 });
 
 export * from './definitions';

--- a/packages/file-picker/src/index.ts
+++ b/packages/file-picker/src/index.ts
@@ -2,6 +2,7 @@ import { registerPlugin } from '@capacitor/core';
 
 import type { FilePickerPlugin } from './definitions';
 // See https://github.com/capawesome-team/capacitor-plugins/issues/14
+// See https://github.com/capawesome-team/capacitor-plugins/issues/14
 import * as web from './web';
 
 const FilePicker = registerPlugin<FilePickerPlugin>('FilePicker', {

--- a/packages/file-picker/src/index.ts
+++ b/packages/file-picker/src/index.ts
@@ -1,6 +1,7 @@
 import { registerPlugin } from '@capacitor/core';
 
 import type { FilePickerPlugin } from './definitions';
+// See https://github.com/capawesome-team/capacitor-plugins/issues/14
 import * as web from './web';
 
 const FilePicker = registerPlugin<FilePickerPlugin>('FilePicker', {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

Close #14 