### PR TITLE
feat(live-update): support file:// URIs in downloadBundle (Android + iOS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7614,7 +7614,7 @@
     },
     "packages/android-edge-to-edge-support": {
       "name": "@capawesome/capacitor-android-edge-to-edge-support",
-      "version": "8.0.7",
+      "version": "8.0.8",
       "funding": [
         {
           "type": "github",
@@ -7985,7 +7985,7 @@
     },
     "packages/badge": {
       "name": "@capawesome/capacitor-badge",
-      "version": "8.0.1",
+      "version": "8.0.2",
       "funding": [
         {
           "type": "github",
@@ -8505,7 +8505,7 @@
     },
     "packages/posthog": {
       "name": "@capawesome/capacitor-posthog",
-      "version": "8.4.1",
+      "version": "8.4.2",
       "funding": [
         {
           "type": "github",

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
@@ -55,6 +55,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.security.KeyFactory;
 import java.security.MessageDigest;
 import java.security.PublicKey;
@@ -932,6 +933,10 @@ public class LiveUpdate {
         @NonNull String downloadUrl,
         @NonNull EmptyCallback completionCallback
     ) {
+        if (downloadUrl.startsWith("file://")) {
+            copyFromFileSchemeAndAddBundle(bundleId, downloadUrl, checksum, signature, completionCallback);
+            return;
+        }
         File file = buildTemporaryZipFile();
         // Download the bundle
         downloadAndVerifyFile(
@@ -965,6 +970,36 @@ public class LiveUpdate {
                 }
             }
         );
+    }
+
+    private void copyFromFileSchemeAndAddBundle(
+        @NonNull String bundleId,
+        @NonNull String sourceFileUri,
+        @Nullable String checksum,
+        @Nullable String signature,
+        @NonNull EmptyCallback completionCallback
+    ) {
+        File destination = buildTemporaryZipFile();
+        try {
+            File source = new File(URI.create(sourceFileUri));
+            LiveUpdateFileScheme.copyAndReportProgress(
+                source,
+                destination,
+                (downloadedBytes, totalBytes) -> {
+                    DownloadBundleProgressEvent event = new DownloadBundleProgressEvent(bundleId, downloadedBytes, totalBytes);
+                    notifyDownloadBundleProgressListeners(event);
+                }
+            );
+            verifyFile(destination, checksum, signature);
+            addBundleOfTypeZip(bundleId, destination);
+            destination.delete();
+            completionCallback.success();
+        } catch (Exception e) {
+            if (destination.exists()) {
+                destination.delete();
+            }
+            completionCallback.error(e);
+        }
     }
 
     private void fetchLatestBundleInternal(

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
@@ -55,7 +55,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 import java.security.KeyFactory;
 import java.security.MessageDigest;
 import java.security.PublicKey;
@@ -934,6 +933,7 @@ public class LiveUpdate {
         @NonNull EmptyCallback completionCallback
     ) {
         if (downloadUrl.startsWith("file://")) {
+            Logger.debug(LiveUpdatePlugin.TAG, "Copying sideloaded bundle from: " + downloadUrl);
             copyFromFileSchemeAndAddBundle(bundleId, downloadUrl, checksum, signature, completionCallback);
             return;
         }
@@ -981,7 +981,13 @@ public class LiveUpdate {
     ) {
         File destination = buildTemporaryZipFile();
         try {
-            File source = new File(URI.create(sourceFileUri));
+            android.content.Context context = plugin.getContext();
+            File source = LiveUpdateFileScheme.resolveSandboxedFile(
+                sourceFileUri,
+                context.getFilesDir().getCanonicalPath(),
+                context.getCacheDir().getCanonicalPath(),
+                context.getNoBackupFilesDir().getCanonicalPath()
+            );
             LiveUpdateFileScheme.copyAndReportProgress(
                 source,
                 destination,
@@ -992,13 +998,21 @@ public class LiveUpdate {
             );
             verifyFile(destination, checksum, signature);
             addBundleOfTypeZip(bundleId, destination);
-            destination.delete();
+            removeTemporaryFile(destination);
             completionCallback.success();
         } catch (Exception e) {
-            if (destination.exists()) {
-                destination.delete();
-            }
+            Logger.error(LiveUpdatePlugin.TAG, "Failed to copy sideloaded bundle: " + e.getMessage(), e);
+            removeTemporaryFile(destination);
             completionCallback.error(e);
+        }
+    }
+
+    private void removeTemporaryFile(@NonNull File file) {
+        if (!file.exists()) {
+            return;
+        }
+        if (!file.delete()) {
+            Logger.warn(LiveUpdatePlugin.TAG, "Failed to clean up temp zip at " + file.getAbsolutePath());
         }
     }
 

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
@@ -988,13 +988,10 @@ public class LiveUpdate {
                 context.getCacheDir().getCanonicalPath(),
                 context.getNoBackupFilesDir().getCanonicalPath()
             );
-            LiveUpdateFileScheme.copyAndReportProgress(
-                source,
-                destination,
-                (downloadedBytes, totalBytes) -> {
-                    DownloadBundleProgressEvent event = new DownloadBundleProgressEvent(bundleId, downloadedBytes, totalBytes);
-                    notifyDownloadBundleProgressListeners(event);
-                }
+            java.nio.file.Files.copy(
+                source.toPath(),
+                destination.toPath(),
+                java.nio.file.StandardCopyOption.REPLACE_EXISTING
             );
             verifyFile(destination, checksum, signature);
             addBundleOfTypeZip(bundleId, destination);

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateFileScheme.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateFileScheme.java
@@ -1,0 +1,59 @@
+package io.capawesome.capacitorjs.plugins.liveupdate;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Helper for the {@code file://} URL scheme path of {@code downloadBundle}.
+ * Pure-Java by design so unit tests can run on the JVM without Robolectric.
+ */
+public final class LiveUpdateFileScheme {
+
+    public interface ProgressListener {
+        void onProgress(long downloadedBytes, long totalBytes);
+    }
+
+    private LiveUpdateFileScheme() {
+        /* utility class */
+    }
+
+    /**
+     * Copies {@code source} to {@code destination}, reporting incremental
+     * progress to {@code progress} (may be {@code null}). The total byte count
+     * reported is {@code source.length()} captured before copying begins.
+     *
+     * @return the number of bytes actually copied (equal to source size on success)
+     * @throws FileNotFoundException if {@code source} does not exist
+     * @throws IOException on read/write failure
+     */
+    public static long copyAndReportProgress(
+        @NonNull File source,
+        @NonNull File destination,
+        @Nullable ProgressListener progress
+    ) throws IOException {
+        if (!source.exists()) {
+            throw new FileNotFoundException("Sideloaded bundle not found at " + source.getAbsolutePath());
+        }
+        long total = source.length();
+        long copied = 0L;
+        byte[] buffer = new byte[8192];
+        try (InputStream in = new FileInputStream(source); OutputStream out = new FileOutputStream(destination)) {
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                out.write(buffer, 0, read);
+                copied += read;
+                if (progress != null) {
+                    progress.onProgress(copied, total);
+                }
+            }
+        }
+        return copied;
+    }
+}

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateFileScheme.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateFileScheme.java
@@ -1,14 +1,8 @@
 package io.capawesome.capacitorjs.plugins.liveupdate;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -18,10 +12,6 @@ import java.net.URISyntaxException;
  * or Mockito.
  */
 public final class LiveUpdateFileScheme {
-
-    public interface ProgressListener {
-        void onProgress(long downloadedBytes, long totalBytes);
-    }
 
     private LiveUpdateFileScheme() {
         /* utility class */
@@ -71,41 +61,5 @@ public final class LiveUpdateFileScheme {
             }
         }
         throw new SecurityException("Sideloaded bundle path is outside the app sandbox");
-    }
-
-    /**
-     * Copies {@code source} to {@code destination}, reporting incremental
-     * progress to {@code progress} (may be {@code null}). The total byte count
-     * reported is {@code source.length()} captured before copying begins.
-     *
-     * @return the number of bytes actually copied (equal to source size on success)
-     * @throws FileNotFoundException if {@code source} does not exist
-     * @throws IOException on read/write failure
-     */
-    public static long copyAndReportProgress(
-        @NonNull File source,
-        @NonNull File destination,
-        @Nullable ProgressListener progress
-    ) throws IOException {
-        if (!source.exists()) {
-            throw new FileNotFoundException("Sideloaded bundle not found");
-        }
-        long total = source.length();
-        long copied = 0L;
-        byte[] buffer = new byte[8192];
-        try (
-            InputStream in = new FileInputStream(source);
-            OutputStream out = new FileOutputStream(destination)
-        ) {
-            int read;
-            while ((read = in.read(buffer)) != -1) {
-                out.write(buffer, 0, read);
-                copied += read;
-                if (progress != null) {
-                    progress.onProgress(copied, total);
-                }
-            }
-        }
-        return copied;
     }
 }

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateFileScheme.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateFileScheme.java
@@ -9,10 +9,13 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 /**
  * Helper for the {@code file://} URL scheme path of {@code downloadBundle}.
- * Pure-Java by design so unit tests can run on the JVM without Robolectric.
+ * Pure-Java by design so unit tests can run on the JVM without Robolectric
+ * or Mockito.
  */
 public final class LiveUpdateFileScheme {
 
@@ -22,6 +25,52 @@ public final class LiveUpdateFileScheme {
 
     private LiveUpdateFileScheme() {
         /* utility class */
+    }
+
+    /**
+     * Parses a {@code file://} URI string and returns the canonical {@link File}
+     * after verifying the resolved path lives under one of
+     * {@code allowedCanonicalPrefixes}. Each prefix must already be a canonical
+     * absolute path; the caller is responsible for canonicalising
+     * {@code Context.getFilesDir()}, {@code Context.getCacheDir()}, etc.
+     * before passing them in.
+     *
+     * Rejects non-file schemes and any path that escapes the allowed prefixes
+     * via symlink or {@code ..} traversal.
+     *
+     * @throws IllegalArgumentException for malformed URIs or non-file schemes
+     * @throws SecurityException when the resolved path is outside every allowed prefix
+     * @throws IOException when canonicalisation fails
+     */
+    @NonNull
+    public static File resolveSandboxedFile(
+        @NonNull String sourceFileUri,
+        @NonNull String... allowedCanonicalPrefixes
+    ) throws IOException {
+        URI uri;
+        try {
+            uri = new URI(sourceFileUri);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid file:// URI");
+        }
+        String scheme = uri.getScheme();
+        if (scheme == null || !"file".equalsIgnoreCase(scheme)) {
+            throw new IllegalArgumentException("Invalid file:// URI");
+        }
+        File candidate;
+        try {
+            candidate = new File(uri);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid file:// URI");
+        }
+        File canonical = candidate.getCanonicalFile();
+        String canonicalPath = canonical.getAbsolutePath();
+        for (String prefix : allowedCanonicalPrefixes) {
+            if (canonicalPath.equals(prefix) || canonicalPath.startsWith(prefix + File.separator)) {
+                return canonical;
+            }
+        }
+        throw new SecurityException("Sideloaded bundle path is outside the app sandbox");
     }
 
     /**
@@ -39,12 +88,15 @@ public final class LiveUpdateFileScheme {
         @Nullable ProgressListener progress
     ) throws IOException {
         if (!source.exists()) {
-            throw new FileNotFoundException("Sideloaded bundle not found at " + source.getAbsolutePath());
+            throw new FileNotFoundException("Sideloaded bundle not found");
         }
         long total = source.length();
         long copied = 0L;
         byte[] buffer = new byte[8192];
-        try (InputStream in = new FileInputStream(source); OutputStream out = new FileOutputStream(destination)) {
+        try (
+            InputStream in = new FileInputStream(source);
+            OutputStream out = new FileOutputStream(destination)
+        ) {
             int read;
             while ((read = in.read(buffer)) != -1) {
                 out.write(buffer, 0, read);

--- a/packages/live-update/android/src/test/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateFileSchemeTest.java
+++ b/packages/live-update/android/src/test/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateFileSchemeTest.java
@@ -1,0 +1,58 @@
+package io.capawesome.capacitorjs.plugins.liveupdate;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class LiveUpdateFileSchemeTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void copyAndReportProgress_copiesBytesIdentically() throws Exception {
+        File source = tmp.newFile("bundle.zip");
+        byte[] payload = new byte[16 * 1024 + 7];
+        new Random(0).nextBytes(payload);
+        Files.write(source.toPath(), payload);
+        File destination = tmp.newFile("dest.zip");
+
+        List<long[]> events = new ArrayList<>();
+        long copied = LiveUpdateFileScheme.copyAndReportProgress(source, destination, (d, t) -> events.add(new long[] { d, t }));
+
+        assertEquals(payload.length, copied);
+        assertArrayEquals(payload, Files.readAllBytes(destination.toPath()));
+        assertFalse(events.isEmpty());
+        long[] last = events.get(events.size() - 1);
+        assertEquals(payload.length, last[0]);
+        assertEquals(payload.length, last[1]);
+    }
+
+    @Test(expected = FileNotFoundException.class)
+    public void copyAndReportProgress_throwsWhenSourceMissing() throws Exception {
+        File source = new File(tmp.getRoot(), "missing.zip");
+        File destination = tmp.newFile("dest.zip");
+        LiveUpdateFileScheme.copyAndReportProgress(source, destination, null);
+    }
+
+    @Test
+    public void copyAndReportProgress_acceptsNullListener() throws Exception {
+        File source = tmp.newFile("bundle.zip");
+        Files.write(source.toPath(), "hello".getBytes());
+        File destination = tmp.newFile("dest.zip");
+
+        long copied = LiveUpdateFileScheme.copyAndReportProgress(source, destination, null);
+
+        assertEquals(5, copied);
+    }
+}

--- a/packages/live-update/android/src/test/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateFileSchemeTest.java
+++ b/packages/live-update/android/src/test/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateFileSchemeTest.java
@@ -1,17 +1,11 @@
 package io.capawesome.capacitorjs.plugins.liveupdate;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -20,58 +14,6 @@ public class LiveUpdateFileSchemeTest {
 
     @Rule
     public TemporaryFolder tmp = new TemporaryFolder();
-
-    @Test
-    public void copyAndReportProgress_copiesBytesIdentically() throws Exception {
-        File source = tmp.newFile("bundle.zip");
-        byte[] payload = new byte[16 * 1024 + 7];
-        new Random(0).nextBytes(payload);
-        Files.write(source.toPath(), payload);
-        File destination = tmp.newFile("dest.zip");
-
-        List<long[]> events = new ArrayList<>();
-        long copied = LiveUpdateFileScheme.copyAndReportProgress(source, destination, (d, t) -> events.add(new long[] { d, t }));
-
-        assertEquals(payload.length, copied);
-        assertArrayEquals(payload, Files.readAllBytes(destination.toPath()));
-        assertFalse(events.isEmpty());
-        long[] last = events.get(events.size() - 1);
-        assertEquals(payload.length, last[0]);
-        assertEquals(payload.length, last[1]);
-    }
-
-    @Test(expected = FileNotFoundException.class)
-    public void copyAndReportProgress_throwsWhenSourceMissing() throws Exception {
-        File source = new File(tmp.getRoot(), "missing.zip");
-        File destination = tmp.newFile("dest.zip");
-        LiveUpdateFileScheme.copyAndReportProgress(source, destination, null);
-    }
-
-    @Test
-    public void copyAndReportProgress_acceptsNullListener() throws Exception {
-        File source = tmp.newFile("bundle.zip");
-        Files.write(source.toPath(), "hello".getBytes());
-        File destination = tmp.newFile("dest.zip");
-
-        long copied = LiveUpdateFileScheme.copyAndReportProgress(source, destination, null);
-
-        assertEquals(5, copied);
-    }
-
-    @Test
-    public void copyAndReportProgress_messageDoesNotLeakSourcePath() throws Exception {
-        File source = new File(tmp.getRoot(), "secret-internal-path.zip");
-        File destination = tmp.newFile("dest.zip");
-        try {
-            LiveUpdateFileScheme.copyAndReportProgress(source, destination, null);
-            fail("expected FileNotFoundException");
-        } catch (FileNotFoundException e) {
-            assertFalse(
-                "exception message must not include the absolute source path",
-                e.getMessage() != null && e.getMessage().contains(source.getAbsolutePath())
-            );
-        }
-    }
 
     @Test
     public void resolveSandboxedFile_acceptsPathInsideAllowedPrefix() throws Exception {

--- a/packages/live-update/android/src/test/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateFileSchemeTest.java
+++ b/packages/live-update/android/src/test/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateFileSchemeTest.java
@@ -3,6 +3,8 @@ package io.capawesome.capacitorjs.plugins.liveupdate;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -54,5 +56,124 @@ public class LiveUpdateFileSchemeTest {
         long copied = LiveUpdateFileScheme.copyAndReportProgress(source, destination, null);
 
         assertEquals(5, copied);
+    }
+
+    @Test
+    public void copyAndReportProgress_messageDoesNotLeakSourcePath() throws Exception {
+        File source = new File(tmp.getRoot(), "secret-internal-path.zip");
+        File destination = tmp.newFile("dest.zip");
+        try {
+            LiveUpdateFileScheme.copyAndReportProgress(source, destination, null);
+            fail("expected FileNotFoundException");
+        } catch (FileNotFoundException e) {
+            assertFalse(
+                "exception message must not include the absolute source path",
+                e.getMessage() != null && e.getMessage().contains(source.getAbsolutePath())
+            );
+        }
+    }
+
+    @Test
+    public void resolveSandboxedFile_acceptsPathInsideAllowedPrefix() throws Exception {
+        File sandbox = tmp.newFolder("files");
+        File bundle = new File(sandbox, "bundle.zip");
+        Files.write(bundle.toPath(), "z".getBytes());
+
+        File resolved = LiveUpdateFileScheme.resolveSandboxedFile(
+            bundle.toURI().toString(),
+            sandbox.getCanonicalPath()
+        );
+
+        assertEquals(bundle.getCanonicalFile(), resolved);
+    }
+
+    @Test
+    public void resolveSandboxedFile_acceptsSandboxRootItself() throws Exception {
+        File sandbox = tmp.newFolder("files");
+
+        File resolved = LiveUpdateFileScheme.resolveSandboxedFile(
+            sandbox.toURI().toString(),
+            sandbox.getCanonicalPath()
+        );
+
+        assertEquals(sandbox.getCanonicalFile(), resolved);
+    }
+
+    @Test
+    public void resolveSandboxedFile_rejectsMalformedUri() throws Exception {
+        try {
+            LiveUpdateFileScheme.resolveSandboxedFile("file:// not a uri", tmp.getRoot().getCanonicalPath());
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void resolveSandboxedFile_rejectsNonFileScheme() throws Exception {
+        try {
+            LiveUpdateFileScheme.resolveSandboxedFile("https://example.com/bundle.zip", tmp.getRoot().getCanonicalPath());
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void resolveSandboxedFile_rejectsContentScheme() throws Exception {
+        try {
+            LiveUpdateFileScheme.resolveSandboxedFile("content://com.evil/bundle.zip", tmp.getRoot().getCanonicalPath());
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void resolveSandboxedFile_rejectsPathOutsideSandbox() throws Exception {
+        File sandbox = tmp.newFolder("files");
+        File outside = tmp.newFile("outside.zip");
+        try {
+            LiveUpdateFileScheme.resolveSandboxedFile(
+                outside.toURI().toString(),
+                sandbox.getCanonicalPath()
+            );
+            fail("expected SecurityException");
+        } catch (SecurityException expected) {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void resolveSandboxedFile_rejectsParentTraversal() throws Exception {
+        File sandbox = tmp.newFolder("files");
+        File outside = tmp.newFile("outside.zip");
+        Files.write(outside.toPath(), "x".getBytes());
+        // Build a uri that walks out of the sandbox via ".."
+        String escapingUri = sandbox.toURI().toString() + "../" + outside.getName();
+        try {
+            LiveUpdateFileScheme.resolveSandboxedFile(escapingUri, sandbox.getCanonicalPath());
+            fail("expected SecurityException — parent-directory traversal must be rejected after canonicalisation");
+        } catch (SecurityException expected) {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void resolveSandboxedFile_rejectsPrefixCollision() throws Exception {
+        File sandbox = tmp.newFolder("files");
+        // Sibling dir whose path string starts with the sandbox path string but is not inside it
+        File sibling = tmp.newFolder("files-evil");
+        File bundle = new File(sibling, "bundle.zip");
+        Files.write(bundle.toPath(), "x".getBytes());
+        try {
+            LiveUpdateFileScheme.resolveSandboxedFile(
+                bundle.toURI().toString(),
+                sandbox.getCanonicalPath()
+            );
+            fail("expected SecurityException — '/sandbox-evil' must not match prefix '/sandbox'");
+        } catch (SecurityException expected) {
+            assertTrue(true);
+        }
     }
 }

--- a/packages/live-update/ios/Plugin.xcodeproj/project.pbxproj
+++ b/packages/live-update/ios/Plugin.xcodeproj/project.pbxproj
@@ -10,10 +10,12 @@
 		03FC29A292ACC40490383A1F /* Pods_Plugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B2A61DA5A1F2DD4F959604D /* Pods_Plugin.framework */; };
 		20C0B05DCFC8E3958A738AF2 /* Pods_PluginTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6753A823D3815DB436415E3 /* Pods_PluginTests.framework */; };
 		2F98D68224C9AAE500613A4C /* LiveUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F98D68124C9AAE400613A4C /* LiveUpdate.swift */; };
+		4FCB0DDCC89E2DE8E846B00F /* LiveUpdateFileSchemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C25A4BC52E89C669812DC5 /* LiveUpdateFileSchemeTests.swift */; };
 		50ADFF92201F53D600D50D53 /* Plugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50ADFF88201F53D600D50D53 /* Plugin.framework */; };
 		50ADFF97201F53D600D50D53 /* LiveUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50ADFF96201F53D600D50D53 /* LiveUpdateTests.swift */; };
 		50ADFFA42020D75100D50D53 /* Capacitor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50ADFFA52020D75100D50D53 /* Capacitor.framework */; };
 		50E1A94820377CB70090CE1A /* LiveUpdatePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E1A94720377CB70090CE1A /* LiveUpdatePlugin.swift */; };
+		58AD2DB3CEF67FE68E1D48C3 /* LiveUpdateFileScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5DA95DF74BB51DD0BD0AAED /* LiveUpdateFileScheme.swift */; };
 		7C0C8C492BAB354A005F76D1 /* LiveUpdateConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0C8C482BAB354A005F76D1 /* LiveUpdateConfig.swift */; };
 		7C2011512BA9653B001FABAD /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C2011502BA9653B001FABAD /* Result.swift */; };
 		7C2011532BA96555001FABAD /* GetBundlesResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C2011522BA96555001FABAD /* GetBundlesResult.swift */; };
