### PR TITLE
Only search for the index.html in root directory

### DIFF
--- a/packages/live-update/ios/Plugin/LiveUpdate.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdate.swift
@@ -497,9 +497,8 @@ import CommonCrypto
     }
 
     private func searchIndexHtmlFile(url: URL) -> URL? {
-        let enumerator = FileManager.default.enumerator(atPath: url.path)
-        while let element = enumerator?.nextObject() as? String {
-            if element.hasSuffix("index.html") {
+        if let directoryContents = try? FileManager.default.contentsOfDirectory(atPath: url.path) {
+            for element in directoryContents where element == "index.html" {
                 return url.appendingPathComponent(element)
             }
         }


### PR DESCRIPTION
The old function searches for the first 'index.html' file it finds, including those in subdirectories. Since Qwik has many 'index.html' files in various directories, this leads to rendering a random page depending on which 'index.html' is found first. The revised function only loads the `index.html` from the root directory.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).
- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

