### PR TITLE
fix(live-update): prevent crash during bundle cleanup when a directory is unreadable

### DIFF
--- a/.changeset/cleanup-null-children-guard.md
+++ b/.changeset/cleanup-null-children-guard.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-live-update': patch
+---
+
+fix(android): prevent crash during bundle cleanup when a directory is unreadable

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
@@ -667,8 +667,11 @@ public class LiveUpdate {
 
     private void deleteFileRecursively(@NonNull File file) {
         if (file.isDirectory()) {
-            for (File child : file.listFiles()) {
-                deleteFileRecursively(child);
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteFileRecursively(child);
+                }
             }
         }
         file.delete();


### PR DESCRIPTION
## Summary
- Guard `deleteFileRecursively` against `File.listFiles()` returning `null`, which happens when an extracted directory lacks the execute permission bit.
- Without this guard, bundle cleanup in `ready()` would throw `NullPointerException` and crash the app — most relevant for bundles previously extracted by versions before v8.2.1, which could be left on disk with restrictive Unix permissions inherited from the zip.

## Test plan
- [ ] Manually verify cleanup completes without crashing on a device that has an old broken bundle on disk and a freshly downloaded v8.2.1 bundle as the current one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)