### PR TITLE
chore(tooling): add pre-commit prettier hook and consolidate prettier devDependency

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx --no-install lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,11 @@
         "@changesets/cli": "2.29.8",
         "@ionic/swiftlint-config": "2.0.0",
         "@robingenz/changelog-github": "0.0.1",
+        "husky": "9.1.7",
+        "lint-staged": "17.0.5",
         "patch-package": "8.0.1",
         "pkg-pr-new": "0.0.20",
+        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "turbo": "2.6.3"
       }
@@ -2036,6 +2039,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2507,6 +2526,131 @@
         "node": ">=8"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2875,6 +3019,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/error-ex": {
@@ -3466,6 +3623,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3814,6 +3978,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -4170,6 +4347,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -4955,6 +5148,138 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lint-staged": {
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.5.tgz",
+      "integrity": "sha512-d12yC+/e8RhBjZtaxZn71FyrgU/P5e+uAPifhCLwdosQZP/zamSdKRWDC30ocVIbzDKiFG1McHc/LUgB92GIPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "listr2": "^10.2.1",
+        "picomatch": "^4.0.4",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.1.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=22.22.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      },
+      "optionalDependencies": {
+        "yaml": "^2.8.4"
+      }
+    },
+    "node_modules/lint-staged/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
+      "integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.2.0",
+        "eventemitter3": "^5.0.4",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -4995,6 +5320,144 @@
       "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/lru-cache": {
       "version": "11.2.6",
@@ -5055,6 +5518,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -5805,12 +6281,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6086,6 +6561,52 @@
         "node": ">=8"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -6096,6 +6617,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "6.1.2",
@@ -6795,6 +7323,16 @@
         "readable-stream": "3"
       }
     },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -7431,9 +7969,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -7515,7 +8053,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -7524,20 +8061,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/age-signals/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/android-battery-optimization": {
@@ -7561,7 +8084,6 @@
         "@capacitor/docgen": "0.3.1",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -7569,20 +8091,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/android-battery-optimization/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/android-dark-mode-support": {
@@ -7602,25 +8110,10 @@
       "devDependencies": {
         "@capacitor/android": "8.0.0",
         "@capacitor/cli": "8.0.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7"
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/android-dark-mode-support/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/android-edge-to-edge-support": {
@@ -7642,7 +8135,6 @@
         "@capacitor/cli": "8.0.0",
         "@capacitor/core": "8.0.0",
         "@capacitor/docgen": "0.3.1",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -7650,20 +8142,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/android-edge-to-edge-support/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/android-foreground-service": {
@@ -7687,7 +8165,6 @@
         "@capacitor/docgen": "0.3.1",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -7695,20 +8172,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/android-foreground-service/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/app-review": {
@@ -7733,7 +8196,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -7742,20 +8204,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/app-review/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/app-shortcuts": {
@@ -7780,7 +8228,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -7789,20 +8236,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/app-shortcuts/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/app-update": {
@@ -7827,7 +8260,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -7836,20 +8268,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/app-update/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/apple-sign-in": {
@@ -7875,7 +8293,6 @@
         "@ionic/eslint-config": "0.4.0",
         "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -7884,20 +8301,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/apple-sign-in/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/asset-manager": {
@@ -7922,7 +8325,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -7931,20 +8333,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/asset-manager/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/background-task": {
@@ -7969,7 +8357,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -7978,20 +8365,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/background-task/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/badge": {
@@ -8016,7 +8389,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -8025,20 +8397,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/badge/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/cloudinary": {
@@ -8063,7 +8421,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -8072,20 +8429,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/cloudinary/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/datetime-picker": {
@@ -8110,7 +8453,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -8119,20 +8461,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/datetime-picker/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/file-opener": {
@@ -8157,7 +8485,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -8166,20 +8493,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/file-opener/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/file-picker": {
@@ -8204,7 +8517,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -8213,20 +8525,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/file-picker/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/formbricks": {
@@ -8253,7 +8551,6 @@
         "@ionic/eslint-config": "0.4.0",
         "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -8268,22 +8565,6 @@
         "@formbricks/js": {
           "optional": true
         }
-      }
-    },
-    "packages/formbricks/node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/google-sign-in": {
@@ -8308,7 +8589,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -8317,20 +8597,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/google-sign-in/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/libsql": {
@@ -8355,7 +8621,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -8366,23 +8631,9 @@
         "@capacitor/core": ">=8.0.0"
       }
     },
