### PR TITLE
refactor(live-update): replace `ZipArchive` with `ZIPFoundation`

### DIFF
--- a/.changeset/two-bulldogs-cheat.md
+++ b/.changeset/two-bulldogs-cheat.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-live-update': patch
+---
+
+Replace ZipArchive with ZIPFoundation

--- a/packages/live-update/Package.swift
+++ b/packages/live-update/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "6.0.0"),
         .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.9.0")),
-        .package(url: "https://github.com/ZipArchive/ZipArchive.git", .upToNextMinor(from: "2.4.0"))
+        .package(url: "https://github.com/weichsel/ZIPFoundation.git", .upToNextMajor(from: "0.9.0"))
     ],
     targets: [
         .target(
@@ -21,7 +21,7 @@ let package = Package(
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
                 .product(name: "Alamofire", package: "Alamofire"),
-                .product(name: "ZipArchive", package: "ZipArchive")
+                .product(name: "ZIPFoundation", package: "ZIPFoundation")
             ],
             path: "ios/Plugin"),
         .testTarget(

--- a/packages/live-update/ios/Plugin/LiveUpdate.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdate.swift
@@ -1,10 +1,6 @@
 import Foundation
 import CryptoKit
-#if canImport(ZipArchive)
-import ZipArchive
-#else
-import SSZipArchive
-#endif
+import ZIPFoundation
 import Capacitor
 import Alamofire
 import CommonCrypto
@@ -274,9 +270,9 @@ import CommonCrypto
 
     private func addBundleOfTypeZip(bundleId: String, zipFile: URL) async throws {
         // Unzip the bundle
-        let unzippedDirectory = self.unzipFile(zipFile: zipFile)
+        let unzippedDirectory = try unzipFile(zipFile: zipFile)
         // Add the bundle
-        try self.addBundle(bundleId: bundleId, directory: unzippedDirectory)
+        try addBundle(bundleId: bundleId, directory: unzippedDirectory)
     }
 
     private func buildCapacitorServerPathFor(bundleId: String?) -> String {
@@ -713,10 +709,12 @@ import CommonCrypto
         rollbackDispatchWorkItem?.cancel()
     }
 
-    private func unzipFile(zipFile: URL) -> URL {
-        let destinationDirectory = zipFile.deletingPathExtension()
-        SSZipArchive.unzipFile(atPath: zipFile.path, toDestination: destinationDirectory.path)
-        return destinationDirectory
+    func unzipFile(zipFile: URL) throws -> URL {
+        let destinationURL = zipFile.deletingPathExtension()
+        let fileManager = FileManager()
+        try fileManager.createDirectory(at: destinationURL, withIntermediateDirectories: true, attributes: nil)
+        try fileManager.unzipItem(at: zipFile, to: destinationURL)
+        return destinationURL
     }
 
     private func verifyFile(url: URL, checksum: String?, signature: String?) throws {

--- a/packages/live-update/ios/PluginTests/LiveUpdateTests.swift
+++ b/packages/live-update/ios/PluginTests/LiveUpdateTests.swift
@@ -11,6 +11,8 @@ class LiveUpdateTests: XCTestCase {
 //        let implementation = LiveUpdate(config: .init(), plugin: .init())
 //        let value = "Hello, World!"
 //        let result = implementation.echo(value)
+
+//        XCTAssertEqual(value, result)
     }
 
     func testUnzipFile() {

--- a/packages/live-update/ios/PluginTests/LiveUpdateTests.swift
+++ b/packages/live-update/ios/PluginTests/LiveUpdateTests.swift
@@ -1,5 +1,6 @@
 import XCTest
-@testable import Plugin
+import ZIPFoundation
+@testable import LiveUpdatePlugin
 
 class LiveUpdateTests: XCTestCase {
 
@@ -7,10 +8,40 @@ class LiveUpdateTests: XCTestCase {
         // This is an example of a functional test case for a plugin.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
 
-        let implementation = LiveUpdate()
-        let value = "Hello, World!"
-        let result = implementation.echo(value)
+//        let implementation = LiveUpdate(config: .init(), plugin: .init())
+//        let value = "Hello, World!"
+//        let result = implementation.echo(value)
+    }
 
-        XCTAssertEqual(value, result)
+    func testUnzipFile() {
+        let config = LiveUpdateConfig()
+        let plugin = LiveUpdatePlugin()
+        let implementation = LiveUpdate(config: config, plugin: plugin)
+        
+        // Create a dummy text file for testing
+        let fileManager = FileManager()
+        let currentWorkingPath = fileManager.currentDirectoryPath
+        var sourceURL = URL(fileURLWithPath: currentWorkingPath)
+        sourceURL.appendPathComponent("test.txt")
+        fileManager.createFile(atPath: sourceURL.path, contents: "test".data(using: .utf8), attributes: nil)
+        
+        // Create a zip archive
+        var destinationURL = URL(fileURLWithPath: currentWorkingPath)
+        destinationURL.appendPathComponent("test.zip")
+        do {
+            try fileManager.zipItem(at: sourceURL, to: destinationURL)
+            
+            // Unzip the file
+            let unzippedDirectory = try implementation.unzipFile(zipFile: destinationURL)
+            let unzippedFilePath = unzippedDirectory.appendingPathComponent("test.txt")
+            XCTAssertTrue(fileManager.fileExists(atPath: unzippedFilePath.path))
+            
+            // Clean up
+            try fileManager.removeItem(at: destinationURL)
+            try fileManager.removeItem(at: unzippedDirectory)
+            try fileManager.removeItem(at: sourceURL)
+        } catch {
+            XCTFail("Error occurred during unzipFile test: \(error)")
+        }
     }
 }

--- a/packages/live-update/ios/Podfile
+++ b/packages/live-update/ios/Podfile
@@ -23,7 +23,7 @@ end
 target 'Plugin' do
   capacitor_pods
   pod 'Alamofire', '5.9.0'
-  pod 'SSZipArchive', '2.2.3'
+  pod 'ZIPFoundation', '~> 0.9'
 end
 
 target 'PluginTests' do


### PR DESCRIPTION
I tried to see how to have unzip without any dependencies but it was a bit more complex than I thought.
I decided to created this PR to replace the ZipArchive with ZIPFoundation which achieves the same functionality and is not outdated due to minimum ios Required version. I also added a test that makes sure unzip works correct

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

