### PR TITLE
fix(android-edge-to-edge-support): only apply top margin on Android 15+

### DIFF
--- a/.changeset/cool-stars-glow.md
+++ b/.changeset/cool-stars-glow.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-android-edge-to-edge-support': patch
+---
+
+fix(android): only apply top margin on Android 15+

--- a/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
+++ b/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
@@ -98,7 +98,9 @@ public class EdgeToEdge {
 
         ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) view.getLayoutParams();
         mlp.bottomMargin = bottomMargin;
-        mlp.topMargin = systemBarsInsets.top;
+        // Only apply top margin on Android 15+ where edge-to-edge is enforced.
+        // On older versions, the system already positions content below the status bar.
+        mlp.topMargin = Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM ? systemBarsInsets.top : 0;
         mlp.leftMargin = systemBarsInsets.left;
         mlp.rightMargin = systemBarsInsets.right;
         view.setLayoutParams(mlp);

--- a/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
+++ b/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
@@ -1,6 +1,7 @@
 package io.capawesome.capacitorjs.plugins.androidedgetoedgesupport;
 
 import android.graphics.Color;
+import android.os.Build;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -100,7 +101,7 @@ public class EdgeToEdge {
         mlp.bottomMargin = bottomMargin;
         // Only apply top margin on Android 15+ where edge-to-edge is enforced.
         // On older versions, the system already positions content below the status bar.
-        mlp.topMargin = Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM ? systemBarsInsets.top : 0;
+        mlp.topMargin = Build.VERSION.SDK_INT >= 35 ? systemBarsInsets.top : 0;
         mlp.leftMargin = systemBarsInsets.left;
         mlp.rightMargin = systemBarsInsets.right;
         view.setLayoutParams(mlp);


### PR DESCRIPTION
## Summary

- Only apply top system bar inset margin on Android 15+ (VANILLA_ICE_CREAM) where edge-to-edge is enforced.
- On older Android versions, the system already positions content below the status bar, so applying the top inset caused double-offsetting.