### PR TITLE
fix(android-edge-to-edge-support): correct WebView margin calculation…

### DIFF
--- a/.changeset/tidy-hotels-give.md
+++ b/.changeset/tidy-hotels-give.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-android-edge-to-edge-support': major
+---
+
+Fix WebView not resizing when the soft keyboard opens on Android 16 in edge-to-edge mode, and WebView collapsing to ~6% on Android 10 (API29). Closes #845, #847.

--- a/.changeset/tidy-hotels-give.md
+++ b/.changeset/tidy-hotels-give.md
@@ -1,5 +1,5 @@
 ---
-'@capawesome/capacitor-android-edge-to-edge-support': major
+'@capawesome/capacitor-android-edge-to-edge-support': patch
 ---
 
-Fix WebView not resizing when the soft keyboard opens on Android 16 in edge-to-edge mode, and WebView collapsing to ~6% on Android 10 (API29). Closes #845, #847.
+fix(android): WebView covered by keyboard

--- a/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
+++ b/packages/android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java
@@ -1,6 +1,7 @@
 package io.capawesome.capacitorjs.plugins.androidedgetoedgesupport;
 
 import android.graphics.Color;
+import android.os.Build;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -91,10 +92,13 @@ public class EdgeToEdge {
     private void applyInsetsInternal(View view, WindowInsetsCompat currentInsets) {
         Insets systemBarsInsets = currentInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
         Insets imeInsets = currentInsets.getInsets(WindowInsetsCompat.Type.ime());
-        boolean keyboardVisible = currentInsets.isVisible(WindowInsetsCompat.Type.ime());
-        // When keyboard is visible, don't apply bottom margin to avoid double-counting
-        // (the system already resizes the window for the keyboard)
-        int bottomMargin = keyboardVisible ? 0 : Math.max(imeInsets.bottom, systemBarsInsets.bottom);
+
+        int bottomMargin;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            bottomMargin = systemBarsInsets.bottom;
+        } else {
+            bottomMargin = Math.max(imeInsets.bottom, systemBarsInsets.bottom);
+        }
 
         ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) view.getLayoutParams();
         mlp.bottomMargin = bottomMargin;


### PR DESCRIPTION
On API 29, the WindowInsetsCompat.Type.ime() backport is unreliable and
The system handles the IME via adjustResize, so the plugin must not add
imeInsets.bottom — doing so collapses the WebView (#845).

On API 30+, the system does not resize the window for the IME (especially
in edge-to-edge mode, which is enforced on API 35+), so the plugin must
honor imeInsets.bottom or the keyboard covers the WebView content
(reproduced on Samsung Galaxy Z Flip4 / One UI 8 / Android 16).

The previous \`keyboardVisible ? 0 : Math.max(...)\` ternary was wrong on
both branches: on API 29 it took the else branch (because isVisible(ime())
returns false on that API, even when the IME is up, and double-counted; on
API 35+, it took the if branch and zeroed the margin while the system
expected the app to honor it.

Closes #845, #847."
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

