### PR TITLE
fix(badge): add Android notification permission

### DIFF
--- a/.changeset/quiet-badges-ask.md
+++ b/.changeset/quiet-badges-ask.md
@@ -1,0 +1,5 @@
+---
+"@capawesome/capacitor-badge": patch
+---
+
+Add Android notification permission support to badge permission methods.

--- a/packages/badge/README.md
+++ b/packages/badge/README.md
@@ -293,6 +293,8 @@ checkPermissions() => Promise<PermissionStatus>
 
 Check permission to display badge.
 
+On Android 13+, this checks the notification permission.
+
 **Returns:** <code>Promise&lt;<a href="#permissionstatus">PermissionStatus</a>&gt;</code>
 
 --------------------
@@ -305,6 +307,8 @@ requestPermissions() => Promise<PermissionStatus>
 ```
 
 Request permission to display badge.
+
+On Android 13+, this requests the notification permission.
 
 **Returns:** <code>Promise&lt;<a href="#permissionstatus">PermissionStatus</a>&gt;</code>
 

--- a/packages/badge/android/src/main/AndroidManifest.xml
+++ b/packages/badge/android/src/main/AndroidManifest.xml
@@ -1,2 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 </manifest>

--- a/packages/badge/android/src/main/java/io/capawesome/capacitorjs/plugins/badge/BadgePlugin.java
+++ b/packages/badge/android/src/main/java/io/capawesome/capacitorjs/plugins/badge/BadgePlugin.java
@@ -1,15 +1,23 @@
 package io.capawesome.capacitorjs.plugins.badge;
 
+import android.Manifest;
+import android.os.Build;
 import com.getcapacitor.JSObject;
-import com.getcapacitor.Logger;
+import com.getcapacitor.PermissionState;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
+import com.getcapacitor.annotation.PermissionCallback;
 
-@CapacitorPlugin(name = "Badge", permissions = @Permission(strings = {}, alias = "display"))
+@CapacitorPlugin(
+    name = "Badge",
+    permissions = @Permission(strings = { Manifest.permission.POST_NOTIFICATIONS }, alias = BadgePlugin.PERMISSION_DISPLAY)
+)
 public class BadgePlugin extends Plugin {
+
+    public static final String PERMISSION_DISPLAY = "display";
 
     private Badge implementation;
 
@@ -90,6 +98,33 @@ public class BadgePlugin extends Plugin {
         }
     }
 
+    @Override
+    @PluginMethod
+    public void checkPermissions(PluginCall call) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            call.resolve(createPermissionsResult("granted"));
+        } else {
+            super.checkPermissions(call);
+        }
+    }
+
+    @Override
+    @PluginMethod
+    public void requestPermissions(PluginCall call) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            call.resolve(createPermissionsResult("granted"));
+        } else if (getPermissionState(PERMISSION_DISPLAY) == PermissionState.GRANTED) {
+            this.checkPermissions(call);
+        } else {
+            requestPermissionForAlias(PERMISSION_DISPLAY, call, "permissionsCallback");
+        }
+    }
+
+    @PermissionCallback
+    private void permissionsCallback(PluginCall call) {
+        this.checkPermissions(call);
+    }
+
     private BadgeConfig getBadgeConfig() {
         BadgeConfig config = new BadgeConfig();
 
@@ -99,5 +134,11 @@ public class BadgePlugin extends Plugin {
         config.setAutoClear(autoClear);
 
         return config;
+    }
+
+    private JSObject createPermissionsResult(String display) {
+        JSObject result = new JSObject();
+        result.put(PERMISSION_DISPLAY, display);
+        return result;
     }
 }

--- a/packages/badge/src/definitions.ts
+++ b/packages/badge/src/definitions.ts
@@ -64,10 +64,14 @@ export interface BadgePlugin {
   isSupported(): Promise<IsSupportedResult>;
   /**
    * Check permission to display badge.
+   *
+   * On Android 13+, this checks the notification permission.
    */
   checkPermissions(): Promise<PermissionStatus>;
   /**
    * Request permission to display badge.
+   *
+   * On Android 13+, this requests the notification permission.
    */
   requestPermissions(): Promise<PermissionStatus>;
 }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

## Summary

- Add Android `POST_NOTIFICATIONS` to the Badge plugin `display` permission alias.
- Implement Android `checkPermissions()` / `requestPermissions()` with Android 13+ runtime permission handling and pre-Android 13 `granted` responses.
- Add the permission callback used by `requestPermissionForAlias(...)` so the request resolves through the normal Capacitor permission flow.
- Update generated badge docs and add a patch changeset.

Closes #3.

## Verification

- `git diff --check HEAD~1 HEAD`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=/Users/arslan/Library/Android/sdk ANDROID_SDK_ROOT=/Users/arslan/Library/Android/sdk npm --workspace @capawesome/capacitor-badge run verify:android`
- `npm --workspace @capawesome/capacitor-badge run verify:web`
- `npm --workspace @capawesome/capacitor-badge run lint` (completed with the existing local SwiftLint-not-installed warning; no Swift files changed)