### PR TITLE
fix(live-update): `resetOnUpdate` configuration option only checked the `CFBundleVersion` but not the `CFBundleShortVersionString`

### DIFF
--- a/.changeset/quick-bikes-cheat.md
+++ b/.changeset/quick-bikes-cheat.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-live-update': patch
+---
+
+fix(ios): `resetOnUpdate` configuration option only checked the `CFBundleVersion` but not the `CFBundleShortVersionString`

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
@@ -237,6 +237,7 @@ public class LiveUpdate {
     }
 
     public void reset() {
+        Logger.debug(LiveUpdatePlugin.TAG, "App was updated. Resetting to default bundle.");
         setNextCapacitorServerPathToDefaultWebAssetDir();
     }
 

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
@@ -104,6 +104,7 @@ public class LiveUpdate {
 
         if (config.getEnabled()) {
             if (wasUpdated() && config.getResetOnUpdate()) {
+                Logger.debug(LiveUpdatePlugin.TAG, "App was updated. Resetting to default bundle.");
                 reset();
             } else {
                 startRollbackTimer();
@@ -237,7 +238,6 @@ public class LiveUpdate {
     }
 
     public void reset() {
-        Logger.debug(LiveUpdatePlugin.TAG, "App was updated. Resetting to default bundle.");
         setNextCapacitorServerPathToDefaultWebAssetDir();
     }
 

--- a/packages/live-update/ios/Plugin/LiveUpdate.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdate.swift
@@ -807,8 +807,7 @@ import CommonCrypto
             // If the current bundle version is not set, return true for safety reasons
             return true
         }
-        CAPLog.print(lastBundleShortVersionString + "_" + lastBundleVersionString)
-        CAPLog.print(currentBundleShortVersionString + "_" + currentBundleVersionString)
+        // `CFBundleVersion` is not unique across different versions of the app
         return lastBundleShortVersionString + "_" + lastBundleVersionString != currentBundleShortVersionString + "_" + currentBundleVersionString
     }
 }

--- a/packages/live-update/ios/Plugin/LiveUpdate.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdate.swift
@@ -43,7 +43,7 @@ import CommonCrypto
             } else {
                 startRollbackTimer()
             }
-            saveCurrentBundleVersion()
+            saveCurrentBundleShortVersionStringAndBundleVersion()
         }
     }
 
@@ -167,6 +167,7 @@ import CommonCrypto
     }
 
     @objc public func reset() {
+        CAPLog.print("[", LiveUpdatePlugin.tag, "] ", "App was updated. Resetting to default bundle.")
         self.setNextCapacitorServerPathToDefaultWebAssetDir()
     }
 
@@ -615,10 +616,10 @@ import CommonCrypto
         setCurrentCapacitorServerPathToDefaultWebAssetDir()
     }
 
