### PR TITLE
fix(posthog): align PostHog SDK version rule across `Podfile` and podspec

### DIFF
--- a/.changeset/full-feet-marry.md
+++ b/.changeset/full-feet-marry.md
@@ -1,0 +1,6 @@
+---
+'@capawesome/capacitor-posthog': patch
+---
+
+fix(ios): align PostHog SDK version rule across Podfile and podspec  
+

--- a/packages/posthog/CapawesomeCapacitorPosthog.podspec
+++ b/packages/posthog/CapawesomeCapacitorPosthog.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
-  s.dependency 'PostHog', '~> 3.19.1'
+  s.dependency 'PostHog', '>= 3.19.1', '< 4.0'
   s.swift_version = '5.1'
   s.static_framework = true
 end

--- a/packages/posthog/ios/Podfile
+++ b/packages/posthog/ios/Podfile
@@ -9,7 +9,7 @@ end
 
 target 'Plugin' do
   capacitor_pods
-  pod 'PostHog', '3.19.1'
+  pod 'PostHog', '>= 3.19.1', '< 4.0'
 end
 
 target 'PluginTests' do


### PR DESCRIPTION
## Summary

- Aligned the PostHog SDK version rule between `Podfile`, `CapawesomeCapacitorPosthog.podspec`, and `Package.swift` so all three allow `>= 3.19.1, < 4.0` (matching SPM's `.upToNextMajor(from: "3.19.1")`).
- Previously, the `Podfile` pinned `3.19.1` exactly and the podspec used `~> 3.19.1` (`>= 3.19.1, < 3.20`), both more restrictive than the SPM rule.

## Related

Follow-up to https://github.com/capawesome-team/capacitor-plugins/pull/821.