### PR TITLE
fix(android-edge-to-edge-support): use no-op listener instead of null on disable

### DIFF
--- a/.changeset/modern-fans-allow.md
+++ b/.changeset/modern-fans-allow.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-android-edge-to-edge-support': patch
+---
+
+fix(android): use no-op listener instead of null on disable

--- a/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
+++ b/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
@@ -144,8 +144,10 @@ public class EdgeToEdge {
         mlp.rightMargin = 0;
         mlp.bottomMargin = 0;
         view.setLayoutParams(mlp);
-        // Reset listener
-        ViewCompat.setOnApplyWindowInsetsListener(view, null);
+        // Set a no-op listener that consumes insets without applying them.
+        // Using null would allow Android 15's default edge-to-edge handling to take over,
+        // which can cause extra padding when re-enabling.
+        ViewCompat.setOnApplyWindowInsetsListener(view, (v, windowInsets) -> WindowInsetsCompat.CONSUMED);
         // Remove color overlays
         removeColorOverlays();
     }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).
- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

