### PR TITLE
fix(android-edge-to-edge-support): support different devices #428

### DIFF
--- a/.changeset/warm-years-hug.md
+++ b/.changeset/warm-years-hug.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-android-edge-to-edge-support': patch
+---
+
+support android devices by api level (<= 29 (Android 10) and >=35 (Android 15))

--- a/.changeset/warm-years-hug.md
+++ b/.changeset/warm-years-hug.md
@@ -2,4 +2,4 @@
 '@capawesome/capacitor-android-edge-to-edge-support': patch
 ---
 
-support android devices by api level (<= 29 (Android 10) and >=35 (Android 15))
+fix: remove bottom margin if keyboard is visible

--- a/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
+++ b/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
@@ -47,15 +47,14 @@ public class EdgeToEdge {
 
             ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                mlp.bottomMargin = insets.bottom;
-            }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
                 if (keyboardVisible) {
                     mlp.bottomMargin = 0;
                 } else {
                     mlp.bottomMargin = insets.bottom;
                 }
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                mlp.bottomMargin = insets.bottom;
             }
 
             mlp.leftMargin = insets.left;

--- a/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
+++ b/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
@@ -1,5 +1,6 @@
 package io.capawesome.capacitorjs.plugins.androidedgetoedgesupport;
 
+import android.os.Build;
 import android.graphics.Color;
 import android.view.View;
 import android.view.ViewGroup;
@@ -42,8 +43,21 @@ public class EdgeToEdge {
         // Apply insets to disable the edge-to-edge feature
         ViewCompat.setOnApplyWindowInsetsListener(view, (v, windowInsets) -> {
             Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            Boolean keyboardVisible = windowInsets.isVisible(WindowInsetsCompat.Type.ime());
+
             ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
-            mlp.bottomMargin = insets.bottom;
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                mlp.bottomMargin = insets.bottom;
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                if (keyboardVisible) {
+                    mlp.bottomMargin = 0;
+                } else {
+                    mlp.bottomMargin = insets.bottom;
+                }
+            }
+
             mlp.leftMargin = insets.left;
             mlp.rightMargin = insets.right;
             mlp.topMargin = insets.top;

--- a/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
+++ b/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
@@ -1,7 +1,7 @@
 package io.capawesome.capacitorjs.plugins.androidedgetoedgesupport;
 
-import android.os.Build;
 import android.graphics.Color;
+import android.os.Build;
 import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.NonNull;


### PR DESCRIPTION
Support more devices with edge to edge.

- On API Level 35 and higher, Edge to Edge is enabled automatically
- -> If the keyboard is visible, it's not needed to add a margin
- API Level 29 and lower does not need a bottom margin because the navigation bar is always visible

fixes #428

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

