### PR TITLE
fix(android-edge-to-edge-support): use Window color API when edge-to-edge is not enforced

### DIFF
--- a/.changeset/fix-edge-to-edge-window-color-api.md
+++ b/.changeset/fix-edge-to-edge-window-color-api.md
@@ -1,0 +1,5 @@
+---
+"@capawesome/capacitor-android-edge-to-edge-support": patch
+---
+
+fix(android-edge-to-edge-support): use Window color API when edge-to-edge is not enforced

--- a/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
+++ b/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
@@ -1,9 +1,13 @@
 package io.capawesome.capacitorjs.plugins.androidedgetoedgesupport;
 
 import android.graphics.Color;
+import android.os.Build;
+import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager;
 import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -27,9 +31,11 @@ public class EdgeToEdge {
     @Nullable
     private View statusBarOverlay;
 
-    private int currentNavigationBarColor;
+    @Nullable
+    private Integer currentNavigationBarColor;
 
-    private int currentStatusBarColor;
+    @Nullable
+    private Integer currentStatusBarColor;
 
     public EdgeToEdge(@NonNull EdgeToEdgePlugin plugin, @NonNull EdgeToEdgeConfig config) {
         this.config = config;
@@ -42,17 +48,27 @@ public class EdgeToEdge {
     }
 
     public void enable() {
-        // Create color overlays if they don't exist
-        createColorOverlays();
-        // Restore previously set colors
-        setStatusBarColor(currentStatusBarColor);
-        setNavigationBarColor(currentNavigationBarColor);
-        // Apply insets
-        applyInsets();
+        if (isEdgeToEdgeEnforced()) {
+            // Create color overlays if they don't exist
+            createColorOverlays();
+            // Restore previously set colors
+            applyStatusBarColor();
+            applyNavigationBarColor();
+            // Apply insets
+            applyInsets();
+        } else {
+            // Pre-Android 15 (or Android 15 with opt-out): the platform still honors
+            // Window.setStatusBarColor/setNavigationBarColor, so we use that directly
+            // instead of overlay views that depend on the inset dispatch chain.
+            applyStatusBarColor();
+            applyNavigationBarColor();
+        }
     }
 
     public void disable() {
-        removeInsets();
+        if (isEdgeToEdgeEnforced()) {
+            removeInsets();
+        }
     }
 
     public ViewGroup.MarginLayoutParams getInsets() {
@@ -98,14 +114,7 @@ public class EdgeToEdge {
 
         ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) view.getLayoutParams();
         mlp.bottomMargin = bottomMargin;
-        // Apply top margin when edge-to-edge is active. On Android 15+ it is always enforced.
-        // On older versions, use the system content view's top padding only as a heuristic that
-        // the top inset may already be handled elsewhere (for example by decor fitting or another
-        // insets/padding adjustment), rather than as a guaranteed signal of decorFitsSystemWindows.
-        View contentView = plugin.getActivity().findViewById(android.R.id.content);
-        boolean topInsetLikelyHandledBySystem =
-            contentView != null && contentView.getPaddingTop() >= systemBarsInsets.top && systemBarsInsets.top > 0;
-        mlp.topMargin = topInsetLikelyHandledBySystem ? 0 : systemBarsInsets.top;
+        mlp.topMargin = systemBarsInsets.top;
         mlp.leftMargin = systemBarsInsets.left;
         mlp.rightMargin = systemBarsInsets.right;
         view.setLayoutParams(mlp);
@@ -114,93 +123,34 @@ public class EdgeToEdge {
         updateColorOverlays(systemBarsInsets);
     }
 
-    private void removeInsets() {
-        View view = plugin.getBridge().getWebView();
-        // Get parent view
-        ViewGroup parent = (ViewGroup) view.getParent();
-        // Reset insets
-        ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) view.getLayoutParams();
-        mlp.topMargin = 0;
-        mlp.leftMargin = 0;
-        mlp.rightMargin = 0;
-        mlp.bottomMargin = 0;
-        view.setLayoutParams(mlp);
-        // Set a no-op listener that consumes insets without applying them.
-        // Using null would allow Android 15's default edge-to-edge handling to take over,
-        // which can cause extra padding when re-enabling.
-        ViewCompat.setOnApplyWindowInsetsListener(view, (v, windowInsets) -> WindowInsetsCompat.CONSUMED);
-        // Remove color overlays
-        removeColorOverlays();
-    }
-
-    private void createColorOverlays() {
-        View webView = plugin.getBridge().getWebView();
-        ViewGroup parent = (ViewGroup) webView.getParent();
-
-        if (statusBarOverlay == null) {
-            statusBarOverlay = new View(parent.getContext());
-            parent.addView(statusBarOverlay, 0); // Add behind webview
+    private void applyNavigationBarColor() {
+        if (currentNavigationBarColor == null) {
+            return;
         }
-
-        if (navigationBarOverlay == null) {
-            navigationBarOverlay = new View(parent.getContext());
-            parent.addView(navigationBarOverlay, 0); // Add behind webview
+        if (isEdgeToEdgeEnforced()) {
+            if (navigationBarOverlay != null) {
+                navigationBarOverlay.setBackgroundColor(currentNavigationBarColor);
+            }
+        } else {
+            Window window = plugin.getActivity().getWindow();
+            window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+            setNavigationBarColorDeprecated(window, currentNavigationBarColor);
         }
     }
 
-    private void removeColorOverlays() {
-        View webView = plugin.getBridge().getWebView();
-        ViewGroup parent = (ViewGroup) webView.getParent();
-
-        if (statusBarOverlay != null) {
-            parent.removeView(statusBarOverlay);
-            statusBarOverlay = null;
+    private void applyStatusBarColor() {
+        if (currentStatusBarColor == null) {
+            return;
         }
-
-        if (navigationBarOverlay != null) {
-            parent.removeView(navigationBarOverlay);
-            navigationBarOverlay = null;
-        }
-    }
-
-    private void setNavigationBarColor(int color) {
-        this.currentNavigationBarColor = color;
-        if (navigationBarOverlay != null) {
-            navigationBarOverlay.setBackgroundColor(color);
-        }
-    }
-
-    private void setStatusBarColor(int color) {
-        this.currentStatusBarColor = color;
-        if (statusBarOverlay != null) {
-            statusBarOverlay.setBackgroundColor(color);
-        }
-    }
-
-    private void updateColorOverlays(Insets systemBarsInsets) {
-        View webView = plugin.getBridge().getWebView();
-        ViewGroup parent = (ViewGroup) webView.getParent();
-
-        if (statusBarOverlay != null) {
-            // Position status bar overlay at top
-            ViewGroup.LayoutParams statusParams = createLayoutParams(
-                parent,
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                systemBarsInsets.top,
-                Gravity.TOP
-            );
-            statusBarOverlay.setLayoutParams(statusParams);
-        }
-
-        if (navigationBarOverlay != null) {
-            // Position navigation bar overlay at bottom
-            ViewGroup.LayoutParams navParams = createLayoutParams(
-                parent,
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                systemBarsInsets.bottom,
-                Gravity.BOTTOM
-            );
-            navigationBarOverlay.setLayoutParams(navParams);
+        if (isEdgeToEdgeEnforced()) {
+            if (statusBarOverlay != null) {
+                statusBarOverlay.setBackgroundColor(currentStatusBarColor);
+            }
+        } else {
+            Window window = plugin.getActivity().getWindow();
+            window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+            window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+            setStatusBarColorDeprecated(window, currentStatusBarColor);
         }
     }
 
@@ -231,5 +181,123 @@ public class EdgeToEdge {
         // Fallback to MarginLayoutParams
         ViewGroup.MarginLayoutParams params = new ViewGroup.MarginLayoutParams(width, height);
         return params;
+    }
+
+    private void createColorOverlays() {
+        View webView = plugin.getBridge().getWebView();
+        ViewGroup parent = (ViewGroup) webView.getParent();
+
+        if (statusBarOverlay == null) {
+            statusBarOverlay = new View(parent.getContext());
+            parent.addView(statusBarOverlay, 0); // Add behind webview
+        }
+
+        if (navigationBarOverlay == null) {
+            navigationBarOverlay = new View(parent.getContext());
+            parent.addView(navigationBarOverlay, 0); // Add behind webview
+        }
+    }
+
+    private boolean isEdgeToEdgeEnforced() {
+        int deviceApi = Build.VERSION.SDK_INT;
+        if (deviceApi < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            // Pre-Android 15: platform honors legacy Window.setStatusBarColor/setNavigationBarColor
+            return false;
+        }
+        if (deviceApi == Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            // Android 15: edge-to-edge enforced unless the app opted out via
+            // android:windowOptOutEdgeToEdgeEnforcement on its theme
+            return !isEdgeToEdgeOptOutEnabled();
+        }
+        // Android 16+: opt-out is ignored, edge-to-edge is always enforced
+        return true;
+    }
+
+    private boolean isEdgeToEdgeOptOutEnabled() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            return false;
+        }
+        TypedValue value = new TypedValue();
+        plugin.getActivity().getTheme().resolveAttribute(android.R.attr.windowOptOutEdgeToEdgeEnforcement, value, true);
+        return value.data != 0;
+    }
+
+    private void removeColorOverlays() {
+        View webView = plugin.getBridge().getWebView();
+        ViewGroup parent = (ViewGroup) webView.getParent();
+
+        if (statusBarOverlay != null) {
+            parent.removeView(statusBarOverlay);
+            statusBarOverlay = null;
+        }
+
+        if (navigationBarOverlay != null) {
+            parent.removeView(navigationBarOverlay);
+            navigationBarOverlay = null;
+        }
+    }
+
+    private void removeInsets() {
+        View view = plugin.getBridge().getWebView();
+        // Reset insets
+        ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) view.getLayoutParams();
+        mlp.topMargin = 0;
+        mlp.leftMargin = 0;
+        mlp.rightMargin = 0;
+        mlp.bottomMargin = 0;
+        view.setLayoutParams(mlp);
+        // Set a no-op listener that consumes insets without applying them.
+        // Using null would allow Android 15's default edge-to-edge handling to take over,
+        // which can cause extra padding when re-enabling.
+        ViewCompat.setOnApplyWindowInsetsListener(view, (v, windowInsets) -> WindowInsetsCompat.CONSUMED);
+        // Remove color overlays
+        removeColorOverlays();
+    }
+
+    private void setNavigationBarColor(int color) {
+        this.currentNavigationBarColor = color;
+        applyNavigationBarColor();
+    }
+
+    @SuppressWarnings("deprecation")
+    private void setNavigationBarColorDeprecated(@NonNull Window window, int color) {
+        window.setNavigationBarColor(color);
+    }
+
+    private void setStatusBarColor(int color) {
+        this.currentStatusBarColor = color;
+        applyStatusBarColor();
+    }
+
+    @SuppressWarnings("deprecation")
+    private void setStatusBarColorDeprecated(@NonNull Window window, int color) {
+        window.setStatusBarColor(color);
+    }
+
+    private void updateColorOverlays(Insets systemBarsInsets) {
+        View webView = plugin.getBridge().getWebView();
+        ViewGroup parent = (ViewGroup) webView.getParent();
+
+        if (statusBarOverlay != null) {
+            // Position status bar overlay at top
+            ViewGroup.LayoutParams statusParams = createLayoutParams(
+                parent,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                systemBarsInsets.top,
+                Gravity.TOP
+            );
+            statusBarOverlay.setLayoutParams(statusParams);
+        }
+
+        if (navigationBarOverlay != null) {
+            // Position navigation bar overlay at bottom
+            ViewGroup.LayoutParams navParams = createLayoutParams(
+                parent,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                systemBarsInsets.bottom,
+                Gravity.BOTTOM
+            );
+            navigationBarOverlay.setLayoutParams(navParams);
+        }
     }
 }

--- a/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdgeConfig.java
+++ b/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdgeConfig.java
@@ -1,34 +1,42 @@
 package io.capawesome.capacitorjs.plugins.androidedgetoedgesupport;
 
-import android.graphics.Color;
+import androidx.annotation.Nullable;
 
 public class EdgeToEdgeConfig {
 
-    private int backgroundColor = Color.TRANSPARENT;
-    private int navigationBarColor = Color.TRANSPARENT;
-    private int statusBarColor = Color.TRANSPARENT;
+    @Nullable
+    private Integer backgroundColor;
 
-    public int getBackgroundColor() {
+    @Nullable
+    private Integer navigationBarColor;
+
+    @Nullable
+    private Integer statusBarColor;
+
+    @Nullable
+    public Integer getBackgroundColor() {
         return this.backgroundColor;
     }
 
-    public int getNavigationBarColor() {
+    @Nullable
+    public Integer getNavigationBarColor() {
         return this.navigationBarColor;
     }
 
-    public int getStatusBarColor() {
+    @Nullable
+    public Integer getStatusBarColor() {
         return this.statusBarColor;
     }
 
-    public void setBackgroundColor(int backgroundColor) {
+    public void setBackgroundColor(@Nullable Integer backgroundColor) {
         this.backgroundColor = backgroundColor;
     }
 
-    public void setNavigationBarColor(int navigationBarColor) {
+    public void setNavigationBarColor(@Nullable Integer navigationBarColor) {
         this.navigationBarColor = navigationBarColor;
     }
 
-    public void setStatusBarColor(int statusBarColor) {
+    public void setStatusBarColor(@Nullable Integer statusBarColor) {
         this.statusBarColor = statusBarColor;
     }
 }

--- a/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdgePlugin.java
+++ b/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdgePlugin.java
@@ -139,7 +139,6 @@ public class EdgeToEdgePlugin extends Plugin {
                 config.setNavigationBarColor(Color.parseColor(navigationBarColor));
             }
 
-            // Keep backgroundColor for any legacy code that might use it
             if (backgroundColor != null) {
                 config.setBackgroundColor(Color.parseColor(backgroundColor));
             }


### PR DESCRIPTION
## Summary

Restores setting the status bar and navigation bar colors on Android versions where edge-to-edge is **not** enforced (API <35, or API 35 with `windowOptOutEdgeToEdgeEnforcement=true`). On those versions, the plugin now uses the platform `Window.setStatusBarColor` / `setNavigationBarColor` APIs (plus `FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS`) — the same approach `@capacitor/status-bar` uses — instead of the overlay-view approach.

The overlay approach is still used on API 35+ when edge-to-edge is enforced, because the legacy Window color APIs are ignored there.

## Why

On API <35 with `decorFitsSystemWindows = true` (the default), the `DecorView` auto-consumes system bar insets as padding before they reach the plugin's `WebView` listener. That made the plugin's overlay-positioning logic silently depend on another plugin (`@capacitor/keyboard` ≤ 8.0.1) keeping a no-op `setOnApplyWindowInsetsListener` on the root view, which happened to disable the auto-consumption.

When `@capacitor/keyboard` 8.0.2 added `ViewCompat.onApplyWindowInsets(v, insets)` inside that listener, insets started being re-applied as padding on the root view, shifting the nav bar overlay ABOVE the nav bar. When 8.0.3 moved the listener from root view to the `content` view, the `DecorView` resumed auto-consuming insets, so the overlay got a height of 0 and became invisible.

Using the platform Window color API on API <35 sidesteps the inset dispatch chain entirely, so the plugin no longer depends on any side effects of other plugins.

## Changes

- `EdgeToEdge.java`: runtime `isEdgeToEdgeEnforced()` check branches `enable()`/`disable()` between the overlay approach (enforced) and the legacy Window color API (not enforced). Split private color setters into `setXxxColor(int)` (store + apply) and `applyXxxColor()` (read current + branch).
- `EdgeToEdgeConfig.java`: color fields switched from `int` defaulting to `TRANSPARENT` to nullable `Integer`. Lets the legacy path avoid clobbering the theme default when the user has not configured a color.
- Removed the obsolete `topInsetLikelyHandledBySystem` heuristic in `applyInsetsInternal` — that path now only runs when edge-to-edge is enforced.

## Test plan

- [ ] API 31 emulator, `@capacitor/keyboard@8.0.3` — `setNavigationBarColor` and `setStatusBarColor` work.
- [ ] API 31 emulator, `@capacitor/keyboard@8.0.1` — no regression.
- [ ] API 35 emulator without opt-out — overlay approach still works (regression check).
- [ ] API 35 emulator with `windowOptOutEdgeToEdgeEnforcement=true` — legacy path, bar colors set.
- [ ] API 36 emulator — overlay approach used.
- [ ] Keyboard show/hide on each of the above — webview layout correct, no double-counted bottom inset.

Close #838