### PR TITLE
fix(edge-to-edge): include display cutout in system bars insets

### DIFF
--- a/.changeset/small-terms-decide.md
+++ b/.changeset/small-terms-decide.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-android-edge-to-edge-support': patch
+---
+
+fix(edge-to-edge): include display cutout in system bars insets

--- a/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
+++ b/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
@@ -50,7 +50,9 @@ public class EdgeToEdge {
         // Set insets
         WindowInsetsCompat currentInsets = ViewCompat.getRootWindowInsets(view);
         if (currentInsets != null) {
-            Insets systemBarsInsets = currentInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            Insets systemBarsInsets = currentInsets.getInsets(
+                WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout()
+            );
             Insets imeInsets = currentInsets.getInsets(WindowInsetsCompat.Type.ime());
             boolean keyboardVisible = currentInsets.isVisible(WindowInsetsCompat.Type.ime());
 
@@ -66,7 +68,9 @@ public class EdgeToEdge {
         // Set listener
         ViewCompat.setOnApplyWindowInsetsListener(view, (v, windowInsets) -> {
             // Retrieve system bars insets (for status/navigation bars)
-            Insets systemBarsInsets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            Insets systemBarsInsets = windowInsets.getInsets(
+                WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout()
+            );
             // Retrieve keyboard (IME) insets
             Insets imeInsets = windowInsets.getInsets(WindowInsetsCompat.Type.ime());
             boolean keyboardVisible = windowInsets.isVisible(WindowInsetsCompat.Type.ime());


### PR DESCRIPTION
Resolve #581 
## Description
This PR updates the Android implementation of the Edge-to-Edge support plugin to correctly account for displayCutout when calculating window insets.

## Reference
Official Android documentation on cutout insets:
https://developer.android.com/develop/ui/views/layout/edge-to-edge#cutout-insets

