### PR TITLE
feat: Added copyVideoToCache() 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7744,7 +7744,7 @@
     },
     "packages/android-edge-to-edge-support": {
       "name": "@capawesome/capacitor-android-edge-to-edge-support",
-      "version": "7.1.1",
+      "version": "7.2.1",
       "funding": [
         {
           "type": "github",

--- a/packages/file-picker/README.md
+++ b/packages/file-picker/README.md
@@ -93,6 +93,7 @@ const requestPermissions = async () => {
 * [`requestPermissions(...)`](#requestpermissions)
 * [`addListener('pickerDismissed', ...)`](#addlistenerpickerdismissed-)
 * [`removeAllListeners()`](#removealllisteners)
+* [`copyVideoToCache(...)`](#copyvideotocache)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
 
@@ -298,6 +299,27 @@ Remove all listeners for this plugin.
 --------------------
 
 
+### copyVideoToCache(...)
+
+```typescript
+copyVideoToCache(options: CopyVideoToCacheOptions) => Promise<CopyVideoToCacheResult>
+```
+
+Convert a picked video to a file:// path by copying it to the local cache folder.
+
+Only available on Android.
+
+| Param         | Type                                                                        |
+| ------------- | --------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#copyvideotocacheoptions">CopyVideoToCacheOptions</a></code> |
+
+**Returns:** <code>Promise&lt;<a href="#copyvideotocacheresult">CopyVideoToCacheResult</a>&gt;</code>
+
+**Since:** 7.0.2
+
+--------------------
+
+
 ### Interfaces
 
 
@@ -384,6 +406,20 @@ Remove all listeners for this plugin.
 | Prop         | Type                                      |
 | ------------ | ----------------------------------------- |
 | **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
+
+
+#### CopyVideoToCacheResult
+
+| Prop          | Type                | Description                                        |
+| ------------- | ------------------- | -------------------------------------------------- |
+| **`newPath`** | <code>string</code> | The file:// path of the video in the cache folder. |
+
+
+#### CopyVideoToCacheOptions
+
+| Prop       | Type                | Description                                                                                             |
+| ---------- | ------------------- | ------------------------------------------------------------------------------------------------------- |
+| **`path`** | <code>string</code> | The path of the video to convert. (same as `path` recieved from <a href="#pickedfile">`PickedFile`</a>) |
 
 
 ### Type Aliases

--- a/packages/file-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePickerPlugin.java
+++ b/packages/file-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePickerPlugin.java
@@ -236,6 +236,33 @@ public class FilePickerPlugin extends Plugin {
         }
     }
 
+    @PluginMethod
+    public void convertVideoToCachePath(PluginCall call) {
+        try {
+            String path = call.getString("path");
+            if (path == null) {
+                call.reject("A path must be provided.");
+                return;
+            }
+
+            Uri uri = Uri.parse(path);
+            String cachePath = implementation.copyVideoToCache(uri);
+
+            if (cachePath == null) {
+                call.reject("Failed to copy video to cache.");
+                return;
+            }
+
+            JSObject result = new JSObject();
+            result.put("newPath", cachePath);
+            call.resolve(result);
+        } catch (Exception ex) {
+            String message = ex.getMessage();
+            Log.e(TAG, message);
+            call.reject(message);
+        }
+    }
+
     private JSObject createPickFilesResult(@Nullable Intent data, boolean readData) {
         JSObject callResult = new JSObject();
         List<JSObject> filesResultList = new ArrayList<>();

--- a/packages/file-picker/src/definitions.ts
+++ b/packages/file-picker/src/definitions.ts
@@ -88,6 +88,14 @@ export interface FilePickerPlugin {
    * @since 0.6.2
    */
   removeAllListeners(): Promise<void>;
+  /**
+   * Convert a picked video to a file:// path by copying it to the local cache folder.
+   *
+   * Only available on Android.
+   *
+   * @since 7.0.2
+   */
+  copyVideoToCache(options: CopyVideoToCacheOptions): Promise<CopyVideoToCacheResult>;
 }
 
 /**
@@ -333,3 +341,27 @@ export interface RequestPermissionsOptions {
  * @since 6.1.0
  */
 export type PermissionType = 'accessMediaLocation' | 'readExternalStorage';
+
+/**
+ * @since 7.0.2
+ */
+export interface CopyVideoToCacheOptions {
+  /**
+   * The path of the video to convert. (same as `path` recieved from `PickedFile`)
+   *
+   * @example 'content://path/to/video.mp4'
+   */
+  path: string;
+}
+
+/**
+ * @since 7.0.2
+ */
+export interface CopyVideoToCacheResult {
+  /**
+   * The file:// path of the video in the cache folder.
+   *
+   * @example 'file:///data/user/0/com.example.app/cache/video.mp4'
+   */
+  newPath: string;
+}

--- a/packages/file-picker/src/web.ts
+++ b/packages/file-picker/src/web.ts
@@ -16,6 +16,8 @@ import type {
   PickedFile,
   RequestPermissionsOptions,
   PickDirectoryResult,
+  CopyVideoToCacheOptions,
+  CopyVideoToCacheResult,
 } from './definitions';
 
 export class FilePickerWeb extends WebPlugin implements FilePickerPlugin {
@@ -28,6 +30,12 @@ export class FilePickerWeb extends WebPlugin implements FilePickerPlugin {
   public async convertHeicToJpeg(
     _options: ConvertHeicToJpegOptions,
   ): Promise<ConvertHeicToJpegResult> {
+    throw this.unimplemented('Not implemented on web.');
+  }
+
+  public async copyVideoToCache(
+    _options: CopyVideoToCacheOptions,
+  ): Promise<CopyVideoToCacheResult> {
     throw this.unimplemented('Not implemented on web.');
   }
 


### PR DESCRIPTION
Hello ! So i've added a copyVideoToCache() function on Android that allows to copy a ``content://`` file path (given from the pickedFile result of a video) into a simple ``file://`` path.

(related to #158)

This is NOT TESTED, as i didn't know how to test it with monorepo :/
It was also made with a lot of help from AI.