### PR TITLE
feat(live-update): add brotli compression support to OkHttp client

### DIFF
--- a/.changeset/brotli-compression.md
+++ b/.changeset/brotli-compression.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-live-update': minor
+---
+
+feat(android): add brotli compression support to OkHttp client

--- a/packages/live-update/README.md
+++ b/packages/live-update/README.md
@@ -93,7 +93,7 @@ android {
 
 If needed, you can define the following project variable in your app’s `variables.gradle` file to change the default version of the dependency:
 
-- `$okhttp3Version` version of `com.squareup.okhttp3:okhttp` (default: `5.3.2`)
+- `$okhttp3Version` version of `com.squareup.okhttp3:okhttp` and `com.squareup.okhttp3:okhttp-brotli` (default: `5.3.2`)
 - `$zip4jVersion` version of `net.lingala.zip4j:zip4j` (default: `2.11.5`)
 
 This can be useful if you encounter dependency conflicts with other plugins in your project.

--- a/packages/live-update/android/build.gradle
+++ b/packages/live-update/android/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "net.lingala.zip4j:zip4j:$zip4jVersion"
     implementation "com.squareup.okhttp3:okhttp:$okhttp3Version"
+    implementation "com.squareup.okhttp3:okhttp-brotli:$okhttp3Version"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateHttpClient.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateHttpClient.java
@@ -15,6 +15,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import okhttp3.brotli.BrotliInterceptor;
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.BufferedSource;
@@ -58,6 +59,7 @@ public class LiveUpdateHttpClient {
         dispatcher.setMaxRequestsPerHost(30);
 
         this.okHttpClient = new OkHttpClient.Builder()
+            .addInterceptor(BrotliInterceptor.INSTANCE)
             .dispatcher(dispatcher)
             .connectTimeout(httpTimeout, TimeUnit.MILLISECONDS)
             .readTimeout(httpTimeout, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
## Summary

- Add `okhttp-brotli` dependency to enable transparent brotli decompression
- Register `BrotliInterceptor` on the `OkHttpClient` builder
- Update README variables docs to reflect the new dependency