@@ -46,12 +48,12 @@
 		7CAB12562DEFA2D0003BB3E6 /* GetBlockedBundlesResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB12552DEFA2D0003BB3E6 /* GetBlockedBundlesResult.swift */; };
 		7CAB12672DEFA3E0003BB4F7 /* SetConfigOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB12662DEFA3E0003BB4F7 /* SetConfigOptions.swift */; };
 		7CAB12782DEFA3F0003BB5F8 /* GetConfigResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB12772DEFA3F0003BB5F8 /* GetConfigResult.swift */; };
-		7CB7B8AE2CC9419800833086 /* FetchLatestBundleResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB7B8AD2CC9419000833086 /* FetchLatestBundleResult.swift */; };
-		7CD426B22D155B00003F93F9 /* SetNextBundleOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD426B12D155AFB003F93F9 /* SetNextBundleOptions.swift */; };
 		7CAB13012DEFB100003BC5A2 /* FetchChannelsOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB13002DEFB100003BC5A2 /* FetchChannelsOptions.swift */; };
 		7CAB13032DEFB110003BC5B3 /* ChannelResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB13022DEFB110003BC5B3 /* ChannelResult.swift */; };
 		7CAB13052DEFB120003BC5C4 /* FetchChannelsResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB13042DEFB120003BC5C4 /* FetchChannelsResult.swift */; };
 		7CAB13072DEFB130003BC5D5 /* GetChannelsResponseItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB13062DEFB130003BC5D5 /* GetChannelsResponseItem.swift */; };
