### PR TITLE
fix(live-update): make fetchLatestBundle method asynchronous

### DIFF
--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateHttpClient.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateHttpClient.java
@@ -2,11 +2,11 @@ package io.capawesome.capacitorjs.plugins.liveupdate;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import com.getcapacitor.Logger;
 import io.capawesome.capacitorjs.plugins.liveupdate.interfaces.DownloadProgressCallback;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import okhttp3.Callback;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -52,6 +52,17 @@ public class LiveUpdateHttpClient {
             .build();
         Request request = new Request.Builder().url(url).build();
         return okHttpClient.newCall(request).execute();
+    }
+
+    public void executeAsync(String url, Callback callback) {
+        int httpTimeout = config.getHttpTimeout();
+        OkHttpClient okHttpClient = new OkHttpClient.Builder()
+            .connectTimeout(httpTimeout, TimeUnit.MILLISECONDS)
+            .readTimeout(httpTimeout, TimeUnit.MILLISECONDS)
+            .writeTimeout(httpTimeout, TimeUnit.MILLISECONDS)
+            .build();
+        Request request = new Request.Builder().url(url).build();
+        okHttpClient.newCall(request).enqueue(callback);
     }
 
     public static void writeResponseBodyToFile(ResponseBody body, File file, @Nullable DownloadProgressCallback callback)


### PR DESCRIPTION
Minimal implementation of asynchronous version of the `fetchLatestBundle` method which somehow seems to block UI rendering when being called on app startup. 

As discussed, this obviously needs to be tested thoroughly. Also the `NonEmptyCallack` types need to be checked because some path call it with null atm. 

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [-] The changes have been tested successfully (only checked the fetchLatestBundle for now).
- [ ] A changeset has been created (`npm run changeset`).
- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

