### PR TITLE
docs(datetime-picker): add missing `await` to usage examples

### DIFF
--- a/packages/datetime-picker/README.md
+++ b/packages/datetime-picker/README.md
@@ -33,7 +33,7 @@ import { DatetimePicker } from '@capawesome-team/capacitor-datetime-picker';
 const present = async () => {
   const date = new Date('1995-12-24T02:23:00');
 
-  const { value } = DatetimePicker.present({
+  const { value } = await DatetimePicker.present({
     cancelButtonText: 'Cancel',
     doneButtonText: 'Ok',
     mode: 'time',


### PR DESCRIPTION
DatetimePicker.present() returns a Promise and should be awaited.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

