### PR TITLE
feat(posthog): add getSessionId method for iOS and Android

### DIFF
--- a/.changeset/cyan-wolves-burn.md
+++ b/.changeset/cyan-wolves-burn.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-posthog': major
+---
+
+feat: add getSessionId method for iOS and Android

--- a/.changeset/cyan-wolves-burn.md
+++ b/.changeset/cyan-wolves-burn.md
@@ -1,5 +1,5 @@
 ---
-'@capawesome/capacitor-posthog': major
+'@capawesome/capacitor-posthog': minor
 ---
 
-feat: add getSessionId method for iOS and Android
+feat: add `getSessionId()` method

--- a/.changeset/fluffy-yaks-raise.md
+++ b/.changeset/fluffy-yaks-raise.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-posthog': major
+---
+
+fix: fix getSessionId method for Android where it returns UUID instead of String

--- a/.changeset/fluffy-yaks-raise.md
+++ b/.changeset/fluffy-yaks-raise.md
@@ -1,5 +1,0 @@
----
-'@capawesome/capacitor-posthog': major
----
-
-fix: fix getSessionId method for Android where it returns UUID instead of String

--- a/packages/posthog/README.md
+++ b/packages/posthog/README.md
@@ -111,6 +111,7 @@ const unregister = async () => {
 * [`capture(...)`](#capture)
 * [`flush()`](#flush)
 * [`getFeatureFlag(...)`](#getfeatureflag)
+* [`getSessionId()`](#getsessionid)
 * [`group(...)`](#group)
 * [`identify(...)`](#identify)
 * [`isFeatureEnabled(...)`](#isfeatureenabled)
@@ -190,6 +191,23 @@ Get the value of a feature flag.
 | **`options`** | <code><a href="#getfeatureflagoptions">GetFeatureFlagOptions</a></code> |
 
 **Returns:** <code>Promise&lt;<a href="#getfeatureflagresult">GetFeatureFlagResult</a>&gt;</code>
+
+**Since:** 7.0.0
+
+--------------------
+
+
+### getSessionId()
+
+```typescript
+getSessionId() => Promise<GetSessionIdResult>
+```
+
+Get the current session ID.
+
+Only available on Android and iOS.
+
+**Returns:** <code>Promise&lt;<a href="#getsessionidresult">GetSessionIdResult</a>&gt;</code>
 
 **Since:** 7.0.0
 
@@ -377,6 +395,13 @@ Remove a super property.
 | Prop      | Type                | Description                  | Since |
 | --------- | ------------------- | ---------------------------- | ----- |
 | **`key`** | <code>string</code> | The key of the feature flag. | 7.0.0 |
+
+
+#### GetSessionIdResult
+
+| Prop            | Type                        | Description                                                              | Since |
+| --------------- | --------------------------- | ------------------------------------------------------------------------ | ----- |
+| **`sessionId`** | <code>string \| null</code> | The current session ID. If no session is active, the value will be null. | 8.0.0 |
 
 
 #### GroupOptions

--- a/packages/posthog/README.md
+++ b/packages/posthog/README.md
@@ -13,7 +13,7 @@ npx cap sync
 
 #### Variables
 
-This plugin will use the following project variables (defined in your app’s `variables.gradle` file):
+This plugin will use the following project variables (defined in your app's `variables.gradle` file):
 
 - `$androidxCoreKtxVersion` version of `androidx.core:core-ktx` (default: `1.13.1`)
 - `$posthogVersion` version of `com.posthog:posthog-android` (default: `3.10.0`)
@@ -209,7 +209,7 @@ Only available on Android and iOS.
 
 **Returns:** <code>Promise&lt;<a href="#getsessionidresult">GetSessionIdResult</a>&gt;</code>
 
-**Since:** 7.0.0
+**Since:** 7.1.0
 
 --------------------
 
@@ -401,7 +401,7 @@ Remove a super property.
 
 | Prop            | Type                        | Description                                                              | Since |
 | --------------- | --------------------------- | ------------------------------------------------------------------------ | ----- |
-| **`sessionId`** | <code>string \| null</code> | The current session ID. If no session is active, the value will be null. | 8.0.0 |
+| **`sessionId`** | <code>string \| null</code> | The current session ID. If no session is active, the value will be null. | 7.1.0 |
 
 
 #### GroupOptions
@@ -473,7 +473,9 @@ Remove a super property.
 
 Construct a type with a set of properties K of type T
 
-<code>{ [P in K]: T; }</code>
+<code>{
+ [P in K]: T;
+ }</code>
 
 </docgen-api>
 

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/Posthog.kt
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/Posthog.kt
@@ -107,7 +107,7 @@ class Posthog(private val plugin: PosthogPlugin) {
     }
 
     fun getSessionId(): GetSessionIdResult {
-        val sessionId = com.posthog.PostHog.getSessionId()
+        val sessionId = com.posthog.PostHog.getSessionId()?.toString()
         return GetSessionIdResult(sessionId)
     }
 }

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/Posthog.kt
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/Posthog.kt
@@ -14,6 +14,7 @@ import io.capawesome.capacitorjs.plugins.posthog.classes.options.GroupOptions
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.IsFeatureEnabledOptions
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.UnregisterOptions
 import io.capawesome.capacitorjs.plugins.posthog.classes.results.GetFeatureFlagResult
+import io.capawesome.capacitorjs.plugins.posthog.classes.results.GetSessionIdResult
 import io.capawesome.capacitorjs.plugins.posthog.classes.results.IsFeatureEnabledResult
 
 class Posthog(private val plugin: PosthogPlugin) {
@@ -103,5 +104,10 @@ class Posthog(private val plugin: PosthogPlugin) {
         val key = options.key
 
         com.posthog.PostHog.unregister(key = key)
+    }
+
+    fun getSessionId(): GetSessionIdResult {
+        val sessionId = com.posthog.PostHog.getSessionId()
+        return GetSessionIdResult(sessionId)
     }
 }

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/PosthogPlugin.java
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/PosthogPlugin.java
@@ -256,6 +256,16 @@ public class PosthogPlugin extends Plugin {
         }
     }
 
+    @PluginMethod
+    public void getSessionId(PluginCall call) {
+        try {
+            Result result = implementation.getSessionId();
+            resolveCall(call, result.toJSObject());
+        } catch (Exception exception) {
+            rejectCall(call, exception);
+        }
+    }
+
     private void resolveCall(@NonNull PluginCall call, @Nullable JSObject result) {
         if (result == null) {
             call.resolve();

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/classes/results/GetSessionIdResult.java
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/classes/results/GetSessionIdResult.java
@@ -18,11 +18,7 @@ public class GetSessionIdResult implements Result {
     @NonNull
     public JSObject toJSObject() {
         JSObject result = new JSObject();
-        if (sessionId != null) {
-            result.put("sessionId", this.sessionId);
-        } else {
-            result.put("sessionId", JSONObject.NULL);
-        }
+        result.put("sessionId", this.sessionId == null ? JSONObject.NULL : this.sessionId);
         return result;
     }
 } 

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/classes/results/GetSessionIdResult.java
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/classes/results/GetSessionIdResult.java
@@ -1,0 +1,28 @@
+package io.capawesome.capacitorjs.plugins.posthog.classes.results;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.getcapacitor.JSObject;
+import io.capawesome.capacitorjs.plugins.posthog.interfaces.Result;
+import org.json.JSONObject;
+
+public class GetSessionIdResult implements Result {
+
+    @Nullable
+    private final String sessionId;
+
+    public GetSessionIdResult(@Nullable String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    @NonNull
+    public JSObject toJSObject() {
+        JSObject result = new JSObject();
+        if (sessionId != null) {
+            result.put("sessionId", this.sessionId);
+        } else {
+            result.put("sessionId", JSONObject.NULL);
+        }
+        return result;
+    }
+} 

--- a/packages/posthog/ios/Plugin/Classes/Results/GetSessionIdResult.swift
+++ b/packages/posthog/ios/Plugin/Classes/Results/GetSessionIdResult.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Capacitor
+
+@objc public class GetSessionIdResult: NSObject, Result {
+    private let sessionId: String?
+
+    init(sessionId: String?) {
+        self.sessionId = sessionId
+    }
+
+    public func toJSObject() -> AnyObject {
+        var result = JSObject()
+        result["sessionId"] = sessionId == nil ? NSNull() : sessionId
+        return result as AnyObject
+    }
+} 

--- a/packages/posthog/ios/Plugin/Posthog.swift
+++ b/packages/posthog/ios/Plugin/Posthog.swift
@@ -94,4 +94,9 @@ import PostHog
 
         PostHogSDK.shared.unregister(key)
     }
+
+    @objc public func getSessionId() -> GetSessionIdResult {
+        let sessionId = PostHogSDK.shared.getSessionId()
+        return GetSessionIdResult(sessionId: sessionId)
+    }
 }

--- a/packages/posthog/ios/Plugin/PosthogPlugin.swift
+++ b/packages/posthog/ios/Plugin/PosthogPlugin.swift
@@ -186,8 +186,6 @@ public class PosthogPlugin: CAPPlugin, CAPBridgedPlugin {
         let result = implementation?.getSessionId()
         if let result = result?.toJSObject() as? JSObject {
             self.resolveCall(call, result)
-        } else {
-            call.resolve(["sessionId": nil])
         }
     }
 

--- a/packages/posthog/ios/Plugin/PosthogPlugin.swift
+++ b/packages/posthog/ios/Plugin/PosthogPlugin.swift
@@ -16,6 +16,7 @@ public class PosthogPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "capture", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "flush", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getFeatureFlag", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getSessionId", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "group", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "identify", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "isFeatureEnabled", returnType: CAPPluginReturnPromise),
@@ -179,6 +180,15 @@ public class PosthogPlugin: CAPPlugin, CAPBridgedPlugin {
 
         implementation?.unregister(options)
         call.resolve()
+    }
+
+    @objc func getSessionId(_ call: CAPPluginCall) {
+        let result = implementation?.getSessionId()
+        if let result = result?.toJSObject() as? JSObject {
+            self.resolveCall(call, result)
+        } else {
+            call.resolve(["sessionId": nil])
+        }
     }
 
     private func rejectCall(_ call: CAPPluginCall, _ error: Error) {

--- a/packages/posthog/src/definitions.ts
+++ b/packages/posthog/src/definitions.ts
@@ -26,6 +26,14 @@ export interface PosthogPlugin {
    */
   getFeatureFlag(options: GetFeatureFlagOptions): Promise<GetFeatureFlagResult>;
   /**
+   * Get the current session ID.
+   * 
+   * Only available on Android and iOS.
+   * 
+   * @since 7.0.1
+   */
+  getSessionId(): Promise<GetSessionIdResult>;
+  /**
    * Associate the events for that user with a group.
    *
    * @since 6.0.0
@@ -277,4 +285,18 @@ export interface UnregisterOptions {
    * @since 6.0.0
    */
   key: string;
+}
+
+/**
+ * @since 8.0.0
+ */
+export interface GetSessionIdResult {
+  /**
+   * The current session ID.
+   * 
+   * If no session is active, the value will be null.
+   * 
+   * @since 8.0.0
+   */
+  sessionId: string | null;
 }

--- a/packages/posthog/src/definitions.ts
+++ b/packages/posthog/src/definitions.ts
@@ -30,7 +30,7 @@ export interface PosthogPlugin {
    * 
    * Only available on Android and iOS.
    * 
-   * @since 7.0.1
+   * @since 7.1.0
    */
   getSessionId(): Promise<GetSessionIdResult>;
   /**
@@ -288,7 +288,7 @@ export interface UnregisterOptions {
 }
 
 /**
- * @since 8.0.0
+ * @since 7.1.0
  */
 export interface GetSessionIdResult {
   /**
@@ -296,7 +296,7 @@ export interface GetSessionIdResult {
    * 
    * If no session is active, the value will be null.
    * 
-   * @since 8.0.0
+   * @since 7.1.0
    */
   sessionId: string | null;
 }

--- a/packages/posthog/src/web.ts
+++ b/packages/posthog/src/web.ts
@@ -6,6 +6,7 @@ import type {
   CaptureOptions,
   GetFeatureFlagOptions,
   GetFeatureFlagResult,
+  GetSessionIdResult,
   GroupOptions,
   IdentifyOptions,
   IsFeatureEnabledOptions,
@@ -79,6 +80,10 @@ export class PosthogWeb extends WebPlugin implements PosthogPlugin {
 
   async unregister(options: UnregisterOptions): Promise<void> {
     posthog.unregister(options.key);
+  }
+
+  async getSessionId(): Promise<GetSessionIdResult> {
+    this.throwUnimplementedError();
   }
 
   private throwUnimplementedError(): never {


### PR DESCRIPTION
## Change Reasons
This feature adds the ability to retrieve the current PostHog session ID from both iOS and Android platforms. Session ID is crucial for tracking user sessions and connecting events that occur within the same session, allowing developers to implement more advanced analytics and debugging capabilities.

## Pull request checklist
Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

