### PR TITLE
fix: AGP 9.0 no longer supports `proguard-android.txt`

### DIFF
--- a/.changeset/open-numbers-clean.md
+++ b/.changeset/open-numbers-clean.md
@@ -1,0 +1,31 @@
+---
+'@capawesome-team/capacitor-android-battery-optimization': patch
+'@capawesome/capacitor-android-edge-to-edge-support': patch
+'@capawesome-team/capacitor-android-foreground-service': patch
+'@capawesome/capacitor-android-dark-mode-support': patch
+'@capawesome/capacitor-managed-configurations': patch
+'@capawesome/capacitor-square-mobile-payments': patch
+'@capawesome/capacitor-screen-orientation': patch
+'@capawesome/capacitor-background-task': patch
+'@capawesome-team/capacitor-datetime-picker': patch
+'@capawesome/capacitor-google-sign-in': patch
+'@capawesome/capacitor-app-shortcuts': patch
+'@capawesome/capacitor-asset-manager': patch
+'@capawesome/capacitor-photo-editor': patch
+'@capawesome/capacitor-age-signals': patch
+'@capawesome-team/capacitor-file-opener': patch
+'@capawesome/capacitor-file-picker': patch
+'@capawesome/capacitor-live-update': patch
+'@capawesome/capacitor-realtimekit': patch
+'@capawesome/capacitor-app-review': patch
+'@capawesome/capacitor-app-update': patch
+'@capawesome/capacitor-cloudinary': patch
+'@capawesome/capacitor-screenshot': patch
+'@capawesome/capacitor-superwall': patch
+'@capawesome/capacitor-posthog': patch
+'@capawesome/capacitor-libsql': patch
+'@capawesome/capacitor-badge': patch
+'@capawesome/capacitor-torch': patch
+---
+
+fix(android): AGP 9.0 no longer supports `proguard-android.txt`

--- a/packages/age-signals/android/build.gradle
+++ b/packages/age-signals/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/android-battery-optimization/android/build.gradle
+++ b/packages/android-battery-optimization/android/build.gradle
@@ -30,7 +30,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/android-dark-mode-support/android/build.gradle
+++ b/packages/android-dark-mode-support/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/android-edge-to-edge-support/android/build.gradle
+++ b/packages/android-edge-to-edge-support/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/android-edge-to-edge-support/example/android/app/build.gradle
+++ b/packages/android-edge-to-edge-support/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/android-foreground-service/android/build.gradle
+++ b/packages/android-foreground-service/android/build.gradle
@@ -30,7 +30,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/android-foreground-service/example/android/app/build.gradle
+++ b/packages/android-foreground-service/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/app-review/android/build.gradle
+++ b/packages/app-review/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/app-review/example/android/app/build.gradle
+++ b/packages/app-review/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/app-shortcuts/android/build.gradle
+++ b/packages/app-shortcuts/android/build.gradle
@@ -30,7 +30,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/app-shortcuts/example/android/app/build.gradle
+++ b/packages/app-shortcuts/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/app-update/android/build.gradle
+++ b/packages/app-update/android/build.gradle
@@ -32,7 +32,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/asset-manager/android/build.gradle
+++ b/packages/asset-manager/android/build.gradle
@@ -30,7 +30,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/asset-manager/example/android/app/build.gradle
+++ b/packages/asset-manager/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/background-task/android/build.gradle
+++ b/packages/background-task/android/build.gradle
@@ -30,7 +30,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/badge/android/build.gradle
+++ b/packages/badge/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/badge/example/android/app/build.gradle
+++ b/packages/badge/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/cloudinary/android/build.gradle
+++ b/packages/cloudinary/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/datetime-picker/android/build.gradle
+++ b/packages/datetime-picker/android/build.gradle
@@ -30,7 +30,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/file-opener/android/build.gradle
+++ b/packages/file-opener/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/file-picker/android/build.gradle
+++ b/packages/file-picker/android/build.gradle
@@ -30,7 +30,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/file-picker/example/android/app/build.gradle
+++ b/packages/file-picker/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/google-sign-in/android/build.gradle
+++ b/packages/google-sign-in/android/build.gradle
@@ -33,7 +33,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/google-sign-in/example/android/app/build.gradle
+++ b/packages/google-sign-in/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/libsql/android/build.gradle
+++ b/packages/libsql/android/build.gradle
@@ -36,7 +36,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/libsql/example/android/app/build.gradle
+++ b/packages/libsql/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/live-update/android/build.gradle
+++ b/packages/live-update/android/build.gradle
@@ -32,7 +32,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/live-update/example/android/app/build.gradle
+++ b/packages/live-update/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/managed-configurations/android/build.gradle
+++ b/packages/managed-configurations/android/build.gradle
@@ -30,7 +30,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/photo-editor/android/build.gradle
+++ b/packages/photo-editor/android/build.gradle
@@ -30,7 +30,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/posthog/android/build.gradle
+++ b/packages/posthog/android/build.gradle
@@ -37,7 +37,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/posthog/example/android/app/build.gradle
+++ b/packages/posthog/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/realtimekit/android/build.gradle
+++ b/packages/realtimekit/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/realtimekit/example/android/app/build.gradle
+++ b/packages/realtimekit/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/screen-orientation/android/build.gradle
+++ b/packages/screen-orientation/android/build.gradle
@@ -30,7 +30,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/screen-orientation/example/android/app/build.gradle
+++ b/packages/screen-orientation/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/screenshot/android/build.gradle
+++ b/packages/screenshot/android/build.gradle
@@ -30,7 +30,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/screenshot/example/android/app/build.gradle
+++ b/packages/screenshot/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/square-mobile-payments/android/build.gradle
+++ b/packages/square-mobile-payments/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/square-mobile-payments/example/android/app/build.gradle
+++ b/packages/square-mobile-payments/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/superwall/android/build.gradle
+++ b/packages/superwall/android/build.gradle
@@ -37,7 +37,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/superwall/example/android/app/build.gradle
+++ b/packages/superwall/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/torch/android/build.gradle
+++ b/packages/torch/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/packages/torch/example/android/app/build.gradle
+++ b/packages/torch/example/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }


### PR DESCRIPTION
See https://github.com/ionic-team/capacitor/pull/8315

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).
- [ ] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

Close https://github.com/capawesome-team/capacitor-plugins/issues/775