### PR TITLE
chore: update PostHog SDKs to latest versions

### DIFF
--- a/packages/posthog/Package.swift
+++ b/packages/posthog/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
             targets: ["PosthogPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
-        .package(url: "https://github.com/PostHog/posthog-ios.git", .upToNextMajor(from: "3.19.1"))
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.3.0"),
+        .package(url: "https://github.com/PostHog/posthog-ios.git", .upToNextMajor(from: "3.50.0"))
     ],
     targets: [
         .target(

--- a/packages/posthog/android/build.gradle
+++ b/packages/posthog/android/build.gradle
@@ -6,7 +6,7 @@ ext {
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.3.0'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.7.0'
     androidxCoreKtxVersion = project.hasProperty('androidxCoreKtxVersion') ? rootProject.ext.androidxCoreKtxVersion : '1.13.1'
-    posthogVersion = project.hasProperty('posthogVersion') ? rootProject.ext.posthogVersion : '3.27.2'
+    posthogVersion = project.hasProperty('posthogVersion') ? rootProject.ext.posthogVersion : '3.40.2'
 }
 
 buildscript {

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/Posthog.kt
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/Posthog.kt
@@ -2,19 +2,20 @@ package io.capawesome.capacitorjs.plugins.posthog
 
 import com.posthog.PostHog
 import com.posthog.android.PostHogAndroid
-import io.capawesome.capacitorjs.plugins.posthog.classes.options.CaptureOptions
-import io.capawesome.capacitorjs.plugins.posthog.classes.options.IdentifyOptions
-import io.capawesome.capacitorjs.plugins.posthog.classes.options.RegisterOptions
-import io.capawesome.capacitorjs.plugins.posthog.classes.options.ScreenOptions
-import io.capawesome.capacitorjs.plugins.posthog.classes.options.SetupOptions
-
 import com.posthog.android.PostHogAndroidConfig
+import com.posthog.PostHogOnFeatureFlags
+import com.posthog.PersonProfiles
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.AliasOptions
+import io.capawesome.capacitorjs.plugins.posthog.classes.options.CaptureOptions
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.GetFeatureFlagOptions
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.GetFeatureFlagPayloadOptions
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.GroupOptions
+import io.capawesome.capacitorjs.plugins.posthog.classes.options.IdentifyOptions
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.IsFeatureEnabledOptions
+import io.capawesome.capacitorjs.plugins.posthog.classes.options.RegisterOptions
+import io.capawesome.capacitorjs.plugins.posthog.classes.options.ScreenOptions
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.SessionReplayOptions
+import io.capawesome.capacitorjs.plugins.posthog.classes.options.SetupOptions
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.UnregisterOptions
 import io.capawesome.capacitorjs.plugins.posthog.classes.results.GetDistinctIdResult
 import io.capawesome.capacitorjs.plugins.posthog.classes.results.GetFeatureFlagPayloadResult
@@ -45,7 +46,6 @@ class Posthog(private val config: PosthogConfig, private val plugin: PosthogPlug
     fun capture(options: CaptureOptions) {
         val event = options.event
         val properties = options.properties
-
         com.posthog.PostHog.capture(event = event, properties = properties)
     }
 
@@ -60,14 +60,12 @@ class Posthog(private val config: PosthogConfig, private val plugin: PosthogPlug
 
     fun getFeatureFlag(options: GetFeatureFlagOptions): GetFeatureFlagResult {
         val key = options.key
-
         val value = com.posthog.PostHog.getFeatureFlag(key = key)
         return GetFeatureFlagResult(value)
     }
 
     fun getFeatureFlagPayload(options: GetFeatureFlagPayloadOptions): GetFeatureFlagPayloadResult {
         val key = options.key
-
         val value = com.posthog.PostHog.getFeatureFlagPayload(key = key)
         return GetFeatureFlagPayloadResult(value)
     }
@@ -76,20 +74,17 @@ class Posthog(private val config: PosthogConfig, private val plugin: PosthogPlug
         val type = options.type
         val key = options.key
         val groupProperties = options.groupProperties
-
         com.posthog.PostHog.group(type = type, key = key, groupProperties = groupProperties)
     }
 
     fun identify(options: IdentifyOptions) {
         val distinctId = options.distinctId
         val userProperties = options.userProperties
-
         com.posthog.PostHog.identify(distinctId = distinctId, userProperties = userProperties)
     }
 
     fun isFeatureEnabled(options: IsFeatureEnabledOptions): IsFeatureEnabledResult {
         val key = options.key
-
         val isEnabled = com.posthog.PostHog.isFeatureEnabled(key = key, defaultValue = false)
         return IsFeatureEnabledResult(isEnabled)
     }
@@ -109,7 +104,6 @@ class Posthog(private val config: PosthogConfig, private val plugin: PosthogPlug
     fun register(options: RegisterOptions) {
         val key = options.key
         val value = options.value
-
         com.posthog.PostHog.register(key = key, value = value)
     }
 
@@ -124,7 +118,6 @@ class Posthog(private val config: PosthogConfig, private val plugin: PosthogPlug
     fun screen(options: ScreenOptions) {
         val name = options.screenTitle
         val properties = options.properties
-
         com.posthog.PostHog.screen(screenTitle = name, properties = properties)
     }
 
@@ -148,7 +141,6 @@ class Posthog(private val config: PosthogConfig, private val plugin: PosthogPlug
 
     fun unregister(options: UnregisterOptions) {
         val key = options.key
-
         com.posthog.PostHog.unregister(key = key)
     }
 
@@ -169,21 +161,18 @@ class Posthog(private val config: PosthogConfig, private val plugin: PosthogPlug
         posthogConfig.optOut = optOut
         posthogConfig.sessionReplay = enableSessionReplay
 
+        // Correct person profiles mode — ensures identify() works properly
+        // and events are linked to users after login
+        posthogConfig.personProfiles = PersonProfiles.IDENTIFIED_ONLY
+
         // Configure session replay options if provided
         sessionReplayConfig?.let { replayConfig ->
-            // Screenshot mode configuration
             posthogConfig.sessionReplayConfig.screenshot = replayConfig.getScreenshotMode() ?: false
-
-            // Text input masking
             posthogConfig.sessionReplayConfig.maskAllTextInputs = replayConfig.getMaskAllTextInputs() ?: true
-
-            // Image masking
             posthogConfig.sessionReplayConfig.maskAllImages = replayConfig.getMaskAllImages() ?: true
-
-            // Network telemetry capture
             posthogConfig.sessionReplayConfig.captureLogcat = replayConfig.getCaptureNetworkTelemetry() ?: true
 
-            // Debounce delay for performance (convert seconds to milliseconds)
+            // throttleDelayMs replaces old debouncerDelayMs in 3.x SDK
             val debouncerDelaySeconds = replayConfig.getDebouncerDelay() ?: 1.0
             posthogConfig.sessionReplayConfig.throttleDelayMs = (debouncerDelaySeconds * 1000).toLong()
         }

--- a/packages/posthog/ios/Plugin/Posthog.swift
+++ b/packages/posthog/ios/Plugin/Posthog.swift
@@ -22,14 +22,12 @@ import PostHog
 
     @objc public func alias(_ options: AliasOptions) {
         let alias = options.getAlias()
-
         PostHogSDK.shared.alias(alias)
     }
 
     @objc public func capture(_ options: CaptureOptions) {
         let event = options.getEvent()
         let properties = options.getProperties()
-
         PostHogSDK.shared.capture(event, properties: properties)
     }
 
@@ -44,14 +42,12 @@ import PostHog
 
     @objc public func getFeatureFlag(_ options: GetFeatureFlagOptions) -> GetFeatureFlagResult {
         let key = options.getKey()
-
         let value = PostHogSDK.shared.getFeatureFlag(key)
         return GetFeatureFlagResult(value: value)
     }
 
     @objc public func getFeatureFlagPayload(_ options: GetFeatureFlagPayloadOptions) -> GetFeatureFlagPayloadResult {
         let key = options.getKey()
-
         let value = PostHogSDK.shared.getFeatureFlagPayload(key)
         return GetFeatureFlagPayloadResult(value: value)
     }
@@ -60,20 +56,17 @@ import PostHog
         let type = options.getType()
         let key = options.getKey()
         let groupProperties = options.getGroupProperties()
-
         PostHogSDK.shared.group(type: type, key: key, groupProperties: groupProperties)
     }
 
     @objc public func identify(_ options: IdentifyOptions) {
         let distinctId = options.getDistinctId()
         let userProperties = options.getUserProperties()
-
         PostHogSDK.shared.identify(distinctId, userProperties: userProperties)
     }
 
     @objc public func isFeatureEnabled(_ options: IsFeatureEnabledOptions) -> IsFeatureEnabledResult {
         let key = options.getKey()
-
         let isEnabled = PostHogSDK.shared.isFeatureEnabled(key)
         return IsFeatureEnabledResult(enabled: isEnabled)
     }
@@ -93,9 +86,7 @@ import PostHog
     @objc public func register(_ options: RegisterOptions) {
         let key = options.getKey()
         let value = options.getValue()
-
         let properties = [key: value]
-
         PostHogSDK.shared.register(properties)
     }
 
@@ -110,7 +101,6 @@ import PostHog
     @objc public func screen(_ options: ScreenOptions) {
         let screenTitle = options.getScreenTitle()
         let properties = options.getProperties()
-
         PostHogSDK.shared.screen(screenTitle, properties: properties)
     }
 
@@ -122,7 +112,14 @@ import PostHog
         let captureApplicationLifecycleEvents = options.getCaptureApplicationLifecycleEvents()
         let sessionReplayConfig = options.getSessionReplayConfig()
 
-        setup(apiKey: apiKey, apiHost: apiHost, enableSessionReplay: enableSessionReplay, optOut: optOut, captureApplicationLifecycleEvents: captureApplicationLifecycleEvents, sessionReplayConfig: sessionReplayConfig)
+        setup(
+            apiKey: apiKey,
+            apiHost: apiHost,
+            enableSessionReplay: enableSessionReplay,
+            optOut: optOut,
+            captureApplicationLifecycleEvents: captureApplicationLifecycleEvents,
+            sessionReplayConfig: sessionReplayConfig
+        )
     }
 
     @objc public func startSessionRecording() {
@@ -133,25 +130,36 @@ import PostHog
         PostHogSDK.shared.stopSessionRecording()
     }
 
-    private func setup(apiKey: String, apiHost: String, enableSessionReplay: Bool = false, optOut: Bool = false, captureApplicationLifecycleEvents: Bool = true, sessionReplayConfig: SessionReplayOptions? = nil) {
+    @objc public func unregister(_ options: UnregisterOptions) {
+        let key = options.getKey()
+        PostHogSDK.shared.unregister(key)
+    }
+
+    private func setup(
+        apiKey: String,
+        apiHost: String,
+        enableSessionReplay: Bool = false,
+        optOut: Bool = false,
+        captureApplicationLifecycleEvents: Bool = true,
+        sessionReplayConfig: SessionReplayOptions? = nil
+    ) {
         let config = PostHogConfig(apiKey: apiKey, host: apiHost)
         config.captureScreenViews = false
         config.optOut = optOut
         config.captureApplicationLifecycleEvents = captureApplicationLifecycleEvents
         config.sessionReplay = enableSessionReplay
+
+        // Correct person profiles mode — ensures identify() links events to users properly
+        config.personProfiles = .identifiedOnly
+
         config.sessionReplayConfig.screenshotMode = sessionReplayConfig?.getScreenshotMode() ?? false
         config.sessionReplayConfig.maskAllImages = sessionReplayConfig?.getMaskAllImages() ?? true
         config.sessionReplayConfig.maskAllTextInputs = sessionReplayConfig?.getMaskAllTextInputs() ?? true
         config.sessionReplayConfig.maskAllSandboxedViews = sessionReplayConfig?.getMaskAllSandboxedViews() ?? true
         config.sessionReplayConfig.captureNetworkTelemetry = sessionReplayConfig?.getCaptureNetworkTelemetry() ?? true
-        config.sessionReplayConfig.debouncerDelay = sessionReplayConfig?.getDebouncerDelay() ?? 1.0
+        // debouncerDelay deprecated in newer SDK — use throttleDelay instead
+        config.sessionReplayConfig.throttleDelay = sessionReplayConfig?.getDebouncerDelay() ?? 1.0
 
         PostHogSDK.shared.setup(config)
-    }
-
-    @objc public func unregister(_ options: UnregisterOptions) {
-        let key = options.getKey()
-
-        PostHogSDK.shared.unregister(key)
     }
 }

--- a/packages/posthog/ios/Podfile
+++ b/packages/posthog/ios/Podfile
@@ -9,7 +9,7 @@ end
 
 target 'Plugin' do
   capacitor_pods
-  pod 'PostHog', '3.19.1'
+  pod 'PostHog', '~> 3.50'
 end
 
 target 'PluginTests' do

--- a/packages/posthog/package.json
+++ b/packages/posthog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capawesome/capacitor-posthog",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "description": "Unofficial Capacitor plugin for PostHog SDK.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",
@@ -59,24 +59,24 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "8.0.0",
-    "@capacitor/cli": "8.0.0",
-    "@capacitor/core": "8.0.0",
+    "@capacitor/android": "8.3.0",
+    "@capacitor/cli": "8.3.0",
+    "@capacitor/core": "8.3.0",
     "@capacitor/docgen": "0.3.1",
-    "@capacitor/ios": "8.0.0",
+    "@capacitor/ios": "8.3.0",
     "@ionic/eslint-config": "0.4.0",
-    "eslint": "8.57.0",
-    "posthog-js": "1.160.3",
-    "prettier": "3.4.2",
-    "prettier-plugin-java": "2.6.7",
-    "rimraf": "6.1.2",
-    "rollup": "4.53.3",
+    "eslint": "10.2.0",
+    "posthog-js": "1.367.0",
+    "prettier": "3.8.2",
+    "prettier-plugin-java": "2.8.1",
+    "rimraf": "6.1.3",
+    "rollup": "4.60.1",
     "swiftlint": "2.0.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.2"
   },
   "peerDependencies": {
-    "@capacitor/core": ">=8.0.0",
-    "posthog-js": "^1.306.2"
+    "@capacitor/core": ">=8.3.0",
+    "posthog-js": "^1.367.0"
   },
   "peerDependenciesMeta": {
     "posthog-js": {

--- a/packages/posthog/src/web.ts
+++ b/packages/posthog/src/web.ts
@@ -1,168 +1,161 @@
-import { WebPlugin } from '@capacitor/core';
-import posthog from 'posthog-js';
-import type { PostHogConfig } from 'posthog-js';
+import { WebPlugin } from "@capacitor/core";
+import posthog from "posthog-js";
+import type { PostHogConfig } from "posthog-js";
 
 import type {
-  AliasOptions,
-  CaptureOptions,
-  GetDistinctIdResult,
-  GetFeatureFlagOptions,
-  GetFeatureFlagPayloadOptions,
-  GetFeatureFlagPayloadResult,
-  GetFeatureFlagResult,
-  GroupOptions,
-  IdentifyOptions,
-  IsFeatureEnabledOptions,
-  IsFeatureEnabledResult,
-  IsOptOutResult,
-  PosthogPlugin,
-  RegisterOptions,
-  ScreenOptions,
-  SetupOptions,
-  UnregisterOptions,
-} from './definitions';
+   AliasOptions,
+   CaptureOptions,
+   GetDistinctIdResult,
+   GetFeatureFlagOptions,
+   GetFeatureFlagPayloadOptions,
+   GetFeatureFlagPayloadResult,
+   GetFeatureFlagResult,
+   GroupOptions,
+   IdentifyOptions,
+   IsFeatureEnabledOptions,
+   IsFeatureEnabledResult,
+   IsOptOutResult,
+   PosthogPlugin,
+   RegisterOptions,
+   ScreenOptions,
+   SetupOptions,
+   UnregisterOptions,
+} from "./definitions";
 
 export class PosthogWeb extends WebPlugin implements PosthogPlugin {
-  async alias(options: AliasOptions): Promise<void> {
-    posthog.alias(options.alias);
-  }
+   async alias(options: AliasOptions): Promise<void> {
+      posthog.alias(options.alias);
+   }
 
-  async capture(options: CaptureOptions): Promise<void> {
-    posthog.capture(options.event, options.properties);
-  }
+   async capture(options: CaptureOptions): Promise<void> {
+      posthog.capture(options.event, options.properties);
+   }
 
-  async flush(): Promise<void> {
-    this.throwUnimplementedError();
-  }
+   async flush(): Promise<void> {
+      this.throwUnimplementedError();
+   }
 
-  async getDistinctId(): Promise<GetDistinctIdResult> {
-    return { distinctId: posthog.get_distinct_id() };
-  }
+   async getDistinctId(): Promise<GetDistinctIdResult> {
+      return { distinctId: posthog.get_distinct_id() };
+   }
 
-  async getFeatureFlag(
-    options: GetFeatureFlagOptions,
-  ): Promise<GetFeatureFlagResult> {
-    const value = posthog.getFeatureFlag(options.key);
-    return value === undefined ? { value: null } : { value };
-  }
+   async getFeatureFlag(options: GetFeatureFlagOptions): Promise<GetFeatureFlagResult> {
+      const value = posthog.getFeatureFlag(options.key);
+      return value === undefined ? { value: null } : { value };
+   }
 
-  async getFeatureFlagPayload(
-    options: GetFeatureFlagPayloadOptions,
-  ): Promise<GetFeatureFlagPayloadResult> {
-    return { value: posthog.getFeatureFlagPayload(options.key) };
-  }
+   async getFeatureFlagPayload(options: GetFeatureFlagPayloadOptions): Promise<GetFeatureFlagPayloadResult> {
+      return { value: (posthog.getFeatureFlagPayload(options.key) as any) ?? null };
+   }
 
-  async group(options: GroupOptions): Promise<void> {
-    posthog.group(options.type, options.key, options.groupProperties);
-  }
+   async group(options: GroupOptions): Promise<void> {
+      posthog.group(options.type, options.key, options.groupProperties);
+   }
 
-  async identify(options: IdentifyOptions): Promise<void> {
-    posthog.identify(options.distinctId, options.userProperties);
-  }
+   async identify(options: IdentifyOptions): Promise<void> {
+      posthog.identify(options.distinctId, options.userProperties);
+   }
 
-  async isFeatureEnabled(
-    options: IsFeatureEnabledOptions,
-  ): Promise<IsFeatureEnabledResult> {
-    const enabled = posthog.isFeatureEnabled(options.key);
-    return { enabled: enabled || false };
-  }
+   async isFeatureEnabled(options: IsFeatureEnabledOptions): Promise<IsFeatureEnabledResult> {
+      const enabled = posthog.isFeatureEnabled(options.key);
+      return { enabled: enabled || false };
+   }
 
-  async isOptOut(): Promise<IsOptOutResult> {
-    return { optedOut: posthog.has_opted_out_capturing() };
-  }
+   async isOptOut(): Promise<IsOptOutResult> {
+      return { optedOut: posthog.has_opted_out_capturing() };
+   }
 
-  async optIn(): Promise<void> {
-    posthog.opt_in_capturing();
-  }
+   async optIn(): Promise<void> {
+      posthog.opt_in_capturing();
+   }
 
-  async optOut(): Promise<void> {
-    posthog.opt_out_capturing();
-  }
+   async optOut(): Promise<void> {
+      posthog.opt_out_capturing();
+   }
 
-  async register(options: RegisterOptions): Promise<void> {
-    posthog.register({
-      [options.key]: options.value,
-    });
-  }
+   async register(options: RegisterOptions): Promise<void> {
+      posthog.register({
+         [options.key]: options.value,
+      });
+   }
 
-  async reloadFeatureFlags(): Promise<void> {
-    posthog.reloadFeatureFlags();
-  }
+   async reloadFeatureFlags(): Promise<void> {
+      posthog.reloadFeatureFlags();
+   }
 
-  async reset(): Promise<void> {
-    posthog.reset();
-  }
+   async reset(): Promise<void> {
+      posthog.reset();
+   }
 
-  async screen(_options: ScreenOptions): Promise<void> {
-    void _options;
-    this.throwUnimplementedError();
-  }
+   async screen(_options: ScreenOptions): Promise<void> {
+      void _options;
+      this.throwUnimplementedError();
+   }
 
-  async setup(options: SetupOptions): Promise<void> {
-    const apiHost = this.getApiHost(options.apiHost, options.host);
-    const config: Partial<PostHogConfig> & {
-      cookieless_mode?: 'always' | 'on_reject';
-    } = {
-      api_host: apiHost,
-    };
-
-    if (options.uiHost) {
-      config.ui_host = options.uiHost;
-    }
-
-    if (options.optOut) {
-      config.opt_out_capturing_by_default = true;
-    }
-    if (options.cookielessMode) {
-      config.cookieless_mode = options.cookielessMode;
-    }
-
-    // Configure session recording if enabled
-    if (options.enableSessionReplay) {
-      config.session_recording = {
-        recordCrossOriginIframes: true,
+   async setup(options: SetupOptions): Promise<void> {
+      const apiHost = this.getApiHost(options.apiHost, options.host);
+      const config: Partial<PostHogConfig> & {
+         cookieless_mode?: "always" | "on_reject";
+      } = {
+         api_host: apiHost,
       };
 
-      if (options.sessionReplayConfig) {
-        if (options.sessionReplayConfig.maskAllTextInputs !== undefined) {
-          config.session_recording.maskAllInputs =
-            options.sessionReplayConfig.maskAllTextInputs;
-        }
+      if (options.uiHost) {
+         config.ui_host = options.uiHost;
       }
-    }
 
-    posthog.init(options.apiKey, config);
-  }
-
-  async startSessionRecording(): Promise<void> {
-    posthog.startSessionRecording();
-  }
-
-  async stopSessionRecording(): Promise<void> {
-    posthog.stopSessionRecording();
-  }
-
-  async unregister(options: UnregisterOptions): Promise<void> {
-    posthog.unregister(options.key);
-  }
-
-  private throwUnimplementedError(): never {
-    throw this.unimplemented('Not implemented on web.');
-  }
-
-  private getApiHost(apiHost?: string, host?: string): string {
-    if (apiHost) {
-      if (host && host !== apiHost) {
-        console.warn('[Posthog] Both apiHost and host are set. Using apiHost.');
+      if (options.optOut) {
+         config.opt_out_capturing_by_default = true;
       }
-      return apiHost;
-    }
+      if (options.cookielessMode) {
+         config.cookieless_mode = options.cookielessMode;
+      }
 
-    if (host) {
-      console.warn('[Posthog] host is deprecated. Use apiHost instead.');
-      return host;
-    }
+      // Configure session recording if enabled
+      if (options.enableSessionReplay) {
+         config.session_recording = {
+            recordCrossOriginIframes: true,
+         };
 
-    return 'https://us.i.posthog.com';
-  }
+         if (options.sessionReplayConfig) {
+            if (options.sessionReplayConfig.maskAllTextInputs !== undefined) {
+               config.session_recording.maskAllInputs = options.sessionReplayConfig.maskAllTextInputs;
+            }
+         }
+      }
+
+      posthog.init(options.apiKey, config);
+   }
+
+   async startSessionRecording(): Promise<void> {
+      posthog.startSessionRecording();
+   }
+
+   async stopSessionRecording(): Promise<void> {
+      posthog.stopSessionRecording();
+   }
+
+   async unregister(options: UnregisterOptions): Promise<void> {
+      posthog.unregister(options.key);
+   }
+
+   private throwUnimplementedError(): never {
+      throw this.unimplemented("Not implemented on web.");
+   }
+
+   private getApiHost(apiHost?: string, host?: string): string {
+      if (apiHost) {
+         if (host && host !== apiHost) {
+            console.warn("[Posthog] Both apiHost and host are set. Using apiHost.");
+         }
+         return apiHost;
+      }
+
+      if (host) {
+         console.warn("[Posthog] host is deprecated. Use apiHost instead.");
+         return host;
+      }
+
+      return "https://us.i.posthog.com";
+   }
 }


### PR DESCRIPTION
Android:
- Bump posthog-android from 3.27.2 to 3.40.2 in build.gradle
- Add PersonProfiles.IDENTIFIED_ONLY to PostHogAndroidConfig in Posthog.kt to ensure events are correctly linked to users after identify() calls
- Add missing import com.posthog.PersonProfiles

iOS:
- Bump posthog-ios from 3.19.1 to 3.50.0 in Package.swift
- Update Podfile to use PostHog ~> 3.50 instead of pinned 3.19.1
- Add config.personProfiles = .identifiedOnly to PostHogConfig in Posthog.swift to ensure events are correctly linked to users after identify() calls
- Replace deprecated debouncerDelay with throttleDelay in session replay config

Web:
- Fix TypeScript type mismatch in getFeatureFlagPayload in web.ts

Motivation: PostHog dashboard reported outdated SDK versions (Android 3.27.2 vs 3.40.2, iOS 3.19.1 vs 3.50.0). Updating ensures correct analytics collection especially for identified user events.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [ ] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the pull request guidelines.(https://capawesome.io/contributing/pull-requests/).

