### PR TITLE
fix(posthog): read sessionReplayConfig from Capacitor config on Android

### DIFF
--- a/.changeset/busy-poems-warn.md
+++ b/.changeset/busy-poems-warn.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-posthog': patch
+---
+
+fix(android): read sessionReplayConfig from Capacitor plugin config

--- a/.changeset/busy-poems-warn.md
+++ b/.changeset/busy-poems-warn.md
@@ -2,4 +2,4 @@
 '@capawesome/capacitor-posthog': patch
 ---
 
-fix(android): read sessionReplayConfig from Capacitor plugin config
+fix(android): read `sessionReplayConfig` from Capacitor Configuration file

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/PosthogPlugin.java
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/PosthogPlugin.java
@@ -354,7 +354,7 @@ public class PosthogPlugin extends Plugin {
                 sessionReplayConfigObject.optBoolean("maskAllTextInputs", true),
                 sessionReplayConfigObject.optBoolean("maskAllImages", true),
                 sessionReplayConfigObject.optBoolean("maskAllSandboxedViews", true),
-                sessionReplayConfigObject.optBoolean("captureNetworkTelemetry", true),
+                sessionReplayConfigObject.optBoolean("captureNetworkTelemetry", false),
                 sessionReplayConfigObject.optDouble("debouncerDelay", 1.0)
             );
             config.setSessionReplayConfig(sessionReplayOptions);

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/PosthogPlugin.java
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/PosthogPlugin.java
@@ -8,7 +8,6 @@ import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
-import org.json.JSONObject;
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.AliasOptions;
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.CaptureOptions;
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.GetFeatureFlagOptions;
@@ -23,6 +22,7 @@ import io.capawesome.capacitorjs.plugins.posthog.classes.options.SetupOptions;
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.StartSessionRecordingOptions;
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.UnregisterOptions;
 import io.capawesome.capacitorjs.plugins.posthog.interfaces.Result;
+import org.json.JSONObject;
 
 @CapacitorPlugin(name = "Posthog")
 public class PosthogPlugin extends Plugin {

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/PosthogPlugin.java
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/PosthogPlugin.java
@@ -8,6 +8,7 @@ import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
+import org.json.JSONObject;
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.AliasOptions;
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.CaptureOptions;
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.GetFeatureFlagOptions;
@@ -345,6 +346,19 @@ public class PosthogPlugin extends Plugin {
         boolean captureApplicationLifecycleEvents = getConfig()
             .getBoolean("captureApplicationLifecycleEvents", config.getCaptureApplicationLifecycleEvents());
         config.setCaptureApplicationLifecycleEvents(captureApplicationLifecycleEvents);
+
+        JSONObject sessionReplayConfigObject = getConfig().getObject("sessionReplayConfig");
+        if (sessionReplayConfigObject != null) {
+            SessionReplayOptions sessionReplayOptions = new SessionReplayOptions(
+                sessionReplayConfigObject.optBoolean("screenshotMode", false),
+                sessionReplayConfigObject.optBoolean("maskAllTextInputs", true),
+                sessionReplayConfigObject.optBoolean("maskAllImages", true),
+                sessionReplayConfigObject.optBoolean("maskAllSandboxedViews", true),
+                sessionReplayConfigObject.optBoolean("captureNetworkTelemetry", true),
+                sessionReplayConfigObject.optDouble("debouncerDelay", 1.0)
+            );
+            config.setSessionReplayConfig(sessionReplayOptions);
+        }
 
         return config;
     }


### PR DESCRIPTION
## Summary

The `getPosthogConfig()` method on Android does not read the `sessionReplayConfig` object from the Capacitor plugin configuration, causing session replay masking options (`maskAllTextInputs`, `maskAllImages`, `maskAllSandboxedViews`, `screenshotMode`, `captureNetworkTelemetry`, `debouncerDelay`) to be silently ignored during auto-initialization from `capacitor.config.ts`.

The iOS implementation already reads this config correctly in `posthogConfig()` ([PosthogPlugin.swift L257-L266](https://github.com/capawesome-team/capacitor-plugins/blob/main/packages/posthog/ios/Plugin/PosthogPlugin.swift#L257-L266)), and the Android `setup()` PluginMethod (JS-callable path) also handles it correctly ([PosthogPlugin.java L298-L309](https://github.com/capawesome-team/capacitor-plugins/blob/main/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/PosthogPlugin.java#L298-L309)). Only the Android auto-init path is missing it.

## Reproduction

Configure `sessionReplayConfig` in `capacitor.config.ts`:

```ts
Posthog: {
  apiKey: '...',
  apiHost: '...',
  enableSessionReplay: true,
  sessionReplayConfig: {
    maskAllTextInputs: false,
    maskAllImages: false,
  },
},
```

On iOS, masking is disabled as expected. On Android, all content remains masked because `sessionReplayConfig` is never read from the config.

## Fix

Adds the missing `sessionReplayConfig` parsing to `getPosthogConfig()`, matching the existing iOS implementation and the Android `setup()` method.