### PR TITLE
fix(android-edge-to-edge-support): detect edge-to-edge at runtime instead of checking API level

### DIFF
--- a/.changeset/fix-edge-to-edge-top-inset.md
+++ b/.changeset/fix-edge-to-edge-top-inset.md
@@ -1,0 +1,5 @@
+---
+"@capawesome/capacitor-android-edge-to-edge-support": patch
+---
+
+fix(android-edge-to-edge-support): detect edge-to-edge at runtime instead of checking API level

--- a/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
+++ b/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
@@ -102,7 +102,8 @@ public class EdgeToEdge {
         // On older versions, detect edge-to-edge by checking whether the system's content view
         // has top padding (which means decorFitsSystemWindows is true and the system handles insets).
         View contentView = plugin.getActivity().findViewById(android.R.id.content);
-        boolean systemHandlesTopInset = contentView != null && contentView.getPaddingTop() >= systemBarsInsets.top && systemBarsInsets.top > 0;
+        boolean systemHandlesTopInset =
+            contentView != null && contentView.getPaddingTop() >= systemBarsInsets.top && systemBarsInsets.top > 0;
         mlp.topMargin = systemHandlesTopInset ? 0 : systemBarsInsets.top;
         mlp.leftMargin = systemBarsInsets.left;
         mlp.rightMargin = systemBarsInsets.right;
@@ -182,10 +183,10 @@ public class EdgeToEdge {
         if (statusBarOverlay != null) {
             // Position status bar overlay at top
             ViewGroup.LayoutParams statusParams = createLayoutParams(
-                    parent,
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    systemBarsInsets.top,
-                    Gravity.TOP
+                parent,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                systemBarsInsets.top,
+                Gravity.TOP
             );
             statusBarOverlay.setLayoutParams(statusParams);
         }
@@ -193,10 +194,10 @@ public class EdgeToEdge {
         if (navigationBarOverlay != null) {
             // Position navigation bar overlay at bottom
             ViewGroup.LayoutParams navParams = createLayoutParams(
-                    parent,
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    systemBarsInsets.bottom,
-                    Gravity.BOTTOM
+                parent,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                systemBarsInsets.bottom,
+                Gravity.BOTTOM
             );
             navigationBarOverlay.setLayoutParams(navParams);
         }

--- a/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
+++ b/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
@@ -99,12 +99,13 @@ public class EdgeToEdge {
         ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) view.getLayoutParams();
         mlp.bottomMargin = bottomMargin;
         // Apply top margin when edge-to-edge is active. On Android 15+ it is always enforced.
-        // On older versions, detect edge-to-edge by checking whether the system's content view
-        // has top padding (which means decorFitsSystemWindows is true and the system handles insets).
+        // On older versions, use the system content view's top padding only as a heuristic that
+        // the top inset may already be handled elsewhere (for example by decor fitting or another
+        // insets/padding adjustment), rather than as a guaranteed signal of decorFitsSystemWindows.
         View contentView = plugin.getActivity().findViewById(android.R.id.content);
-        boolean systemHandlesTopInset =
+        boolean topInsetLikelyHandledBySystem =
             contentView != null && contentView.getPaddingTop() >= systemBarsInsets.top && systemBarsInsets.top > 0;
-        mlp.topMargin = systemHandlesTopInset ? 0 : systemBarsInsets.top;
+        mlp.topMargin = topInsetLikelyHandledBySystem ? 0 : systemBarsInsets.top;
         mlp.leftMargin = systemBarsInsets.left;
         mlp.rightMargin = systemBarsInsets.right;
         view.setLayoutParams(mlp);

--- a/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
+++ b/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
@@ -1,7 +1,6 @@
 package io.capawesome.capacitorjs.plugins.androidedgetoedgesupport;
 
 import android.graphics.Color;
-import android.os.Build;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -99,9 +98,12 @@ public class EdgeToEdge {
 
         ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) view.getLayoutParams();
         mlp.bottomMargin = bottomMargin;
-        // Only apply top margin on Android 15+ where edge-to-edge is enforced.
-        // On older versions, the system already positions content below the status bar.
-        mlp.topMargin = Build.VERSION.SDK_INT >= 35 ? systemBarsInsets.top : 0;
+        // Apply top margin when edge-to-edge is active. On Android 15+ it is always enforced.
+        // On older versions, detect edge-to-edge by checking whether the system's content view
+        // has top padding (which means decorFitsSystemWindows is true and the system handles insets).
+        View contentView = plugin.getActivity().findViewById(android.R.id.content);
+        boolean systemHandlesTopInset = contentView != null && contentView.getPaddingTop() >= systemBarsInsets.top && systemBarsInsets.top > 0;
+        mlp.topMargin = systemHandlesTopInset ? 0 : systemBarsInsets.top;
         mlp.leftMargin = systemBarsInsets.left;
         mlp.rightMargin = systemBarsInsets.right;
         view.setLayoutParams(mlp);
@@ -180,10 +182,10 @@ public class EdgeToEdge {
         if (statusBarOverlay != null) {
             // Position status bar overlay at top
             ViewGroup.LayoutParams statusParams = createLayoutParams(
-                parent,
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                systemBarsInsets.top,
-                Gravity.TOP
+                    parent,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    systemBarsInsets.top,
+                    Gravity.TOP
             );
             statusBarOverlay.setLayoutParams(statusParams);
         }
@@ -191,10 +193,10 @@ public class EdgeToEdge {
         if (navigationBarOverlay != null) {
             // Position navigation bar overlay at bottom
             ViewGroup.LayoutParams navParams = createLayoutParams(
-                parent,
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                systemBarsInsets.bottom,
-                Gravity.BOTTOM
+                    parent,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    systemBarsInsets.bottom,
+                    Gravity.BOTTOM
             );
             navigationBarOverlay.setLayoutParams(navParams);
         }


### PR DESCRIPTION
## Summary

- Replace the `Build.VERSION.SDK_INT >= 35` check for applying the top margin with runtime detection of whether the system is already handling the top inset.
- Check `android.R.id.content` padding to determine if `decorFitsSystemWindows` is true, which works across all API levels without reflection.
- Fixes an issue where the WebView would render behind the status bar on Android < 15 when edge-to-edge was enabled by the app or emulator configuration.