-    "packages/libsql/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "packages/live-update": {
       "name": "@capawesome/capacitor-live-update",
-      "version": "8.2.2",
+      "version": "8.2.3",
       "funding": [
         {
           "type": "github",
@@ -8402,7 +8653,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -8411,20 +8661,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/live-update/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/managed-configurations": {
@@ -8449,7 +8685,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -8458,20 +8693,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/managed-configurations/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/photo-editor": {
@@ -8496,7 +8717,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -8505,20 +8725,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/photo-editor/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/pixlive": {
@@ -8544,7 +8750,6 @@
         "@ionic/eslint-config": "0.4.0",
         "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -8553,22 +8758,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/pixlive/node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/posthog": {
@@ -8594,7 +8783,6 @@
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
         "posthog-js": "1.160.3",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -8609,20 +8797,6 @@
         "posthog-js": {
           "optional": true
         }
-      }
-    },
-    "packages/posthog/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/realtimekit": {
@@ -8647,7 +8821,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -8656,20 +8829,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/realtimekit/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/screen-orientation": {
@@ -8694,7 +8853,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -8703,20 +8861,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/screen-orientation/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/screenshot": {
@@ -8742,7 +8886,6 @@
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
         "html2canvas": "1.4.1",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -8752,20 +8895,6 @@
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0",
         "html2canvas": "^1.4.1"
-      }
-    },
-    "packages/screenshot/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/square-mobile-payments": {
@@ -8790,7 +8919,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -8799,20 +8927,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/square-mobile-payments/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/superwall": {
@@ -8837,7 +8951,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -8846,20 +8959,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/superwall/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/torch": {
@@ -8884,7 +8983,6 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "prettier": "3.4.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",
@@ -8893,20 +8991,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "packages/torch/node_modules/prettier": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,15 +35,22 @@
     "changeset": "changeset",
     "release": "npm run build && changeset publish",
     "release:preview": "pkg-pr-new publish './packages/*'",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@changesets/cli": "2.29.8",
     "@ionic/swiftlint-config": "2.0.0",
     "@robingenz/changelog-github": "0.0.1",
+    "husky": "9.1.7",
+    "lint-staged": "17.0.5",
     "patch-package": "8.0.1",
     "pkg-pr-new": "0.0.20",
+    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "turbo": "2.6.3"
+  },
+  "lint-staged": {
+    "**/*.{css,html,ts,js,java}": "prettier --write"
   }
 }

--- a/packages/age-signals/package.json
+++ b/packages/age-signals/package.json
@@ -65,7 +65,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/android-battery-optimization/package.json
+++ b/packages/android-battery-optimization/package.json
@@ -60,7 +60,6 @@
     "@capacitor/docgen": "0.3.1",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/android-dark-mode-support/package.json
