### PR TITLE
fix(live-update): reset to the default bundle if the sync has not found a bundle

### DIFF
--- a/.changeset/serious-walls-kiss.md
+++ b/.changeset/serious-walls-kiss.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-live-update': patch
+---
+
+fix: reset to the default bundle if the sync has not found a bundle

--- a/packages/live-update/README.md
+++ b/packages/live-update/README.md
@@ -71,6 +71,7 @@ We recommend to declare [`CA92.1`](https://developer.apple.com/documentation/bun
 | **`autoDeleteBundles`** | <code>boolean</code>      | Whether or not to automatically delete unused bundles. When enabled, the plugin will automatically delete unused bundles after calling `ready()`.                                                                                                                                    | <code>false</code> | 5.0.0 |
 | **`defaultChannel`**    | <code>string</code>       | The default channel of the app.                                                                                                                                                                                                                                                      |                    | 6.3.0 |
 | **`enabled`**           | <code>boolean</code>      | Whether or not the plugin is enabled.                                                                                                                                                                                                                                                | <code>true</code>  | 5.0.0 |
+| **`httpTimeout`**       | <code>number</code>       | The timeout in milliseconds for HTTP requests.                                                                                                                                                                                                                                       | <code>60000</code> | 6.4.0 |
 | **`location`**          | <code>'us' \| 'eu'</code> | The location of the server to use when using [Capawesome Cloud](https://capawesome.io/cloud).                                                                                                                                                                                        | <code>'us'</code>  | 6.2.0 |
 | **`publicKey`**         | <code>string</code>       | The public key to verify the integrity of the bundle. The public key must be a PEM-encoded RSA public key.                                                                                                                                                                           |                    | 6.1.0 |
 | **`readyTimeout`**      | <code>number</code>       | The timeout in milliseconds to wait for the app to be ready before resetting to the default bundle.                                                                                                                                                                                  | <code>10000</code> | 5.0.0 |
@@ -88,6 +89,7 @@ In `capacitor.config.json`:
       "autoDeleteBundles": undefined,
       "defaultChannel": 'production',
       "enabled": undefined,
+      "httpTimeout": undefined,
       "location": 'eu',
       "publicKey": '-----BEGIN PUBLIC KEY-----MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDDodf1SD0OOn6hIlDuKBza0Ed0OqtwyVJwiyjmE9BJaZ7y8ZUfcF+SKmd0l2cDPM45XIg2tAFux5n29uoKyHwSt+6tCi5CJA5Z1/1eZruRRqABLonV77KS3HUtvOgqRLDnKSV89dYZkM++NwmzOPgIF422mvc+VukcVOBfc8/AHQIDAQAB-----END PUBLIC KEY-----',
       "readyTimeout": undefined,
@@ -111,6 +113,7 @@ const config: CapacitorConfig = {
       autoDeleteBundles: undefined,
       defaultChannel: 'production',
       enabled: undefined,
+      httpTimeout: undefined,
       location: 'eu',
       publicKey: '-----BEGIN PUBLIC KEY-----MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDDodf1SD0OOn6hIlDuKBza0Ed0OqtwyVJwiyjmE9BJaZ7y8ZUfcF+SKmd0l2cDPM45XIg2tAFux5n29uoKyHwSt+6tCi5CJA5Z1/1eZruRRqABLonV77KS3HUtvOgqRLDnKSV89dYZkM++NwmzOPgIF422mvc+VukcVOBfc8/AHQIDAQAB-----END PUBLIC KEY-----',
       readyTimeout: undefined,
@@ -620,9 +623,10 @@ Only available on Android and iOS.
 
 #### SyncResult
 
-| Prop               | Type                        | Description                                                                                                | Since |
-| ------------------ | --------------------------- | ---------------------------------------------------------------------------------------------------------- | ----- |
-| **`nextBundleId`** | <code>string \| null</code> | The identifier of the next bundle to use. If `null`, the app is up-to-date and no new bundle is available. | 5.0.0 |
+| Prop                  | Type                        | Description                                                                               | Since |
+| --------------------- | --------------------------- | ----------------------------------------------------------------------------------------- | ----- |
+| **`currentBundleId`** | <code>string \| null</code> | The unique identifier of the current bundle. If `null`, the default bundle is being used. | 7.0.0 |
+| **`nextBundleId`**    | <code>string \| null</code> | The identifier of the next bundle to use. If `null`, the default bundle is being used.    | 5.0.0 |
 
 </docgen-api>
 

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/classes/api/GetLatestBundleResponse.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/classes/api/GetLatestBundleResponse.java
@@ -5,6 +5,7 @@ import org.json.JSONObject;
 
 public class GetLatestBundleResponse {
 
+    @Nullable
     private String bundleId;
 
     @Nullable
@@ -13,7 +14,15 @@ public class GetLatestBundleResponse {
     @Nullable
     private String signature;
 
+    @Nullable
     private String url;
+
+    public GetLatestBundleResponse() {
+        this.bundleId = null;
+        this.checksum = null;
+        this.signature = null;
+        this.url = null;
+    }
 
     public GetLatestBundleResponse(JSONObject responseJson) {
         this.bundleId = responseJson.optString("bundleId");
@@ -32,6 +41,7 @@ public class GetLatestBundleResponse {
         this.url = responseJson.optString("url");
     }
 
+    @Nullable
     public String getBundleId() {
         return bundleId;
     }
@@ -46,6 +56,7 @@ public class GetLatestBundleResponse {
         return signature;
     }
 
+    @Nullable
     public String getUrl() {
         return url;
     }

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/classes/results/SyncResult.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/classes/results/SyncResult.java
@@ -7,15 +7,19 @@ import org.json.JSONObject;
 
 public class SyncResult implements Result {
 
+  @Nullable
+  private  final String currentBundleId;
     @Nullable
     private final String nextBundleId;
 
-    public SyncResult(@Nullable String nextBundleId) {
-        this.nextBundleId = nextBundleId;
+    public SyncResult(@Nullable String currentBundleId, @Nullable String nextBundleId) {
+        this.currentBundleId = currentBundleId;
+      this.nextBundleId = nextBundleId;
     }
 
     public JSObject toJSObject() {
         JSObject result = new JSObject();
+        result.put("currentBundleId", currentBundleId == null ? JSONObject.NULL : currentBundleId);
         result.put("nextBundleId", nextBundleId == null ? JSONObject.NULL : nextBundleId);
         return result;
     }

--- a/packages/live-update/ios/Plugin/Protocols/Api/GetLatestBundleResponse.swift
+++ b/packages/live-update/ios/Plugin/Protocols/Api/GetLatestBundleResponse.swift
@@ -1,6 +1,6 @@
 struct GetLatestBundleResponse: Codable {
-    var bundleId: String
+    var bundleId: String?
     var checksum: String?
     var signature: String?
-    var url: String
+    var url: String?
 }

--- a/packages/live-update/src/definitions.ts
+++ b/packages/live-update/src/definitions.ts
@@ -412,9 +412,17 @@ export interface SetCustomIdOptions {
  */
 export interface SyncResult {
   /**
+   * The unique identifier of the current bundle.
+   *
+   * If `null`, the default bundle is being used.
+   *
+   * @since 7.0.0
+   */
+  currentBundleId: string | null;
+  /**
    * The identifier of the next bundle to use.
    *
-   * If `null`, the app is up-to-date and no new bundle is available.
+   * If `null`, the default bundle is being used.
    *
    * @since 5.0.0
    */


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).
- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

Close #272

---

BREAKING CHANGE: `SyncResult.nextBundleId` is now always set and only returns `null` when resetting to the default bundle