### PR TITLE
fix(asset-manager): android implementation making invalid cast

### DIFF
--- a/.changeset/nasty-spiders-bake.md
+++ b/.changeset/nasty-spiders-bake.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-asset-manager': patch
+---
+
+fix android implementation making invalid cast

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,9 @@ node_modules
 # IntelliJ
 .idea
 
-# Clause
+# Claude
 CLAUDE.md
+
+.settings/
+.project
+.classpath

--- a/package-lock.json
+++ b/package-lock.json
@@ -6742,22 +6742,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/swiftlint/node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",

--- a/packages/asset-manager/android/src/main/java/io/capawesome/capacitorjs/plugins/assetmanager/AssetManager.java
+++ b/packages/asset-manager/android/src/main/java/io/capawesome/capacitorjs/plugins/assetmanager/AssetManager.java
@@ -110,15 +110,14 @@ public class AssetManager {
     }
 
     private String readFileAsBase64EncodedData(InputStream inputStream) throws IOException {
-        FileInputStream fileInputStream = (FileInputStream) inputStream;
         ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
 
         byte[] buffer = new byte[1024];
-        int c;
-        while ((c = fileInputStream.read(buffer)) != -1) {
-            byteStream.write(buffer, 0, c);
+        int length;
+        while ((length = inputStream.read(buffer)) != -1) {
+            byteStream.write(buffer, 0, length);
         }
-        fileInputStream.close();
+        inputStream.close();
 
         return Base64.encodeToString(byteStream.toByteArray(), Base64.NO_WRAP);
     }


### PR DESCRIPTION
in readFileAsBase64EncodedData

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

