### PR TITLE
fix(live-update): bundle file download fails for empty files on iOS

### DIFF
--- a/.changeset/quiet-bags-chew.md
+++ b/.changeset/quiet-bags-chew.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-live-update': patch
+---
+
+fix(ios): bundle file download fails for empty files

--- a/packages/live-update/ios/Plugin/LiveUpdateHttpClient.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdateHttpClient.swift
@@ -27,7 +27,7 @@ public class LiveUpdateHttpClient: NSObject {
                 if let callback = callback {
                     callback(progress)
                 }
-            }.responseData { response in
+            }.responseData(emptyResponseCodes: [200, 204, 205]) { response in
                 continuation.resume(returning: response)
             }
         }


### PR DESCRIPTION
Close https://github.com/capawesome-team/cli/issues/77

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