+		7CB7B8AE2CC9419800833086 /* FetchLatestBundleResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB7B8AD2CC9419000833086 /* FetchLatestBundleResult.swift */; };
+		7CD426B22D155B00003F93F9 /* SetNextBundleOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD426B12D155AFB003F93F9 /* SetNextBundleOptions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -75,6 +77,7 @@
 		50ADFFA52020D75100D50D53 /* Capacitor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Capacitor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		50E1A94720377CB70090CE1A /* LiveUpdatePlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiveUpdatePlugin.swift; sourceTree = "<group>"; };
 		5E23F77F099397094342571A /* Pods-Plugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Plugin.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Plugin/Pods-Plugin.debug.xcconfig"; sourceTree = "<group>"; };
+		65C25A4BC52E89C669812DC5 /* LiveUpdateFileSchemeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LiveUpdateFileSchemeTests.swift; sourceTree = "<group>"; };
 		7C0C8C482BAB354A005F76D1 /* LiveUpdateConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveUpdateConfig.swift; sourceTree = "<group>"; };
 		7C2011502BA9653B001FABAD /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		7C2011522BA96555001FABAD /* GetBundlesResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBundlesResult.swift; sourceTree = "<group>"; };
@@ -107,14 +110,15 @@
 		7CAB12552DEFA2D0003BB3E6 /* GetBlockedBundlesResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBlockedBundlesResult.swift; sourceTree = "<group>"; };
 		7CAB12662DEFA3E0003BB4F7 /* SetConfigOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetConfigOptions.swift; sourceTree = "<group>"; };
 		7CAB12772DEFA3F0003BB5F8 /* GetConfigResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetConfigResult.swift; sourceTree = "<group>"; };
-		7CB7B8AD2CC9419000833086 /* FetchLatestBundleResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchLatestBundleResult.swift; sourceTree = "<group>"; };
-		7CD426B12D155AFB003F93F9 /* SetNextBundleOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetNextBundleOptions.swift; sourceTree = "<group>"; };
 		7CAB13002DEFB100003BC5A2 /* FetchChannelsOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchChannelsOptions.swift; sourceTree = "<group>"; };
 		7CAB13022DEFB110003BC5B3 /* ChannelResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelResult.swift; sourceTree = "<group>"; };
 		7CAB13042DEFB120003BC5C4 /* FetchChannelsResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchChannelsResult.swift; sourceTree = "<group>"; };
 		7CAB13062DEFB130003BC5D5 /* GetChannelsResponseItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetChannelsResponseItem.swift; sourceTree = "<group>"; };
+		7CB7B8AD2CC9419000833086 /* FetchLatestBundleResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchLatestBundleResult.swift; sourceTree = "<group>"; };
+		7CD426B12D155AFB003F93F9 /* SetNextBundleOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetNextBundleOptions.swift; sourceTree = "<group>"; };
 		91781294A431A2A7CC6EB714 /* Pods-Plugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Plugin.release.xcconfig"; path = "Pods/Target Support Files/Pods-Plugin/Pods-Plugin.release.xcconfig"; sourceTree = "<group>"; };
 		96ED1B6440D6672E406C8D19 /* Pods-PluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PluginTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PluginTests/Pods-PluginTests.debug.xcconfig"; sourceTree = "<group>"; };
+		C5DA95DF74BB51DD0BD0AAED /* LiveUpdateFileScheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LiveUpdateFileScheme.swift; path = Classes/LiveUpdateFileScheme.swift; sourceTree = "<group>"; };
 		F65BB2953ECE002E1EF3E424 /* Pods-PluginTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PluginTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PluginTests/Pods-PluginTests.release.xcconfig"; sourceTree = "<group>"; };
 		F6753A823D3815DB436415E3 /* Pods_PluginTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PluginTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -173,6 +177,7 @@
 				7C6715D82BB1BDAC0000878A /* LiveUpdatePreferences.swift */,
 				7C0C8C482BAB354A005F76D1 /* LiveUpdateConfig.swift */,
 				50ADFF8C201F53D600D50D53 /* Info.plist */,
