### PR TITLE
fix(live-update): use `identifierForVendor` to get a device id on iOS

### DIFF
--- a/.changeset/violet-ways-fold.md
+++ b/.changeset/violet-ways-fold.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-live-update': patch
+---
+
+fix(ios): use `identifierForVendor` to get a device id

--- a/packages/live-update/README.md
+++ b/packages/live-update/README.md
@@ -475,9 +475,9 @@ Only available on Android and iOS.
 
 #### GetDeviceIdResult
 
-| Prop           | Type                | Description                          | Since |
-| -------------- | ------------------- | ------------------------------------ | ----- |
-| **`deviceId`** | <code>string</code> | The unique identifier of the device. | 5.0.0 |
+| Prop           | Type                | Description                                                                                                                                                                                                                                                                    | Since |
+| -------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
+| **`deviceId`** | <code>string</code> | The unique identifier of the device. On iOS, [`identifierForVendor`](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor) is used. The value of this property is the same for apps that come from the same vendor running on the same device. | 5.0.0 |
 
 
 #### GetVersionCodeResult

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdatePlugin.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdatePlugin.java
@@ -19,7 +19,7 @@ import io.capawesome.capacitorjs.plugins.liveupdate.interfaces.Result;
 public class LiveUpdatePlugin extends Plugin {
 
     public static final String TAG = "LiveUpdate";
-    public static final String VERSION = "6.0.3";
+    public static final String VERSION = "6.0.4";
     public static final String SHARED_PREFERENCES_NAME = "CapawesomeLiveUpdate"; // DO NOT CHANGE
     public static final String ERROR_APP_ID_MISSING = "appId must be configured.";
     public static final String ERROR_BUNDLE_EXISTS = "bundle already exists.";

--- a/packages/live-update/ios/Plugin/LiveUpdate.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdate.swift
@@ -386,11 +386,7 @@ import Alamofire
     }
 
     private func getDeviceId() -> String {
-        if let deviceId = preferences.getDeviceIdForApp(appId: config.appId) {
-            return deviceId
-        }
-        let deviceId = UUID().uuidString
-        preferences.setDeviceIdForApp(appId: config.appId, deviceId)
+        let deviceId = UIDevice.current.identifierForVendor?.uuidString ?? ""
         return deviceId
     }
 

--- a/packages/live-update/ios/Plugin/LiveUpdatePlugin.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdatePlugin.swift
@@ -8,7 +8,7 @@ import Capacitor
 @objc(LiveUpdatePlugin)
 public class LiveUpdatePlugin: CAPPlugin {
     public static let tag = "LiveUpdate"
-    public static let version = "6.0.3"
+    public static let version = "6.0.4"
     public static let userDefaultsPrefix = "CapawesomeLiveUpdate" // DO NOT CHANGE
 
     private var config: LiveUpdateConfig?

--- a/packages/live-update/ios/Plugin/LiveUpdatePreferences.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdatePreferences.swift
@@ -2,20 +2,11 @@ import Foundation
 
 public class LiveUpdatePreferences: NSObject {
     private let channelKey = "channel" // DO NOT CHANGE
-    private let deviceIdKey = "deviceId" // DO NOT CHANGE
     private let customIdKey = "customId" // DO NOT CHANGE
     private let lastBundleVersionKey = "lastBundleVersion" // DO NOT CHANGE
 
     public func getChannel() -> String? {
         return UserDefaults.standard.string(forKey: applyPrefix(to: channelKey))
-    }
-
-    public func getDeviceIdForApp(appId: String?) -> String? {
-        if let appId = appId {
-            return UserDefaults.standard.string(forKey: applyPrefix(to: deviceIdKey + "_" + appId))
-        } else {
-            return UserDefaults.standard.string(forKey: applyPrefix(to: deviceIdKey))
-        }
     }
 
     public func getCustomId() -> String? {
@@ -31,15 +22,6 @@ public class LiveUpdatePreferences: NSObject {
             UserDefaults.standard.set(value, forKey: applyPrefix(to: channelKey))
         } else {
             UserDefaults.standard.removeObject(forKey: applyPrefix(to: channelKey))
-        }
-        UserDefaults.standard.synchronize()
-    }
-
-    public func setDeviceIdForApp(appId: String?, _ value: String) {
-        if let appId = appId {
-            UserDefaults.standard.set(value, forKey: applyPrefix(to: deviceIdKey + "_" + appId))
-        } else {
-            UserDefaults.standard.set(value, forKey: applyPrefix(to: deviceIdKey))
         }
         UserDefaults.standard.synchronize()
     }

--- a/packages/live-update/src/definitions.ts
+++ b/packages/live-update/src/definitions.ts
@@ -262,6 +262,9 @@ export interface GetDeviceIdResult {
   /**
    * The unique identifier of the device.
    *
+   * On iOS, [`identifierForVendor`](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor) is used.
+   * The value of this property is the same for apps that come from the same vendor running on the same device.
+   *
    * @since 5.0.0
    *
    * @example '50d2a548-80b7-4dad-adc7-97c0e79d8a89'


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).
- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

---

It seems like it is not allowed to use [UserDefaults](https://developer.apple.com/documentation/foundation/userdefaults) to store a unique device id: 

![grafik](https://github.com/capawesome-team/capacitor-plugins/assets/13857929/d93ad0a6-bc16-4f4f-917b-9155f28e07fd)

For this reason, we are migrating to [`identifierForVendor`](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor).