### PR TITLE
feat(badge): add Android notification permission handling

### DIFF
--- a/.changeset/bright-badges-permit.md
+++ b/.changeset/bright-badges-permit.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-badge': patch
+---
+
+feat(android): request notification permission for badge display on Android 13+

--- a/packages/badge/README.md
+++ b/packages/badge/README.md
@@ -355,6 +355,8 @@ Request permission to display badge.
 
 On **Android** not all launchers support badges. This plugin uses [ShortcutBadger](https://github.com/leolin310148/ShortcutBadger). All supported launchers are listed [there](https://github.com/leolin310148/ShortcutBadger#supported-launchers).
 
+On **Android 13+**, call `requestPermissions()` before setting the badge count if your app targets Android's notification runtime permission.
+
 On **Web**, the app must run as an installed PWA (in the taskbar or dock).
 
 ## Changelog

--- a/packages/badge/android/src/main/AndroidManifest.xml
+++ b/packages/badge/android/src/main/AndroidManifest.xml
@@ -1,2 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 </manifest>

--- a/packages/badge/android/src/main/java/io/capawesome/capacitorjs/plugins/badge/BadgePlugin.java
+++ b/packages/badge/android/src/main/java/io/capawesome/capacitorjs/plugins/badge/BadgePlugin.java
@@ -1,15 +1,23 @@
 package io.capawesome.capacitorjs.plugins.badge;
 
+import android.Manifest;
+import android.os.Build;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Logger;
+import com.getcapacitor.PermissionState;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
 
-@CapacitorPlugin(name = "Badge", permissions = @Permission(strings = {}, alias = "display"))
+@CapacitorPlugin(
+    name = "Badge",
+    permissions = @Permission(strings = { Manifest.permission.POST_NOTIFICATIONS }, alias = BadgePlugin.DISPLAY)
+)
 public class BadgePlugin extends Plugin {
+
+    public static final String DISPLAY = "display";
 
     private Badge implementation;
 
@@ -87,6 +95,32 @@ public class BadgePlugin extends Plugin {
             call.resolve(ret);
         } catch (Exception ex) {
             call.reject(ex.getLocalizedMessage());
+        }
+    }
+
+    @Override
+    @PluginMethod
+    public void checkPermissions(PluginCall call) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            JSObject result = new JSObject();
+            result.put(DISPLAY, "granted");
+            call.resolve(result);
+        } else {
+            super.checkPermissions(call);
+        }
+    }
+
+    @Override
+    @PluginMethod
+    public void requestPermissions(PluginCall call) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            JSObject result = new JSObject();
+            result.put(DISPLAY, "granted");
+            call.resolve(result);
+        } else if (getPermissionState(DISPLAY) == PermissionState.GRANTED) {
+            checkPermissions(call);
+        } else {
+            requestPermissionForAlias(DISPLAY, call, "permissionsCallback");
         }
     }
 


### PR DESCRIPTION
## Summary

- Add Android `POST_NOTIFICATIONS` permission to the Badge plugin's `display` permission alias.
- Implement Android `checkPermissions()` and `requestPermissions()` handling for Android 13+ while returning `granted` on earlier Android versions.
- Document that Android 13+ apps should request badge display permission before setting the badge count.
- Add a patch changeset for `@capawesome/capacitor-badge`.

Closes #3.

## Verification

- `git diff --check`
- `npx prettier --check packages/badge/android/src/main/java/io/capawesome/capacitorjs/plugins/badge/BadgePlugin.java packages/badge/README.md .changeset/bright-badges-permit.md`
- `npm run build` in `packages/badge`
- `npm run eslint` in `packages/badge`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH="/opt/homebrew/opt/openjdk@21/bin:$PATH" ANDROID_HOME=/opt/homebrew/share/android-commandlinetools ANDROID_SDK_ROOT=/opt/homebrew/share/android-commandlinetools ./gradlew clean build test` in `packages/badge/android`
  - Result: `BUILD SUCCESSFUL in 2m 49s`, `150 actionable tasks: 150 executed`.