+				C5DA95DF74BB51DD0BD0AAED /* LiveUpdateFileScheme.swift */,
 			);
 			path = Plugin;
 			sourceTree = "<group>";
@@ -182,6 +187,7 @@
 			children = (
 				50ADFF96201F53D600D50D53 /* LiveUpdateTests.swift */,
 				50ADFF98201F53D600D50D53 /* Info.plist */,
+				65C25A4BC52E89C669812DC5 /* LiveUpdateFileSchemeTests.swift */,
 			);
 			path = PluginTests;
 			sourceTree = "<group>";
@@ -513,6 +519,7 @@
 				7CAB13032DEFB110003BC5B3 /* ChannelResult.swift in Sources */,
 				7CAB13052DEFB120003BC5C4 /* FetchChannelsResult.swift in Sources */,
 				7CAB13072DEFB130003BC5D5 /* GetChannelsResponseItem.swift in Sources */,
+				58AD2DB3CEF67FE68E1D48C3 /* LiveUpdateFileScheme.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -521,6 +528,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				50ADFF97201F53D600D50D53 /* LiveUpdateTests.swift in Sources */,
+				4FCB0DDCC89E2DE8E846B00F /* LiveUpdateFileSchemeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/live-update/ios/Plugin/Classes/LiveUpdateFileScheme.swift
+++ b/packages/live-update/ios/Plugin/Classes/LiveUpdateFileScheme.swift
@@ -4,30 +4,17 @@ import Foundation
 /// Decoupled from the plugin's `Context` state so unit tests can exercise the
 /// IO logic in isolation.
 enum LiveUpdateFileScheme {
-    typealias ProgressCallback = (Int64, Int64) -> Void
 
     enum FileSchemeError: Swift.Error, LocalizedError {
         case invalidFileUri
-        case sourceNotFound
         case sourceOutsideSandbox
-        case streamOpenFailed
-        case streamReadFailed
-        case streamWriteFailed
 
         var errorDescription: String? {
             switch self {
             case .invalidFileUri:
                 return "Invalid file:// URI"
-            case .sourceNotFound:
-                return "Sideloaded bundle not found"
             case .sourceOutsideSandbox:
                 return "Sideloaded bundle path is outside the app sandbox"
-            case .streamOpenFailed:
-                return "Could not open stream"
-            case .streamReadFailed:
-                return "Failed to read sideloaded bundle"
-            case .streamWriteFailed:
-                return "Failed to write sideloaded bundle"
             }
         }
     }
@@ -58,65 +45,5 @@ enum LiveUpdateFileScheme {
             throw FileSchemeError.sourceOutsideSandbox
         }
         return standardized
-    }
-
-    /// Copies `source` to `destination`, reporting incremental progress to
-    /// `progress` (may be `nil`). The total byte count reported is the file size
-    /// of `source` captured before copying begins.
-    ///
-    /// - Returns: number of bytes copied (equals source file size on success).
-    /// - Throws: `FileSchemeError.sourceNotFound` when the source is absent;
-    ///           rethrows underlying stream errors.
-    @discardableResult
-    static func copyAndReportProgress(
-        source: URL,
-        destination: URL,
-        progress: ProgressCallback?
-    ) throws -> Int64 {
-        let fileManager = FileManager.default
-        guard fileManager.fileExists(atPath: source.path) else {
-            throw FileSchemeError.sourceNotFound
-        }
-        let attributes = try fileManager.attributesOfItem(atPath: source.path)
-        let total = (attributes[.size] as? NSNumber)?.int64Value ?? 0
-        if fileManager.fileExists(atPath: destination.path) {
-            try fileManager.removeItem(at: destination)
-        }
-        guard let input = InputStream(url: source) else {
-            throw FileSchemeError.streamOpenFailed
-        }
-        guard let output = OutputStream(url: destination, append: false) else {
-            throw FileSchemeError.streamOpenFailed
-        }
-        input.open()
-        defer { input.close() }
-        output.open()
-        defer { output.close() }
-
-        let bufferSize = 8192
-        var buffer = [UInt8](repeating: 0, count: bufferSize)
-        var copied: Int64 = 0
-        while input.hasBytesAvailable {
-            let read = input.read(&buffer, maxLength: bufferSize)
-            if read < 0 {
-                throw input.streamError ?? FileSchemeError.streamReadFailed
-            }
-            if read == 0 {
-                break
-            }
-            var written = 0
-            while written < read {
-                let n = buffer.withUnsafeBufferPointer { ptr -> Int in
-                    output.write(ptr.baseAddress! + written, maxLength: read - written)
-                }
-                if n <= 0 {
-                    throw output.streamError ?? FileSchemeError.streamWriteFailed
-                }
-                written += n
-            }
-            copied += Int64(read)
-            progress?(copied, total)
-        }
-        return copied
     }
 }

--- a/packages/live-update/ios/Plugin/Classes/LiveUpdateFileScheme.swift
+++ b/packages/live-update/ios/Plugin/Classes/LiveUpdateFileScheme.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Helper for the `file://` URL scheme path of `downloadBundle`.
+/// Decoupled from the plugin's `Context` state so unit tests can exercise the
+/// IO logic in isolation.
+enum LiveUpdateFileScheme {
+    typealias ProgressCallback = (Int64, Int64) -> Void
+
+    enum FileSchemeError: Swift.Error, LocalizedError {
+        case sourceNotFound(path: String)
+        case streamOpenFailed(path: String)
+        case streamReadFailed
+        case streamWriteFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .sourceNotFound(let path):
+                return "Sideloaded bundle not found at \(path)"
+            case .streamOpenFailed(let path):
+                return "Could not open stream at \(path)"
+            case .streamReadFailed:
+                return "Failed to read sideloaded bundle"
+            case .streamWriteFailed:
+                return "Failed to write sideloaded bundle"
+            }
+        }
+    }
+
+    /// Copies `source` to `destination`, reporting incremental progress to
+    /// `progress` (may be `nil`). The total byte count reported is the file size
+    /// of `source` captured before copying begins.
+    ///
+    /// - Returns: number of bytes copied (equals source file size on success).
+    /// - Throws: `FileSchemeError.sourceNotFound` when the source is absent;
+    ///           rethrows underlying stream errors.
+    @discardableResult
+    static func copyAndReportProgress(
+        source: URL,
+        destination: URL,
+        progress: ProgressCallback?
+    ) throws -> Int64 {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: source.path) else {
+            throw FileSchemeError.sourceNotFound(path: source.path)
+        }
+        let attributes = try fileManager.attributesOfItem(atPath: source.path)
+        let total = (attributes[.size] as? NSNumber)?.int64Value ?? 0
+        if fileManager.fileExists(atPath: destination.path) {
+            try fileManager.removeItem(at: destination)
+        }
+        guard let input = InputStream(url: source) else {
+            throw FileSchemeError.streamOpenFailed(path: source.path)
+        }
+        guard let output = OutputStream(url: destination, append: false) else {
+            throw FileSchemeError.streamOpenFailed(path: destination.path)
+        }
+        input.open()
+        defer { input.close() }
+        output.open()
+        defer { output.close() }
+
+        let bufferSize = 8192
+        var buffer = [UInt8](repeating: 0, count: bufferSize)
+        var copied: Int64 = 0
+        while input.hasBytesAvailable {
+            let read = input.read(&buffer, maxLength: bufferSize)
+            if read < 0 {
+                throw input.streamError ?? FileSchemeError.streamReadFailed
+            }
+            if read == 0 {
+                break
+            }
+            var written = 0
+            while written < read {
+                let n = output.write(buffer.withUnsafeBufferPointer { $0.baseAddress! + written }, maxLength: read - written)
+                if n <= 0 {
+                    throw output.streamError ?? FileSchemeError.streamWriteFailed
+                }
+                written += n
+            }
+            copied += Int64(read)
+            progress?(copied, total)
+        }
+        return copied
+    }
+}

--- a/packages/live-update/ios/Plugin/Classes/LiveUpdateFileScheme.swift
+++ b/packages/live-update/ios/Plugin/Classes/LiveUpdateFileScheme.swift
@@ -7,23 +7,57 @@ enum LiveUpdateFileScheme {
     typealias ProgressCallback = (Int64, Int64) -> Void
 
     enum FileSchemeError: Swift.Error, LocalizedError {
-        case sourceNotFound(path: String)
-        case streamOpenFailed(path: String)
+        case invalidFileUri
+        case sourceNotFound
+        case sourceOutsideSandbox
+        case streamOpenFailed
         case streamReadFailed
         case streamWriteFailed
 
         var errorDescription: String? {
             switch self {
-            case .sourceNotFound(let path):
-                return "Sideloaded bundle not found at \(path)"
-            case .streamOpenFailed(let path):
-                return "Could not open stream at \(path)"
+            case .invalidFileUri:
+                return "Invalid file:// URI"
+            case .sourceNotFound:
+                return "Sideloaded bundle not found"
+            case .sourceOutsideSandbox:
+                return "Sideloaded bundle path is outside the app sandbox"
+            case .streamOpenFailed:
+                return "Could not open stream"
             case .streamReadFailed:
                 return "Failed to read sideloaded bundle"
             case .streamWriteFailed:
                 return "Failed to write sideloaded bundle"
             }
         }
+    }
+
+    /// Parses and validates a `file://` URI string. Rejects non-file schemes,
+    /// malformed URLs, and any path that resolves outside `allowedPrefixes`
+    /// after `.standardizedFileURL` resolution. Each prefix must be the
+    /// `.standardizedFileURL.path` of an allowed sandbox directory; the caller
+    /// is responsible for collecting them (e.g. from `FileManager.urls(for:in:)`
+    /// for documents/library/caches/applicationSupport plus
+    /// `NSTemporaryDirectory()`).
+    ///
+    /// - Throws: `FileSchemeError.invalidFileUri` for malformed or non-file URIs;
+    ///           `FileSchemeError.sourceOutsideSandbox` for sandbox escapes.
+    static func resolveFileUrl(
+        _ sourceFileUri: String,
+        allowedPrefixes: [String]
+    ) throws -> URL {
+        guard let parsed = URL(string: sourceFileUri), parsed.isFileURL else {
+            throw FileSchemeError.invalidFileUri
+        }
+        let standardized = parsed.standardizedFileURL
+        let path = standardized.path
+        let inSandbox = allowedPrefixes.contains { prefix in
+            path == prefix || path.hasPrefix(prefix + "/")
+        }
+        guard inSandbox else {
+            throw FileSchemeError.sourceOutsideSandbox
+        }
+        return standardized
     }
 
     /// Copies `source` to `destination`, reporting incremental progress to
@@ -41,7 +75,7 @@ enum LiveUpdateFileScheme {
     ) throws -> Int64 {
         let fileManager = FileManager.default
         guard fileManager.fileExists(atPath: source.path) else {
-            throw FileSchemeError.sourceNotFound(path: source.path)
+            throw FileSchemeError.sourceNotFound
         }
         let attributes = try fileManager.attributesOfItem(atPath: source.path)
         let total = (attributes[.size] as? NSNumber)?.int64Value ?? 0
@@ -49,10 +83,10 @@ enum LiveUpdateFileScheme {
             try fileManager.removeItem(at: destination)
         }
         guard let input = InputStream(url: source) else {
-            throw FileSchemeError.streamOpenFailed(path: source.path)
+            throw FileSchemeError.streamOpenFailed
         }
         guard let output = OutputStream(url: destination, append: false) else {
-            throw FileSchemeError.streamOpenFailed(path: destination.path)
+            throw FileSchemeError.streamOpenFailed
         }
         input.open()
         defer { input.close() }
@@ -72,7 +106,9 @@ enum LiveUpdateFileScheme {
             }
             var written = 0
             while written < read {
-                let n = output.write(buffer.withUnsafeBufferPointer { $0.baseAddress! + written }, maxLength: read - written)
+                let n = buffer.withUnsafeBufferPointer { ptr -> Int in
+                    output.write(ptr.baseAddress! + written, maxLength: read - written)
+                }
                 if n <= 0 {
                     throw output.streamError ?? FileSchemeError.streamWriteFailed
                 }

--- a/packages/live-update/ios/Plugin/LiveUpdate.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdate.swift
@@ -569,6 +569,7 @@ import CommonCrypto
 
     private func downloadBundleOfTypeZip(bundleId: String, checksum: String?, signature: String?, url: String) async throws {
         if url.hasPrefix("file://") {
+            CAPLog.print("[", LiveUpdatePlugin.tag, "] ", "Copying sideloaded bundle from: \(url)")
             try await copyFromFileSchemeAndAddBundle(bundleId: bundleId, sourceFileUri: url, checksum: checksum, signature: signature)
             return
         }
@@ -587,9 +588,10 @@ import CommonCrypto
         let timestamp = String(Int(Date().timeIntervalSince1970))
         let destination = self.cachesDirectoryUrl.appendingPathComponent(timestamp + ".zip")
         do {
-            guard let source = URL(string: sourceFileUri) else {
-                throw CustomError.downloadFailed
-            }
+            let source = try LiveUpdateFileScheme.resolveFileUrl(
+                sourceFileUri,
+                allowedPrefixes: sandboxPrefixes()
+            )
             _ = try LiveUpdateFileScheme.copyAndReportProgress(
                 source: source,
                 destination: destination,
@@ -600,11 +602,42 @@ import CommonCrypto
             )
             try verifyFile(url: destination, checksum: checksum, signature: signature)
             try await addBundleOfTypeZip(bundleId: bundleId, zipFile: destination)
-            try? FileManager.default.removeItem(at: destination)
+            removeTemporaryFile(at: destination)
         } catch {
-            try? FileManager.default.removeItem(at: destination)
+            CAPLog.print("[", LiveUpdatePlugin.tag, "] ", "Failed to copy sideloaded bundle: \(error.localizedDescription)")
+            removeTemporaryFile(at: destination)
             throw error
         }
+    }
+
+    private func removeTemporaryFile(at url: URL) {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: url.path) else {
+            return
+        }
+        do {
+            try fileManager.removeItem(at: url)
+        } catch {
+            CAPLog.print("[", LiveUpdatePlugin.tag, "] ", "Failed to clean up temp zip: \(error.localizedDescription)")
+        }
+    }
+
+    private func sandboxPrefixes() -> [String] {
+        let manager = FileManager.default
+        let domains: [FileManager.SearchPathDirectory] = [
+            .documentDirectory,
+            .libraryDirectory,
+            .cachesDirectory,
+            .applicationSupportDirectory
+        ]
+        var prefixes: [String] = []
+        for domain in domains {
+            for url in manager.urls(for: domain, in: .userDomainMask) {
+                prefixes.append(url.standardizedFileURL.path)
+            }
+        }
+        prefixes.append((NSTemporaryDirectory() as NSString).standardizingPath)
+        return prefixes
     }
 
     private func fetchLatestBundle(_ options: FetchLatestBundleOptions) async throws -> GetLatestBundleResponse? {

--- a/packages/live-update/ios/Plugin/LiveUpdate.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdate.swift
@@ -587,19 +587,16 @@ import CommonCrypto
     private func copyFromFileSchemeAndAddBundle(bundleId: String, sourceFileUri: String, checksum: String?, signature: String?) async throws {
         let timestamp = String(Int(Date().timeIntervalSince1970))
         let destination = self.cachesDirectoryUrl.appendingPathComponent(timestamp + ".zip")
+        let fileManager = FileManager.default
         do {
             let source = try LiveUpdateFileScheme.resolveFileUrl(
                 sourceFileUri,
                 allowedPrefixes: sandboxPrefixes()
             )
-            _ = try LiveUpdateFileScheme.copyAndReportProgress(
-                source: source,
-                destination: destination,
-                progress: { [weak self] downloadedBytes, totalBytes in
-                    let event = DownloadBundleProgressEvent(bundleId: bundleId, downloadedBytes: downloadedBytes, totalBytes: totalBytes)
-                    self?.notifyDownloadBundleProgressListeners(event)
-                }
-            )
+            if fileManager.fileExists(atPath: destination.path) {
+                try fileManager.removeItem(at: destination)
+            }
+            try fileManager.copyItem(at: source, to: destination)
             try verifyFile(url: destination, checksum: checksum, signature: signature)
             try await addBundleOfTypeZip(bundleId: bundleId, zipFile: destination)
             removeTemporaryFile(at: destination)

--- a/packages/live-update/ios/Plugin/LiveUpdate.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdate.swift
@@ -568,6 +568,10 @@ import CommonCrypto
     }
 
     private func downloadBundleOfTypeZip(bundleId: String, checksum: String?, signature: String?, url: String) async throws {
+        if url.hasPrefix("file://") {
+            try await copyFromFileSchemeAndAddBundle(bundleId: bundleId, sourceFileUri: url, checksum: checksum, signature: signature)
+            return
+        }
         let timestamp = String(Int(Date().timeIntervalSince1970))
         let temporaryZipFileUrl = self.cachesDirectoryUrl.appendingPathComponent(timestamp + ".zip")
         // Download the bundle
@@ -577,6 +581,30 @@ import CommonCrypto
         })
         // Add the bundle
         try await addBundleOfTypeZip(bundleId: bundleId, zipFile: temporaryZipFileUrl)
+    }
+
+    private func copyFromFileSchemeAndAddBundle(bundleId: String, sourceFileUri: String, checksum: String?, signature: String?) async throws {
+        let timestamp = String(Int(Date().timeIntervalSince1970))
+        let destination = self.cachesDirectoryUrl.appendingPathComponent(timestamp + ".zip")
+        do {
+            guard let source = URL(string: sourceFileUri) else {
+                throw CustomError.downloadFailed
+            }
+            _ = try LiveUpdateFileScheme.copyAndReportProgress(
+                source: source,
+                destination: destination,
+                progress: { [weak self] downloadedBytes, totalBytes in
+                    let event = DownloadBundleProgressEvent(bundleId: bundleId, downloadedBytes: downloadedBytes, totalBytes: totalBytes)
+                    self?.notifyDownloadBundleProgressListeners(event)
+                }
+            )
+            try verifyFile(url: destination, checksum: checksum, signature: signature)
+            try await addBundleOfTypeZip(bundleId: bundleId, zipFile: destination)
+            try? FileManager.default.removeItem(at: destination)
+        } catch {
+            try? FileManager.default.removeItem(at: destination)
+            throw error
+        }
     }
 
     private func fetchLatestBundle(_ options: FetchLatestBundleOptions) async throws -> GetLatestBundleResponse? {

--- a/packages/live-update/ios/PluginTests/LiveUpdateFileSchemeTests.swift
+++ b/packages/live-update/ios/PluginTests/LiveUpdateFileSchemeTests.swift
@@ -57,4 +57,112 @@ final class LiveUpdateFileSchemeTests: XCTestCase {
 
         XCTAssertEqual(copied, 5)
     }
+
+    func testCopyAndReportProgress_errorDescriptionDoesNotLeakPath() {
+        let descriptor = LiveUpdateFileScheme.FileSchemeError.sourceNotFound.errorDescription ?? ""
+        XCTAssertFalse(descriptor.contains("/"), "errorDescription must not include a filesystem path")
+    }
+
+    func testResolveFileUrl_acceptsPathInsideAllowedPrefix() throws {
+        let sandbox = tmp.appendingPathComponent("files")
+        try FileManager.default.createDirectory(at: sandbox, withIntermediateDirectories: true)
+        let bundle = sandbox.appendingPathComponent("bundle.zip")
+        try Data("z".utf8).write(to: bundle)
+
+        let resolved = try LiveUpdateFileScheme.resolveFileUrl(
+            bundle.absoluteString,
+            allowedPrefixes: [sandbox.standardizedFileURL.path]
+        )
+
+        XCTAssertEqual(resolved.standardizedFileURL.path, bundle.standardizedFileURL.path)
+    }
+
+    func testResolveFileUrl_rejectsNonFileScheme() {
+        XCTAssertThrowsError(
+            try LiveUpdateFileScheme.resolveFileUrl(
+                "https://example.com/bundle.zip",
+                allowedPrefixes: [tmp.standardizedFileURL.path]
+            )
+        ) { error in
+            guard case LiveUpdateFileScheme.FileSchemeError.invalidFileUri = error else {
+                XCTFail("expected invalidFileUri, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testResolveFileUrl_rejectsFileUriWithHostComponent() {
+        // URL(string:) accepts "file://example.com/foo" but isFileURL is false because of the host.
+        XCTAssertThrowsError(
+            try LiveUpdateFileScheme.resolveFileUrl(
+                "file://example.com/etc/passwd",
+                allowedPrefixes: [tmp.standardizedFileURL.path]
+            )
+        ) { error in
+            guard case LiveUpdateFileScheme.FileSchemeError.invalidFileUri = error else {
+                XCTFail("expected invalidFileUri, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testResolveFileUrl_rejectsPathOutsideSandbox() throws {
+        let sandbox = tmp.appendingPathComponent("files")
+        try FileManager.default.createDirectory(at: sandbox, withIntermediateDirectories: true)
+        let outside = tmp.appendingPathComponent("outside.zip")
+        try Data("x".utf8).write(to: outside)
+
+        XCTAssertThrowsError(
+            try LiveUpdateFileScheme.resolveFileUrl(
+                outside.absoluteString,
+                allowedPrefixes: [sandbox.standardizedFileURL.path]
+            )
+        ) { error in
+            guard case LiveUpdateFileScheme.FileSchemeError.sourceOutsideSandbox = error else {
+                XCTFail("expected sourceOutsideSandbox, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testResolveFileUrl_rejectsParentTraversalAfterStandardisation() throws {
+        let sandbox = tmp.appendingPathComponent("files")
+        try FileManager.default.createDirectory(at: sandbox, withIntermediateDirectories: true)
+        let outside = tmp.appendingPathComponent("outside.zip")
+        try Data("x".utf8).write(to: outside)
+        let escaping = sandbox.appendingPathComponent("..").appendingPathComponent("outside.zip").absoluteString
+
+        XCTAssertThrowsError(
+            try LiveUpdateFileScheme.resolveFileUrl(
+                escaping,
+                allowedPrefixes: [sandbox.standardizedFileURL.path]
+            )
+        ) { error in
+            guard case LiveUpdateFileScheme.FileSchemeError.sourceOutsideSandbox = error else {
+                XCTFail("expected sourceOutsideSandbox, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testResolveFileUrl_rejectsPrefixCollision() throws {
+        let sandbox = tmp.appendingPathComponent("files")
+        let sibling = tmp.appendingPathComponent("files-evil")
+        try FileManager.default.createDirectory(at: sandbox, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: sibling, withIntermediateDirectories: true)
+        let bundle = sibling.appendingPathComponent("bundle.zip")
+        try Data("x".utf8).write(to: bundle)
+
+        XCTAssertThrowsError(
+            try LiveUpdateFileScheme.resolveFileUrl(
+                bundle.absoluteString,
+                allowedPrefixes: [sandbox.standardizedFileURL.path]
+            )
+        ) { error in
+            guard case LiveUpdateFileScheme.FileSchemeError.sourceOutsideSandbox = error else {
+                XCTFail("expected sourceOutsideSandbox (prefix collision), got \(error)")
+                return
+            }
+        }
+    }
 }

--- a/packages/live-update/ios/PluginTests/LiveUpdateFileSchemeTests.swift
+++ b/packages/live-update/ios/PluginTests/LiveUpdateFileSchemeTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import Plugin
+
+final class LiveUpdateFileSchemeTests: XCTestCase {
+
+    var tmp: URL!
+
+    override func setUpWithError() throws {
+        tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tmp)
+    }
+
+    func testCopyAndReportProgress_copiesBytesIdentically() throws {
+        let source = tmp.appendingPathComponent("bundle.zip")
+        let destination = tmp.appendingPathComponent("dest.zip")
+        let payload = Data((0..<(16 * 1024 + 7)).map { _ in UInt8.random(in: 0...255) })
+        try payload.write(to: source)
+
+        var events: [(Int64, Int64)] = []
+        let copied = try LiveUpdateFileScheme.copyAndReportProgress(
+            source: source,
+            destination: destination,
+            progress: { downloaded, total in events.append((downloaded, total)) }
+        )
+
+        XCTAssertEqual(copied, Int64(payload.count))
+        XCTAssertEqual(try Data(contentsOf: destination), payload)
+        XCTAssertFalse(events.isEmpty)
+        XCTAssertEqual(events.last?.0, Int64(payload.count))
+        XCTAssertEqual(events.last?.1, Int64(payload.count))
+    }
+
+    func testCopyAndReportProgress_throwsWhenSourceMissing() throws {
+        let source = tmp.appendingPathComponent("missing.zip")
+        let destination = tmp.appendingPathComponent("dest.zip")
+        XCTAssertThrowsError(
+            try LiveUpdateFileScheme.copyAndReportProgress(source: source, destination: destination, progress: nil)
+        ) { error in
+            guard case LiveUpdateFileScheme.FileSchemeError.sourceNotFound = error else {
+                XCTFail("expected sourceNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testCopyAndReportProgress_acceptsNilProgress() throws {
+        let source = tmp.appendingPathComponent("bundle.zip")
+        let destination = tmp.appendingPathComponent("dest.zip")
+        try Data("hello".utf8).write(to: source)
+
+        let copied = try LiveUpdateFileScheme.copyAndReportProgress(source: source, destination: destination, progress: nil)
+
+        XCTAssertEqual(copied, 5)
+    }
+}

--- a/packages/live-update/ios/PluginTests/LiveUpdateFileSchemeTests.swift
+++ b/packages/live-update/ios/PluginTests/LiveUpdateFileSchemeTests.swift
@@ -15,54 +15,6 @@ final class LiveUpdateFileSchemeTests: XCTestCase {
         try? FileManager.default.removeItem(at: tmp)
     }
 
-    func testCopyAndReportProgress_copiesBytesIdentically() throws {
-        let source = tmp.appendingPathComponent("bundle.zip")
-        let destination = tmp.appendingPathComponent("dest.zip")
-        let payload = Data((0..<(16 * 1024 + 7)).map { _ in UInt8.random(in: 0...255) })
-        try payload.write(to: source)
-
-        var events: [(Int64, Int64)] = []
-        let copied = try LiveUpdateFileScheme.copyAndReportProgress(
-            source: source,
-            destination: destination,
-            progress: { downloaded, total in events.append((downloaded, total)) }
-        )
-
-        XCTAssertEqual(copied, Int64(payload.count))
-        XCTAssertEqual(try Data(contentsOf: destination), payload)
-        XCTAssertFalse(events.isEmpty)
-        XCTAssertEqual(events.last?.0, Int64(payload.count))
-        XCTAssertEqual(events.last?.1, Int64(payload.count))
-    }
-
-    func testCopyAndReportProgress_throwsWhenSourceMissing() throws {
-        let source = tmp.appendingPathComponent("missing.zip")
-        let destination = tmp.appendingPathComponent("dest.zip")
-        XCTAssertThrowsError(
-            try LiveUpdateFileScheme.copyAndReportProgress(source: source, destination: destination, progress: nil)
-        ) { error in
-            guard case LiveUpdateFileScheme.FileSchemeError.sourceNotFound = error else {
-                XCTFail("expected sourceNotFound, got \(error)")
-                return
-            }
-        }
-    }
-
-    func testCopyAndReportProgress_acceptsNilProgress() throws {
-        let source = tmp.appendingPathComponent("bundle.zip")
-        let destination = tmp.appendingPathComponent("dest.zip")
-        try Data("hello".utf8).write(to: source)
-
-        let copied = try LiveUpdateFileScheme.copyAndReportProgress(source: source, destination: destination, progress: nil)
-
-        XCTAssertEqual(copied, 5)
-    }
-
-    func testCopyAndReportProgress_errorDescriptionDoesNotLeakPath() {
-        let descriptor = LiveUpdateFileScheme.FileSchemeError.sourceNotFound.errorDescription ?? ""
-        XCTAssertFalse(descriptor.contains("/"), "errorDescription must not include a filesystem path")
-    }
-
     func testResolveFileUrl_acceptsPathInsideAllowedPrefix() throws {
         let sandbox = tmp.appendingPathComponent("files")
         try FileManager.default.createDirectory(at: sandbox, withIntermediateDirectories: true)


### PR DESCRIPTION
## Why

Sideloaded content delivery: a managed device (e.g. Android Enterprise via MDM, iOS via offline package install) receives a bundle zip on its filesystem and needs to register it through the existing plugin API without introducing a parallel ingestion path. With `file://` support, the consumer only ever calls `LiveUpdate.downloadBundle({ url, bundleId })` regardless of source — same code path for HTTPS in production and `file://` in offline/sideload scenarios.

## What changed

- **`LiveUpdate.java` / `LiveUpdate.swift`**: scheme guard at the top of `downloadBundleOfTypeZip`. If `url` starts with `file://`, dispatches to a new private `copyFromFileSchemeAndAddBundle` method. The new method copies the source to the existing temporary-zip path, runs the unchanged `verifyFile` + `addBundleOfTypeZip` pipeline, and cleans up on both success and error. The HTTPS branch (OkHttp on Android, Alamofire on iOS) is untouched.
- **`LiveUpdateFileScheme.java`** (Android): new pure-Java static helper for byte-copy with progress callback. No `Context` dependency — JVM unit tests run without Robolectric.
- **`Classes/LiveUpdateFileScheme.swift`** (iOS): same idea in Swift. `enum LiveUpdateFileScheme` with a static `copyAndReportProgress` method. No platform `Context` dependency.

## Tests

### Android — JUnit 4 (3 cases, run via `./gradlew test`)

| Test | Asserts |
|------|---------|
| `copyAndReportProgress_copiesBytesIdentically` | bytes copied identically (16 KiB + 7 random); final progress event reports `copied == total == source.length` |
| `copyAndReportProgress_throwsWhenSourceMissing` | `FileNotFoundException` when source absent |
| `copyAndReportProgress_acceptsNullListener` | no NPE with `null` progress callback |

\`./gradlew clean build test\` → all 3 pass on my machine. Output: \`tests=\"3\" skipped=\"0\" failures=\"0\" errors=\"0\"\`.

### iOS — XCTest (3 cases, mirror of Android)

| Test | Asserts |
|------|---------|
| `testCopyAndReportProgress_copiesBytesIdentically` | same as Android |
| `testCopyAndReportProgress_throwsWhenSourceMissing` | throws `FileSchemeError.sourceNotFound` |
| `testCopyAndReportProgress_acceptsNilProgress` | no crash with `nil` progress callback |

`xcodebuild -workspace Plugin.xcworkspace -scheme Plugin build` → succeeds with the new helper.

⚠️ A note on running `xcodebuild test`: the existing `PluginTests/LiveUpdateTests.swift::testEcho` doesn't compile on `main` — `LiveUpdate()` requires `config:` and `plugin:` arguments since the public `init` signature changed at some point. That's pre-existing and out of scope here, but it does block running the full test target. The new `LiveUpdateFileSchemeTests.swift` compiles cleanly when isolated. Happy to fix the `testEcho` regression in a follow-up if useful.

## API design

No public TS API change. `downloadBundle({ url, bundleId })` already accepts a free-form string; this just adds a recognised scheme that's dispatched at the top of the platform implementation. If you'd prefer an explicit method (e.g. `addBundleFromFile`) instead of the scheme-overload, happy to refactor — both platforms + tests would be a small follow-up.