### PR TITLE
Support for both LANDSCAPE_PRIMARY & LANDSCAPE_SECONDARY in case of LANDSCAPE [iOS]

### DIFF
--- a/.changeset/hungry-poets-hope.md
+++ b/.changeset/hungry-poets-hope.md
@@ -2,4 +2,4 @@
 '@capawesome/capacitor-screen-orientation': patch
 ---
 
-Screen-Orientation plugin now supports both LANDSCAPE_PRIMARY and LANDSCAPE_SECONDARY for iOS platform when the orientation is locked with only LANDSCAPE
+Screen-Orientation plugin now supports both LANDSCAPE_PRIMARY and LANDSCAPE_SECONDARY for iOS (16 or later) when the orientation is locked with only LANDSCAPE

--- a/.changeset/hungry-poets-hope.md
+++ b/.changeset/hungry-poets-hope.md
@@ -2,4 +2,4 @@
 '@capawesome/capacitor-screen-orientation': patch
 ---
 
-Screen-Orientation plugin now supports both LANDSCAPE_PRIMARY and LANDSCAPE_SECONDARY for iOS (16 or later) when the orientation is locked with only LANDSCAPE
+fix(ios): lock orientation type `LANDSCAPE` now supports `LANDSCAPE_PRIMARY` and `LANDSCAPE_SECONDARY`

--- a/.changeset/hungry-poets-hope.md
+++ b/.changeset/hungry-poets-hope.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-screen-orientation': patch
+---
+
+Screen-Orientation plugin now supports both LANDSCAPE_PRIMARY and LANDSCAPE_SECONDARY for iOS platform when the orientation is locked with only LANDSCAPE

--- a/packages/screen-orientation/ios/Plugin/ScreenOrientation.swift
+++ b/packages/screen-orientation/ios/Plugin/ScreenOrientation.swift
@@ -113,14 +113,14 @@ import Capacitor
             return UIInterfaceOrientationMask.portraitUpsideDown
         default:
             let isPortrait = UIApplication.shared.windows.first?.windowScene?.interfaceOrientation.isPortrait ?? false
-            return isPortrait ? UIInterfaceOrientationMask.portrait : UIInterfaceOrientationMask.landscapeLeft
+            return isPortrait ? UIInterfaceOrientationMask.portrait : UIInterfaceOrientationMask.landscape
         }
     }
 
     @objc private func convertOrientationTypeToMask(_ orientationType: String) -> UIInterfaceOrientationMask {
         switch orientationType {
         case "landscape":
-            return UIInterfaceOrientationMask.landscapeRight
+            return UIInterfaceOrientationMask.landscape
         case "landscape-primary":
             return UIInterfaceOrientationMask.landscapeLeft
         case "landscape-secondary":


### PR DESCRIPTION
Screen-Orientation plugin now supports both `UIInterfaceOrientation.landscapeLeft` and `UIInterfaceOrientation.landscapeRight` for iOS 16 or later when the orientation is locked with `OrientationType.LANDSCAPE`

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] The changes have been tested successfully.
- [X] A changeset has been created (`npm run changeset`).
- [X] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

