### PR TITLE
feat(android-foreground-service): add ability to define notification channel options

### DIFF
--- a/.changeset/hungry-hornets-impress.md
+++ b/.changeset/hungry-hornets-impress.md
@@ -1,0 +1,5 @@
+---
+'@capawesome-team/capacitor-android-foreground-service': minor
+---
+
+Added createNotificationChannel method, allowing you to specify notification channel options

--- a/packages/android-foreground-service/README.md
+++ b/packages/android-foreground-service/README.md
@@ -69,6 +69,7 @@ const stopForegroundService = async () => {
 <docgen-index>
 
 * [`moveToForeground()`](#movetoforeground)
+* [`createNotificationChannel(...)`](#createnotificationchannel)
 * [`startForegroundService(...)`](#startforegroundservice)
 * [`stopForegroundService()`](#stopforegroundservice)
 * [`checkPermissions()`](#checkpermissions)
@@ -79,6 +80,7 @@ const stopForegroundService = async () => {
 * [`removeAllListeners()`](#removealllisteners)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
+* [Enums](#enums)
 
 </docgen-index>
 
@@ -101,6 +103,27 @@ permission is granted.
 Only available on Android.
 
 **Since:** 0.3.0
+
+--------------------
+
+
+### createNotificationChannel(...)
+
+```typescript
+createNotificationChannel(options: CreateNotificationChannelOptions) => Promise<void>
+```
+
+Creates a notification channel. If you don't explicitly create a channel,
+then the plugin will create a default channel with the name "Default" and
+the description "Default".
+
+Only available on Android.
+
+| Param         | Type                                                                                          |
+| ------------- | --------------------------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#createnotificationchanneloptions">CreateNotificationChannelOptions</a></code> |
+
+**Since:** 6.1.0
 
 --------------------
 
@@ -249,6 +272,15 @@ Remove all listeners for this plugin.
 ### Interfaces
 
 
+#### CreateNotificationChannelOptions
+
+| Prop              | Type                                                                      | Description              | Default                                     | Since |
+| ----------------- | ------------------------------------------------------------------------- | ------------------------ | ------------------------------------------- | ----- |
+| **`name`**        | <code>string</code>                                                       | The channel name.        | <code>"Default"</code>                      | 6.1.0 |
+| **`description`** | <code>string</code>                                                       | The channel description. | <code>"Default"</code>                      | 6.1.0 |
+| **`importance`**  | <code><a href="#notificationimportance">NotificationImportance</a></code> | The channel importance.  | <code>NotificationImportance.DEFAULT</code> | 6.1.0 |
+
+
 #### StartForegroundServiceOptions
 
 | Prop            | Type                              | Description                                                                                                                                                                                                     | Since |
@@ -307,6 +339,22 @@ Remove all listeners for this plugin.
 #### ButtonClickedEventListener
 
 <code>(event: <a href="#buttonclickedevent">ButtonClickedEvent</a>): void</code>
+
+
+### Enums
+
+
+#### NotificationImportance
+
+| Members           | Value              |
+| ----------------- | ------------------ |
+| **`DEFAULT`**     | <code>3</code>     |
+| **`HIGH`**        | <code>4</code>     |
+| **`LOW`**         | <code>2</code>     |
+| **`MAX`**         | <code>5</code>     |
+| **`MIN`**         | <code>1</code>     |
+| **`NONE`**        | <code>0</code>     |
+| **`UNSPECIFIED`** | <code>-1000</code> |
 
 </docgen-api>
 

--- a/packages/android-foreground-service/android/src/main/java/io/capawesome/capacitorjs/plugins/foregroundservice/ForegroundServicePlugin.java
+++ b/packages/android-foreground-service/android/src/main/java/io/capawesome/capacitorjs/plugins/foregroundservice/ForegroundServicePlugin.java
@@ -1,5 +1,6 @@
 package io.capawesome.capacitorjs.plugins.foregroundservice;
 
+import android.app.NotificationManager;
 import android.Manifest;
 import android.content.Intent;
 import android.net.Uri;
@@ -55,6 +56,21 @@ public class ForegroundServicePlugin extends Plugin {
             String packageName = getContext().getPackageName();
             Intent intent = getContext().getApplicationContext().getPackageManager().getLaunchIntentForPackage(packageName);
             startActivityForResult(call, intent, MOVE_TO_FOREGROUND_CALLBACK_NAME);
+        } catch (Exception exception) {
+            call.reject(exception.getMessage());
+            Logger.error(ForegroundServicePlugin.TAG, exception.getMessage(), exception);
+        }
+    }
+
+    @PluginMethod
+    public void createNotificationChannel(PluginCall call) {
+        try {
+            implementation.createNotificationChannel(
+                call.getString("name", "Default"),
+                call.getString("description", "Default"),
+                call.getInt("importance", NotificationManager.IMPORTANCE_DEFAULT)
+            );
+            call.resolve();
         } catch (Exception exception) {
             call.reject(exception.getMessage());
             Logger.error(ForegroundServicePlugin.TAG, exception.getMessage(), exception);

--- a/packages/android-foreground-service/src/definitions.ts
+++ b/packages/android-foreground-service/src/definitions.ts
@@ -16,6 +16,16 @@ export interface ForegroundServicePlugin {
    */
   moveToForeground(): Promise<void>;
   /**
+   * Creates a notification channel. If you don't explicitly create a channel,
+   * then the plugin will create a default channel with the name "Default" and
+   * the description "Default".
+   * 
+   * Only available on Android.
+   * 
+   * @since 6.1.0
+   */
+  createNotificationChannel(options: CreateNotificationChannelOptions): Promise<void>;
+  /**
    * Starts the foreground service.
    *
    * Only available on Android.
@@ -84,6 +94,42 @@ export interface ForegroundServicePlugin {
    * @since 0.2.0
    */
   removeAllListeners(): Promise<void>;
+}
+
+export enum NotificationImportance {
+  DEFAULT = 3,
+  HIGH = 4,
+  LOW = 2,
+  MAX = 5,
+  MIN = 1,
+  NONE = 0,
+  UNSPECIFIED = -1000,
+}
+
+export interface CreateNotificationChannelOptions {
+  /**
+   * The channel name.
+   *
+   * @since 6.1.0
+   * @default "Default"
+   */
+  name?: string;
+
+  /**
+   * The channel description.
+   *
+   * @since 6.1.0
+   * @default "Default"
+   */
+  description?: string;
+
+  /**
+   * The channel importance.
+   *
+   * @since 6.1.0
+   * @default NotificationImportance.DEFAULT
+   */
+  importance?: NotificationImportance;
 }
 
 export interface StartForegroundServiceOptions {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

---

Close #266 

Adds a new `createNotificationChannel` method which allows implementing apps to create a notification channel prior to starting a foreground service. If a channel is not explicitly created, it's created with the same default values as previously when `startForegroundService` is called.