-    private func saveCurrentBundleVersion() {
-        guard let currentBundleVersion = Bundle.main.infoDictionary?["CFBundleVersion"] as? String else {
-            return
-        }
+    private func saveCurrentBundleShortVersionStringAndBundleVersion() {
+        let currentBundleShortVersionString = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+        preferences.setLastBundleShortVersionString(currentBundleShortVersionString)
+        let currentBundleVersion = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
         preferences.setLastBundleVersion(currentBundleVersion)
     }
 
@@ -790,19 +791,25 @@ import CommonCrypto
     }
 
     private func wasUpdated() -> Bool {
-        guard let lastBundleVersionString = preferences.getLastBundleVersion() else {
-            return false
+        guard let lastBundleShortVersionString = preferences.getLastBundleShortVersionString() else {
+            // If the last bundle short version is not set, the app may have been updated
+            return true
         }
-        guard let lastBundleVersion = Int(lastBundleVersionString) else {
-            return false
+        guard let lastBundleVersionString = preferences.getLastBundleVersion() else {
+            // If the last bundle version is not set, the app may have been updated
+            return true
+        }
+        guard let currentBundleShortVersionString = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {
+            // If the current bundle short version is not set, return true for safety reasons
+            return true
         }
         guard let currentBundleVersionString = Bundle.main.infoDictionary?["CFBundleVersion"] as? String else {
-            return false
+            // If the current bundle version is not set, return true for safety reasons
+            return true
         }
-        guard let currentBundleVersion = Int(currentBundleVersionString) else {
-            return false
-        }
-        return currentBundleVersion > lastBundleVersion
+        CAPLog.print(lastBundleShortVersionString + "_" + lastBundleVersionString)
+        CAPLog.print(currentBundleShortVersionString + "_" + currentBundleVersionString)
+        return lastBundleShortVersionString + "_" + lastBundleVersionString != currentBundleShortVersionString + "_" + currentBundleVersionString
     }
 }
 

--- a/packages/live-update/ios/Plugin/LiveUpdate.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdate.swift
@@ -39,6 +39,7 @@ import CommonCrypto
 
         if config.enabled {
             if wasUpdated() && config.resetOnUpdate {
+                CAPLog.print("[", LiveUpdatePlugin.tag, "] ", "App was updated. Resetting to default bundle.")
                 reset()
             } else {
                 startRollbackTimer()
@@ -167,7 +168,6 @@ import CommonCrypto
     }
 
     @objc public func reset() {
-        CAPLog.print("[", LiveUpdatePlugin.tag, "] ", "App was updated. Resetting to default bundle.")
         self.setNextCapacitorServerPathToDefaultWebAssetDir()
     }
 

--- a/packages/live-update/ios/Plugin/LiveUpdatePreferences.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdatePreferences.swift
@@ -3,6 +3,7 @@ import Foundation
 public class LiveUpdatePreferences: NSObject {
     private let channelKey = "channel" // DO NOT CHANGE
     private let customIdKey = "customId" // DO NOT CHANGE
+    private let lastBundleShortVersionStringKey = "lastBundleShortVersionString" // DO NOT CHANGE
     private let lastBundleVersionKey = "lastBundleVersion" // DO NOT CHANGE
 
     public func getChannel() -> String? {
@@ -11,6 +12,10 @@ public class LiveUpdatePreferences: NSObject {
 
     public func getCustomId() -> String? {
         return UserDefaults.standard.string(forKey: applyPrefix(to: customIdKey))
+    }
+    
+    public func getLastBundleShortVersionString() -> String? {
+        return UserDefaults.standard.string(forKey: applyPrefix(to: lastBundleShortVersionStringKey))
     }
 
     public func getLastBundleVersion() -> String? {
@@ -30,9 +35,22 @@ public class LiveUpdatePreferences: NSObject {
         UserDefaults.standard.set(value, forKey: applyPrefix(to: customIdKey))
         UserDefaults.standard.synchronize()
     }
+    
+    public func setLastBundleShortVersionString(_ value: String?) {
+        if let value = value {
+            UserDefaults.standard.set(value, forKey: applyPrefix(to: lastBundleShortVersionStringKey))
+        } else {
+            UserDefaults.standard.removeObject(forKey: applyPrefix(to: lastBundleShortVersionStringKey))
+        }
+        UserDefaults.standard.synchronize()
+    }
 
-    public func setLastBundleVersion(_ value: String) {
-        UserDefaults.standard.set(value, forKey: applyPrefix(to: lastBundleVersionKey))
+    public func setLastBundleVersion(_ value: String?) {
+        if let value = value {
+            UserDefaults.standard.set(value, forKey: applyPrefix(to: lastBundleVersionKey))
+        } else {
+            UserDefaults.standard.removeObject(forKey: applyPrefix(to: lastBundleVersionKey))
+        }
         UserDefaults.standard.synchronize()
     }
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

Some customers do not seem to increment the `CFBundleVersion` permanently with each build but start again at 1 with each new `CFBundleShortVersionString`. For these customers the `resetOnUpdate` configuration option has not worked so far.