### PR TITLE
#131 PackageManager.getPackageInfo(packageName, 0) is deprecated as of…

### DIFF
--- a/packages/app-update/android/src/main/java/io/capawesome/capacitorjs/plugins/appupdate/AppUpdatePlugin.java
+++ b/packages/app-update/android/src/main/java/io/capawesome/capacitorjs/plugins/appupdate/AppUpdatePlugin.java
@@ -10,6 +10,8 @@ import android.content.IntentSender;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.os.Build;
+
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Logger;
 import com.getcapacitor.Plugin;
@@ -227,7 +229,13 @@ public class AppUpdatePlugin extends Plugin {
 
     private PackageInfo getPackageInfo() throws PackageManager.NameNotFoundException {
         String packageName = this.getContext().getPackageName();
-        return this.getContext().getPackageManager().getPackageInfo(packageName, 0);
+
+        // PackageManager.getPackageInfo(packageName, 0) is deprecated as of API 33: Android 13.0 (Tiramisu).
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            return this.getContext().getPackageManager().getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0));
+        } else {
+            return this.getContext().getPackageManager().getPackageInfo(packageName, 0);
+        }
     }
 
     private boolean readyForUpdate(PluginCall call, int appUpdateType) {


### PR DESCRIPTION
… API 33: Android 13.0 (Tiramisu).

Close https://github.com/capawesome-team/capacitor-plugins/issues/131

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).
- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

