### PR TITLE
fix(android-edge-to-edge-support): opt into edge-to-edge on all API levels

### DIFF
--- a/.changeset/fix-edge-to-edge-decor-fits-system-windows.md
+++ b/.changeset/fix-edge-to-edge-decor-fits-system-windows.md
@@ -1,0 +1,5 @@
+---
+"@capawesome/capacitor-android-edge-to-edge-support": patch
+---
+
+fix(android-edge-to-edge-support): opt into edge-to-edge on all API levels

--- a/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
+++ b/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
@@ -9,6 +9,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import com.getcapacitor.Logger;
 import java.lang.reflect.Constructor;
@@ -42,6 +43,12 @@ public class EdgeToEdge {
     }
 
     public void enable() {
+        // Opt into edge-to-edge layout so the DecorView stops auto-consuming system bar
+        // insets as padding. Without this, inset listeners set by other plugins (notably
+        // @capacitor/keyboard >= 8.0.2) can perturb the inset dispatch chain and make the
+        // overlay views end up in the wrong place or with zero height. On Android 15+
+        // this is already enforced by the platform.
+        WindowCompat.setDecorFitsSystemWindows(plugin.getActivity().getWindow(), false);
         // Create color overlays if they don't exist
         createColorOverlays();
         // Restore previously set colors


### PR DESCRIPTION
## Summary

Calls `WindowCompat.setDecorFitsSystemWindows(window, false)` in `EdgeToEdge.enable()`. This is the one-line alternative to #839 (Option B: hybrid overlay + `Window.setStatusBarColor` fallback).

This opens a comparison PR against #839 — pick one.

## Why

On API <35 with the default `decorFitsSystemWindows = true`, the `DecorView` auto-consumes system bar insets as padding before they reach the plugin's `WebView` listener. The overlay positions silently depended on another plugin (`@capacitor/keyboard` ≤ 8.0.1) keeping a no-op `setOnApplyWindowInsetsListener` on the root view, which happened to disable the auto-consumption.

`@capacitor/keyboard` 8.0.2+ changed that listener's behavior and 8.0.3 moved it to a different view, breaking the implicit contract:
- 8.0.2: overlay rendered ABOVE the nav bar (root view padded by the keyboard plugin's `ViewCompat.onApplyWindowInsets` call).
- 8.0.3: overlay has height 0 (DecorView resumes auto-consuming insets).

Calling `setDecorFitsSystemWindows(false)` is the official platform opt-in for edge-to-edge layout and tells the window we handle all insets ourselves. On Android 15+ the platform already does this; on older APIs this is a no-op to app code that was already correctly sized via the plugin's explicit margin logic.

## Trade-offs vs #839

- **Smaller diff** (1 line + comment) vs #839 (hybrid branching, nullable config, ~150 lines).
- **Unified code path** across API levels vs two separate paths.
- **Behavior change on API <35**: the plugin now explicitly enables edge-to-edge instead of preserving the traditional app layout. README claim "this plugin doesn't enable edge-to-edge mode by default" becomes incorrect and would need updating.
- **Status/nav bars go transparent by default** on API <35 when the user hasn't configured a color. #839 preserves the theme default in that case.

## Test plan

- [ ] API 31 emulator, `@capacitor/keyboard@8.0.3` — `setNavigationBarColor` and `setStatusBarColor` work.
- [ ] API 31 emulator, `@capacitor/keyboard@8.0.1` — no regression.
- [ ] API 31 with no color configured — confirm theme bars look acceptable (or are visibly transparent — pick the expected behavior).
- [ ] API 35 without opt-out — overlay approach still works.
- [ ] API 35 with `windowOptOutEdgeToEdgeEnforcement=true` — still works after explicit opt-in.
- [ ] API 36 — overlay approach used.
- [ ] Keyboard show/hide on each — webview layout correct, no double-counted bottom inset.

Close #838