+++ b/packages/android-dark-mode-support/package.json
@@ -41,7 +41,6 @@
   "devDependencies": {
     "@capacitor/android": "8.0.0",
     "@capacitor/cli": "8.0.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7"
   },
   "peerDependencies": {

--- a/packages/android-edge-to-edge-support/package.json
+++ b/packages/android-edge-to-edge-support/package.json
@@ -55,7 +55,6 @@
     "@capacitor/cli": "8.0.0",
     "@capacitor/core": "8.0.0",
     "@capacitor/docgen": "0.3.1",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/android-foreground-service/package.json
+++ b/packages/android-foreground-service/package.json
@@ -60,7 +60,6 @@
     "@capacitor/docgen": "0.3.1",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/app-review/package.json
+++ b/packages/app-review/package.json
@@ -69,7 +69,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/app-shortcuts/package.json
+++ b/packages/app-shortcuts/package.json
@@ -69,7 +69,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/app-update/package.json
+++ b/packages/app-update/package.json
@@ -68,7 +68,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/apple-sign-in/package.json
+++ b/packages/apple-sign-in/package.json
@@ -65,7 +65,6 @@
     "@ionic/eslint-config": "0.4.0",
     "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/asset-manager/package.json
+++ b/packages/asset-manager/package.json
@@ -65,7 +65,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/background-task/package.json
+++ b/packages/background-task/package.json
@@ -65,7 +65,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -70,7 +70,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/cloudinary/package.json
+++ b/packages/cloudinary/package.json
@@ -72,7 +72,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/datetime-picker/package.json
+++ b/packages/datetime-picker/package.json
@@ -69,7 +69,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/file-opener/package.json
+++ b/packages/file-opener/package.json
@@ -70,7 +70,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/file-picker/package.json
+++ b/packages/file-picker/package.json
@@ -70,7 +70,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/formbricks/package.json
+++ b/packages/formbricks/package.json
@@ -68,7 +68,6 @@
     "@ionic/eslint-config": "0.4.0",
     "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/google-sign-in/package.json
+++ b/packages/google-sign-in/package.json
@@ -64,7 +64,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/libsql/package.json
+++ b/packages/libsql/package.json
@@ -63,7 +63,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/live-update/package.json
+++ b/packages/live-update/package.json
@@ -74,7 +74,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/managed-configurations/package.json
+++ b/packages/managed-configurations/package.json
@@ -69,7 +69,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/photo-editor/package.json
+++ b/packages/photo-editor/package.json
@@ -69,7 +69,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/pixlive/package.json
+++ b/packages/pixlive/package.json
@@ -65,7 +65,6 @@
     "@ionic/eslint-config": "0.4.0",
     "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/posthog/package.json
+++ b/packages/posthog/package.json
@@ -67,7 +67,6 @@
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
     "posthog-js": "1.160.3",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/realtimekit/package.json
+++ b/packages/realtimekit/package.json
@@ -65,7 +65,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/screen-orientation/package.json
+++ b/packages/screen-orientation/package.json
@@ -70,7 +70,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/screenshot/package.json
+++ b/packages/screenshot/package.json
@@ -70,7 +70,6 @@
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
     "html2canvas": "1.4.1",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/square-mobile-payments/package.json
+++ b/packages/square-mobile-payments/package.json
@@ -64,7 +64,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/superwall/package.json
+++ b/packages/superwall/package.json
@@ -65,7 +65,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/torch/package.json
+++ b/packages/torch/package.json
@@ -65,7 +65,6 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "prettier": "3.4.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",


### PR DESCRIPTION
## Summary

- Add \`husky\` + \`lint-staged\` so staged \`**/*.{css,html,ts,js,java}\` files are auto-formatted with the workspace-pinned prettier on every commit. Makes it physically impossible to push prettier-dirty code without \`--no-verify\`.
- Move \`prettier@3.4.2\` from every \`packages/*/package.json\` into the root \`package.json\` devDependencies (single source of truth). Per-package \`npm run prettier\` scripts continue to work via npm workspace hoisting.
- Add \`"prepare": "husky"\` so \`npm install\` wires up the hook automatically.

\`prettier-plugin-java\` duplication is left alone (already consistent — hoisted at root and listed in each package).

Ports the tooling changes from capawesome-team/capacitor-firebase#995 to this repo. The Node version bump from that PR is omitted because CI here is already on Node 24.

## Test plan

- [x] \`npm install\` runs cleanly and triggers \`prepare\` → husky wires up \`core.hooksPath=.husky/_\`
- [x] Per-package prettier still resolves via workspace hoisting (verified \`npx prettier --version\` → 3.4.2 from \`packages/age-signals\`)
- [x] Commit with no matching staged files short-circuits cleanly (\`lint-staged could not find any staged files matching configured tasks\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)