### PR TITLE
fix(badge): add Android notification permission handling

### DIFF
--- a/.changeset/quiet-badges-ask.md
+++ b/.changeset/quiet-badges-ask.md
@@ -1,0 +1,5 @@
+---
+"@capawesome/capacitor-badge": patch
+---
+
+Add Android notification permission handling for badge display.

--- a/packages/badge/android/src/main/AndroidManifest.xml
+++ b/packages/badge/android/src/main/AndroidManifest.xml
@@ -1,2 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 </manifest>

--- a/packages/badge/android/src/main/java/io/capawesome/capacitorjs/plugins/badge/BadgePlugin.java
+++ b/packages/badge/android/src/main/java/io/capawesome/capacitorjs/plugins/badge/BadgePlugin.java
@@ -1,15 +1,24 @@
 package io.capawesome.capacitorjs.plugins.badge;
 
+import android.Manifest;
+import android.os.Build;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Logger;
+import com.getcapacitor.PermissionState;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
+import com.getcapacitor.annotation.PermissionCallback;
 
-@CapacitorPlugin(name = "Badge", permissions = @Permission(strings = {}, alias = "display"))
+@CapacitorPlugin(
+    name = "Badge",
+    permissions = @Permission(strings = { Manifest.permission.POST_NOTIFICATIONS }, alias = BadgePlugin.PERMISSION_DISPLAY)
+)
 public class BadgePlugin extends Plugin {
+
+    public static final String PERMISSION_DISPLAY = "display";
 
     private Badge implementation;
 
@@ -90,6 +99,32 @@ public class BadgePlugin extends Plugin {
         }
     }
 
+    @Override
+    @PluginMethod
+    public void checkPermissions(PluginCall call) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            JSObject result = new JSObject();
+            result.put(PERMISSION_DISPLAY, "granted");
+            call.resolve(result);
+        } else {
+            super.checkPermissions(call);
+        }
+    }
+
+    @Override
+    @PluginMethod
+    public void requestPermissions(PluginCall call) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            JSObject result = new JSObject();
+            result.put(PERMISSION_DISPLAY, "granted");
+            call.resolve(result);
+        } else if (getPermissionState(PERMISSION_DISPLAY) == PermissionState.GRANTED) {
+            checkPermissions(call);
+        } else {
+            requestPermissionForAlias(PERMISSION_DISPLAY, call, "permissionsCallback");
+        }
+    }
+
     private BadgeConfig getBadgeConfig() {
         BadgeConfig config = new BadgeConfig();
 
@@ -99,5 +134,10 @@ public class BadgePlugin extends Plugin {
         config.setAutoClear(autoClear);
 
         return config;
+    }
+
+    @PermissionCallback
+    private void permissionsCallback(PluginCall call) {
+        checkPermissions(call);
     }
 }


### PR DESCRIPTION
## Summary
- add Android `POST_NOTIFICATIONS` permission metadata for the Badge plugin
- implement Android `checkPermissions()` / `requestPermissions()` for the existing `display` permission API
- return `granted` on Android versions below 13 where runtime notification permission does not apply
- add a patch changeset

Fixes #3

## Verification
- `npm --workspace @capawesome/capacitor-badge run prettier -- --check`
- `npm --workspace @capawesome/capacitor-badge run build`
- `JAVA_HOME=/home/admin/codexGoalMoney/jdks/jdk-21.0.11+10 ANDROID_HOME=/home/admin/codexGoalMoney/android-sdk npm --workspace @capawesome/capacitor-badge run verify:android`

## Note
I validated compile/build/test/lint locally. I do not have a physical Android launcher/device attached in this environment, so I could not verify the visual launcher badge behavior directly.