### PR TITLE
fix(badge): create Android badge notification channel

### DIFF
--- a/.changeset/thin-badges-serve.md
+++ b/.changeset/thin-badges-serve.md
@@ -1,0 +1,5 @@
+---
+"@capawesome/capacitor-badge": patch
+---
+
+fix(android): create a badge-enabled notification channel before applying counts

--- a/packages/badge/android/src/main/java/io/capawesome/capacitorjs/plugins/badge/Badge.java
+++ b/packages/badge/android/src/main/java/io/capawesome/capacitorjs/plugins/badge/Badge.java
@@ -2,23 +2,29 @@ package io.capawesome.capacitorjs.plugins.badge;
 
 import static me.leolin.shortcutbadger.ShortcutBadger.isBadgeCounterSupported;
 
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 import com.getcapacitor.Logger;
 import me.leolin.shortcutbadger.ShortcutBadger;
 
 public class Badge {
 
+    private static final String TAG = "Badge";
+    private static final String DEFAULT_NOTIFICATION_CHANNEL_ID = "capacitor_badge";
+    private static final String DEFAULT_NOTIFICATION_CHANNEL_NAME = "Badge";
     private static final String STORAGE_KEY = "capacitor.badge";
     private Context context;
     private BadgeConfig config;
 
     Badge(Context context, BadgeConfig config) {
         this.config = config;
+        this.context = context.getApplicationContext();
+        createNotificationChannel();
         if (isBadgeCounterSupported(context)) {
             this.context = context;
-        } else {
-            this.context = context.getApplicationContext();
         }
         boolean restoreCount = this.config.getPersist();
         if (restoreCount) {
@@ -45,7 +51,7 @@ public class Badge {
         SharedPreferences.Editor editor = getPrefs().edit();
         editor.putInt(STORAGE_KEY, count);
         editor.apply();
-        ShortcutBadger.applyCount(context, count);
+        applyCount(count);
     }
 
     public void increase() {
@@ -78,10 +84,38 @@ public class Badge {
     private void restore() {
         try {
             int count = get();
-            ShortcutBadger.applyCount(context, count);
+            applyCount(count);
         } catch (Exception ex) {
             Logger.error(ex.getLocalizedMessage(), ex);
         }
+    }
+
+    private void applyCount(int count) {
+        createNotificationChannel();
+        boolean success = ShortcutBadger.applyCount(context, count);
+        if (!success) {
+            Logger.warn(TAG, "Unable to apply badge count.");
+        }
+    }
+
+    private void createNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return;
+        }
+        NotificationManager notificationManager = context.getSystemService(NotificationManager.class);
+        if (
+            notificationManager == null ||
+            notificationManager.getNotificationChannel(DEFAULT_NOTIFICATION_CHANNEL_ID) != null
+        ) {
+            return;
+        }
+        NotificationChannel notificationChannel = new NotificationChannel(
+            DEFAULT_NOTIFICATION_CHANNEL_ID,
+            DEFAULT_NOTIFICATION_CHANNEL_NAME,
+            NotificationManager.IMPORTANCE_DEFAULT
+        );
+        notificationChannel.setShowBadge(true);
+        notificationManager.createNotificationChannel(notificationChannel);
     }
 
     private SharedPreferences getPrefs() {


### PR DESCRIPTION
## Pull request checklist

- [ ] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

## What changed

- Create a badge-enabled notification channel on Android 8+ before ShortcutBadger runs its support check or applies a count.
- Reuse the same apply path for `set` and persisted-count restore so `Badge.set({ count })` can prepare badge support before any app notification is posted.

Closes #3.

## Testing

- `git diff --check`
- `JAVA_HOME=/Applications/StataNow/utilities/java/macos-arm64/zulu-jdk21.0.7/zulu-21.jdk/Contents/Home ./gradlew test` (blocked by TLS handshake failures while resolving Gradle dependencies from `dl.google.com` and Maven Central in this environment)