### PR TITLE
feat(posthog): SDK needs to be initialized early to capture application lifecycle events in iOS

### DIFF
--- a/.changeset/fast-bats-warn.md
+++ b/.changeset/fast-bats-warn.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-posthog': minor
+---
+
+feat: initialize sdk early

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/PosthogPlugin.java
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/PosthogPlugin.java
@@ -41,6 +41,18 @@ public class PosthogPlugin extends Plugin {
     public void load() {
         try {
             implementation = new Posthog(this);
+
+            // Fetch config from capacitor.config
+            String apiKey = getConfig().getString("apiKey");
+            if (apiKey == null || apiKey.isEmpty()) {
+                Logger.error(ERROR_API_KEY_MISSING);
+                return;
+            }
+
+            String host = getConfig().getString("host", "https://us.i.posthog.com");
+            SetupOptions options = new SetupOptions(apiKey, host);
+
+            implementation.setup(options);
         } catch (Exception exception) {
             Logger.error(PosthogPlugin.TAG, exception.getMessage(), exception);
         }

--- a/packages/posthog/ios/Plugin/PosthogPlugin.swift
+++ b/packages/posthog/ios/Plugin/PosthogPlugin.swift
@@ -32,6 +32,16 @@ public class PosthogPlugin: CAPPlugin, CAPBridgedPlugin {
 
     override public func load() {
         self.implementation = Posthog(plugin: self)
+        // Posthog SDK initialized early with config from capacitor.config.
+        // This is needed for the SDK to capture application lifecycle events such as Application Installed and Update
+        guard let apiKey = getConfig().getString("apiKey") else {
+            CAPLog.print(CustomError.apiKeyMissing.localizedDescription)
+            return
+        }
+        let host = getConfig().getString("host") ?? "https://us.i.posthog.com"
+
+        let options = SetupOptions(apiKey: apiKey, host: host)
+        implementation?.setup(options)
     }
 
     @objc func alias(_ call: CAPPluginCall) {


### PR DESCRIPTION
If the Posthog SDK is not initialized as soon as the app starts, there's an issue in iOS that lifecycle events such as Application Installed and Application Updated are not triggered. 

With this change what I did is try to get the `apiKey` and `host` from `capacitor.config.ts` file and if the values are there then initialize the sdk when the plugin loads. If you do this then you don't need to call the `setup` function from your app's code. 

In `capacitor.config.ts` inside your `plugins` object add:
```
Posthog: {
      apiKey: YOUR_API_KEY,
      host: YOUR_HOST  // if different from https://us.i.posthog.com
}
 ```

Disclaimer: this is my first time working with Capacitor plugins so maybe I'm missing something.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] The changes have been tested successfully.
- [X] A changeset has been created (`npm run changeset`).
- [X] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

