### PR TITLE
feat(datetime-picker): add month-year picker mode

### DIFF
--- a/.changeset/add-month-year-mode.md
+++ b/.changeset/add-month-year-mode.md
@@ -1,0 +1,5 @@
+---
+'@capawesome-team/capacitor-datetime-picker': minor
+---
+
+feat(datetime-picker): add month-year picker mode

--- a/packages/datetime-picker/README.md
+++ b/packages/datetime-picker/README.md
@@ -90,6 +90,19 @@ const present = async () => {
 
   return value;
 };
+
+const presentMonthYear = async () => {
+  const { value } = await DatetimePicker.present({
+    cancelButtonText: 'Cancel',
+    doneButtonText: 'Ok',
+    mode: 'month-year',
+    value: '2026-05',
+    format: 'yyyy-MM',
+    locale: 'en-US',
+  });
+
+  return value;
+};
 ```
 
 ## API
@@ -165,7 +178,7 @@ Only available on Android and iOS.
 | **`locale`**                | <code>string</code>                         | BCP 47 language tag to define the language of the UI.                                                                                                                                                                                                                  |                                             | 0.0.2 |
 | **`max`**                   | <code>string</code>                         | The latest date and time to accept. The format of this value must match the value of the `format` parameter. This value must specify a date string later than or equal to the one specified by the `min` attribute.                                                    |                                             | 0.0.1 |
 | **`min`**                   | <code>string</code>                         | The earliest date and time to accept. The format of this value must match the value of the `format` parameter. This value must specify a date string earlier than or equal to the one specified by the `max` attribute.                                                |                                             | 0.0.1 |
-| **`mode`**                  | <code>'date' \| 'time' \| 'datetime'</code> | Whether you want a date or time or datetime picker.                                                                                                                                                                                                                    | <code>'datetime'</code>                     | 0.0.1 |
+| **`mode`**                  | <code>'date' \| 'time' \| 'datetime' \| 'month-year'</code> | Whether you want a date, time, datetime, or month-year picker.                                                                                                                                                                                                         | <code>'datetime'</code>                     | 0.0.1 |
 | **`theme`**                 | <code>'auto' \| 'light' \| 'dark'</code>    | Choose the theme that the datetime picker should have. With `auto` the system theme is used. This value overwrites the `theme` configuration value. Only available on Android and iOS. Spinner options only available on Android                                       |                                             | 0.0.1 |
 | **`value`**                 | <code>string</code>                         | The predefined value when opening the picker. The format of this value must match the value of the `format` parameter.                                                                                                                                                 |                                             | 0.0.1 |
 | **`androidTimePickerMode`** | <code>'clock' \| 'spinner'</code>           | Whether to use the spinner or clock mode for the time picker on Android. This value overwrites the `androidTimePickerMode` configuration value. Only available on Android.                                                                                             |                                             | 5.1.0 |

--- a/packages/datetime-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/datetimepicker/DatetimePicker.java
+++ b/packages/datetime-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/datetimepicker/DatetimePicker.java
@@ -1,14 +1,19 @@
 package io.capawesome.capacitorjs.plugins.datetimepicker;
 
+import android.app.AlertDialog;
 import android.app.DatePickerDialog;
 import android.app.Dialog;
 import android.app.TimePickerDialog;
 import android.content.res.Configuration;
 import android.text.format.DateFormat;
+import android.view.Gravity;
 import android.widget.Button;
 import android.widget.DatePicker;
+import android.widget.LinearLayout;
+import android.widget.NumberPicker;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import java.text.DateFormatSymbols;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
@@ -185,6 +190,124 @@ public class DatetimePicker {
         });
 
         dialog.show();
+    }
+
+    public void presentMonthYearPicker(
+        Date date,
+        @Nullable Date minDate,
+        @Nullable Date maxDate,
+        @Nullable Locale locale,
+        String cancelButtonText,
+        String doneButtonText,
+        @Nullable String theme,
+        final PresentResultCallback resultCallback,
+        @Nullable AndroidDatePickerMode androidDatePickerMode,
+        @Nullable AndroidTimePickerMode androidTimePickerMode
+    ) {
+        if (locale != null) {
+            this.updateLocaleConfiguration(locale);
+        }
+
+        Calendar calendar = this.createCalendarFromDate(date);
+        int currentYear = calendar.get(Calendar.YEAR);
+        int currentMonth = calendar.get(Calendar.MONTH);
+
+        int minYear = currentYear - 100;
+        int minMonthValue = Calendar.JANUARY;
+        if (minDate != null) {
+            Calendar minCal = this.createCalendarFromDate(minDate);
+            minYear = minCal.get(Calendar.YEAR);
+            minMonthValue = minCal.get(Calendar.MONTH);
+        }
+
+        int maxYear = currentYear + 100;
+        int maxMonthValue = Calendar.DECEMBER;
+        if (maxDate != null) {
+            Calendar maxCal = this.createCalendarFromDate(maxDate);
+            maxYear = maxCal.get(Calendar.YEAR);
+            maxMonthValue = maxCal.get(Calendar.MONTH);
+        }
+
+        Locale displayLocale = locale != null ? locale : Locale.getDefault();
+        String[] monthNames = new DateFormatSymbols(displayLocale).getMonths();
+
+        LinearLayout layout = new LinearLayout(plugin.getContext());
+        layout.setOrientation(LinearLayout.HORIZONTAL);
+        layout.setGravity(Gravity.CENTER);
+        int padding = (int) (24 * plugin.getContext().getResources().getDisplayMetrics().density);
+        layout.setPadding(padding, padding, padding, padding);
+
+        NumberPicker monthPicker = new NumberPicker(plugin.getContext());
+        NumberPicker yearPicker = new NumberPicker(plugin.getContext());
+
+        final int fMinYear = minYear;
+        final int fMaxYear = maxYear;
+        final int fMinMonth = minMonthValue;
+        final int fMaxMonth = maxMonthValue;
+
+        yearPicker.setMinValue(minYear);
+        yearPicker.setMaxValue(maxYear);
+        yearPicker.setValue(currentYear);
+        yearPicker.setWrapSelectorWheel(false);
+        yearPicker.setDescendantFocusability(NumberPicker.FOCUS_BLOCK_DESCENDANTS);
+
+        updateMonthPicker(monthPicker, currentYear, fMinYear, fMaxYear, fMinMonth, fMaxMonth, monthNames);
+        monthPicker.setValue(currentMonth);
+        monthPicker.setWrapSelectorWheel(false);
+        monthPicker.setDescendantFocusability(NumberPicker.FOCUS_BLOCK_DESCENDANTS);
+
+        yearPicker.setOnValueChangedListener((picker, oldVal, newVal) -> {
+            int previousMonth = monthPicker.getValue();
+            updateMonthPicker(monthPicker, newVal, fMinYear, fMaxYear, fMinMonth, fMaxMonth, monthNames);
+            int newMin = monthPicker.getMinValue();
+            int newMax = monthPicker.getMaxValue();
+            int clampedMonth = Math.min(Math.max(previousMonth, newMin), newMax);
+            monthPicker.setValue(clampedMonth);
+        });
+
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f);
+        layout.addView(monthPicker, params);
+        layout.addView(yearPicker, params);
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(
+            plugin.getContext(),
+            getTheme(theme, null, null)
+        );
+        builder.setView(layout);
+        builder.setPositiveButton(doneButtonText, (dialog, which) -> {
+            calendar.set(Calendar.YEAR, yearPicker.getValue());
+            calendar.set(Calendar.MONTH, monthPicker.getValue());
+            calendar.set(Calendar.DAY_OF_MONTH, 1);
+            resultCallback.success(calendar.getTime());
+        });
+        builder.setNegativeButton(cancelButtonText, (dialog, which) -> {
+            resultCallback.cancel();
+        });
+
+        AlertDialog dialog = builder.create();
+        dialog.setOnDismissListener(_dialog -> resultCallback.dismiss());
+        dialog.show();
+    }
+
+    private void updateMonthPicker(
+        NumberPicker monthPicker,
+        int year,
+        int minYear,
+        int maxYear,
+        int minMonth,
+        int maxMonth,
+        String[] monthNames
+    ) {
+        int lower = (year == minYear) ? minMonth : Calendar.JANUARY;
+        int upper = (year == maxYear) ? maxMonth : Calendar.DECEMBER;
+        String[] displayed = new String[upper - lower + 1];
+        for (int i = lower; i <= upper; i++) {
+            displayed[i - lower] = monthNames[i];
+        }
+        monthPicker.setDisplayedValues(null);
+        monthPicker.setMinValue(lower);
+        monthPicker.setMaxValue(upper);
+        monthPicker.setDisplayedValues(displayed);
     }
 
     private Calendar createCalendarFromDate(Date date) {

--- a/packages/datetime-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/datetimepicker/DatetimePickerPlugin.java
+++ b/packages/datetime-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/datetimepicker/DatetimePickerPlugin.java
@@ -125,6 +125,19 @@ public class DatetimePickerPlugin extends Plugin {
                     androidDatePickerMode,
                     androidTimePickerMode
                 );
+            } else if (mode.equals("month-year")) {
+                implementation.presentMonthYearPicker(
+                    date,
+                    minDate,
+                    maxDate,
+                    locale,
+                    cancelButtonText,
+                    doneButtonText,
+                    theme,
+                    resultCallback,
+                    androidDatePickerMode,
+                    androidTimePickerMode
+                );
             } else {
                 call.reject(ERROR_MODE_INVALID);
             }

--- a/packages/datetime-picker/ios/Plugin.xcodeproj/project.pbxproj
+++ b/packages/datetime-picker/ios/Plugin.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		7CD7816928A3976B001BEAAE /* DatetimePickerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD7816828A3976B001BEAAE /* DatetimePickerConfig.swift */; };
 		7CD7816B28A39BA0001BEAAE /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD7816A28A39BA0001BEAAE /* Theme.swift */; };
 		7CE32AE328A6810C0064C6BE /* DatetimePickerStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CE32AE228A6810C0064C6BE /* DatetimePickerStyle.swift */; };
+		A1B2C3D400000001E0000001 /* MonthYearPickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D400000001E0000002 /* MonthYearPickerController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +50,7 @@
 		7CD7816828A3976B001BEAAE /* DatetimePickerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatetimePickerConfig.swift; sourceTree = "<group>"; };
 		7CD7816A28A39BA0001BEAAE /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		7CE32AE228A6810C0064C6BE /* DatetimePickerStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatetimePickerStyle.swift; sourceTree = "<group>"; };
+		A1B2C3D400000001E0000002 /* MonthYearPickerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthYearPickerController.swift; sourceTree = "<group>"; };
 		91781294A431A2A7CC6EB714 /* Pods-Plugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Plugin.release.xcconfig"; path = "Pods/Target Support Files/Pods-Plugin/Pods-Plugin.release.xcconfig"; sourceTree = "<group>"; };
 		96ED1B6440D6672E406C8D19 /* Pods-PluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PluginTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PluginTests/Pods-PluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		F65BB2953ECE002E1EF3E424 /* Pods-PluginTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PluginTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PluginTests/Pods-PluginTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -109,6 +111,7 @@
 				7CD7816A28A39BA0001BEAAE /* Theme.swift */,
 				7CE32AE228A6810C0064C6BE /* DatetimePickerStyle.swift */,
 				7CA3513728B69A7C00D3C1C7 /* ErrorCode.swift */,
+				A1B2C3D400000001E0000002 /* MonthYearPickerController.swift */,
 			);
 			path = Plugin;
 			sourceTree = "<group>";
@@ -325,6 +328,7 @@
 				7CA3513828B69A7C00D3C1C7 /* ErrorCode.swift in Sources */,
 				7C0CB8CE28A3D7D9000D55CD /* RPicker.swift in Sources */,
 				7CD7816928A3976B001BEAAE /* DatetimePickerConfig.swift in Sources */,
+				A1B2C3D400000001E0000001 /* MonthYearPickerController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/datetime-picker/ios/Plugin/DatetimePicker.swift
+++ b/packages/datetime-picker/ios/Plugin/DatetimePicker.swift
@@ -32,6 +32,32 @@ import Foundation
         }
     }
 
+    @objc public func presentMonthYearPicker(date: Date, minDate: Date?, maxDate: Date?, locale: Locale?, cancelButtonText: String, doneButtonText: String, theme: String?, completion: @escaping (Date?, ErrorCode) -> Void) {
+        closeKeyboard()
+        DispatchQueue.main.asyncAfter(deadline: .now() + waitForKeyboardCloseSeconds) {
+            guard let cc = self.plugin.bridge?.viewController else { return }
+
+            let vc = MonthYearPickerController(title: "", cancelText: cancelButtonText, doneText: doneButtonText,
+                                               selectedDate: date, minDate: minDate, maxDate: maxDate,
+                                               locale: locale, theme: self.getTheme(unconvertedTheme: theme))
+
+            vc.modalPresentationStyle = .overCurrentContext
+            vc.modalTransitionStyle = .crossDissolve
+
+            vc.onDateSelected = { (selectedDate) in
+                completion(selectedDate, ErrorCode.none)
+            }
+            vc.onCanceled = {
+                completion(nil, ErrorCode.canceled)
+            }
+            vc.onBackdropDismissed = {
+                completion(nil, ErrorCode.dismissed)
+            }
+
+            cc.present(vc, animated: true, completion: nil)
+        }
+    }
+
     @objc public func presentTimePicker(date: Date, locale: Locale?, cancelButtonText: String, doneButtonText: String, theme: String?, minuteInterval: Int, completion: @escaping (Date?, ErrorCode) -> Void) {
         closeKeyboard()
         DispatchQueue.main.asyncAfter(deadline: .now() + waitForKeyboardCloseSeconds) {

--- a/packages/datetime-picker/ios/Plugin/DatetimePickerPlugin.swift
+++ b/packages/datetime-picker/ios/Plugin/DatetimePickerPlugin.swift
@@ -83,6 +83,9 @@ public class DatetimePickerPlugin: CAPPlugin, CAPBridgedPlugin {
         } else if mode == "time" {
             implementation?.presentTimePicker(date: date, locale: locale, cancelButtonText: cancelButtonText,
                                               doneButtonText: doneButtonText, theme: theme, minuteInterval: minuteInterval, completion: completion)
+        } else if mode == "month-year" {
+            implementation?.presentMonthYearPicker(date: date, minDate: minDate, maxDate: maxDate, locale: locale,
+                                                   cancelButtonText: cancelButtonText, doneButtonText: doneButtonText, theme: theme, completion: completion)
         } else {
             call.reject(errorModeInvalid)
         }

--- a/packages/datetime-picker/ios/Plugin/MonthYearPickerController.swift
+++ b/packages/datetime-picker/ios/Plugin/MonthYearPickerController.swift
@@ -1,0 +1,383 @@
+import UIKit
+
+class MonthYearPickerController: UIViewController, UIPickerViewDataSource, UIPickerViewDelegate {
+
+    // MARK: - Public closures
+    var onDateSelected: ((_ date: Date) -> Void)?
+    var onCanceled: (() -> Void)?
+    var onBackdropDismissed: (() -> Void)?
+
+    // MARK: - Public variables
+    var selectedDate = Date()
+    var maxDate: Date?
+    var minDate: Date?
+    var titleText: String?
+    var cancelText: String?
+    var doneText: String = "Done"
+    var locale: Locale?
+    var theme: Theme = .auto
+
+    // MARK: - Private variables
+    private let barViewHeight: CGFloat = 44
+    private let pickerHeight: CGFloat = 216
+    private let buttonWidth: CGFloat = 84
+    private let lineHeight: CGFloat = 0.5
+    private let buttonColor = UIColor(red: 72/255, green: 152/255, blue: 240/255, alpha: 1)
+    private let lineColor = UIColor(red: 240/255, green: 240/255, blue: 240/255, alpha: 1)
+
+    private let monthComponent = 0
+    private let yearComponent = 1
+
+    private var selectedMonth: Int = 0
+    private var selectedYear: Int = 0
+    private var minYear: Int = 0
+    private var maxYear: Int = 0
+    private var minMonth: Int = 0
+    private var maxMonth: Int = 11
+    private var monthNames: [String] = []
+
+    // MARK: - Init
+    init(title: String? = nil,
+         cancelText: String? = nil,
+         doneText: String = "Done",
+         selectedDate: Date = Date(),
+         minDate: Date? = nil,
+         maxDate: Date? = nil,
+         locale: Locale? = nil,
+         theme: Theme = .auto) {
+
+        self.titleText = title
+        self.cancelText = cancelText
+        self.doneText = doneText
+        self.selectedDate = selectedDate
+        self.minDate = minDate
+        self.maxDate = maxDate
+        self.locale = locale
+        self.theme = theme
+
+        super.init(nibName: nil, bundle: nil)
+
+        configureDateRange()
+        initialSetup()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        // Trait collection has already changed
+    }
+
+    override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
+        if #available(iOS 12.0, *) {
+            if newCollection.userInterfaceStyle != traitCollection.userInterfaceStyle {
+                if newCollection.userInterfaceStyle == .dark {
+                    setUpThemeMode(theme: theme, systemIsDark: true)
+                } else {
+                    setUpThemeMode(theme: theme, systemIsDark: false)
+                }
+            }
+        } else {
+            setUpThemeMode(theme: .light, systemIsDark: false)
+        }
+    }
+
+    // MARK: - Private functions
+    private func configureDateRange() {
+        let calendar = Calendar.current
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = locale ?? Locale.current
+        monthNames = dateFormatter.monthSymbols
+
+        let currentComponents = calendar.dateComponents([.year, .month], from: selectedDate)
+        selectedMonth = (currentComponents.month ?? 1) - 1
+        selectedYear = currentComponents.year ?? calendar.component(.year, from: Date())
+
+        if let minDate = minDate {
+            let minComponents = calendar.dateComponents([.year, .month], from: minDate)
+            minYear = minComponents.year ?? selectedYear - 100
+            minMonth = (minComponents.month ?? 1) - 1
+        } else {
+            minYear = selectedYear - 100
+            minMonth = 0
+        }
+
+        if let maxDate = maxDate {
+            let maxComponents = calendar.dateComponents([.year, .month], from: maxDate)
+            maxYear = maxComponents.year ?? selectedYear + 100
+            maxMonth = (maxComponents.month ?? 12) - 1
+        } else {
+            maxYear = selectedYear + 100
+            maxMonth = 11
+        }
+    }
+
+    private func initialSetup() {
+
+        view.backgroundColor = UIColor.clear
+        let bgView = transView
+        view.addSubview(bgView)
+        bgView.fillConstraints(bgView: view)
+
+        // Stack View
+        stackView.addArrangedSubview(lineLabel)
+        stackView.addArrangedSubview(toolBarView)
+        stackView.addArrangedSubview(lineLabel)
+        stackView.addArrangedSubview(monthYearPicker)
+
+        let height = barViewHeight + (2*lineHeight) + pickerHeight
+
+        self.view.addSubview(stackView)
+
+        stackView.edgeConstraints( view, left: 0, right: 0, bottom: 0, height: height)
+
+        monthYearPicker.selectRow(selectedMonth - monthRangeForYear(selectedYear).lowerBound, inComponent: monthComponent, animated: false)
+        monthYearPicker.selectRow(selectedYear - minYear, inComponent: yearComponent, animated: false)
+
+        if #available(iOS 12.0, *) {
+            if traitCollection.userInterfaceStyle == .dark {
+                setUpThemeMode(theme: theme, systemIsDark: true)
+            } else {
+                setUpThemeMode(theme: theme, systemIsDark: false)
+            }
+        } else {
+            setUpThemeMode(theme: .light, systemIsDark: false)
+        }
+    }
+
+    private func monthRangeForYear(_ year: Int) -> Range<Int> {
+        let lower = (year == minYear) ? minMonth : 0
+        let upper = (year == maxYear) ? maxMonth : 11
+        return lower..<(upper + 1)
+    }
+
+    private func setUpThemeMode(theme: Theme, systemIsDark: Bool) {
+        switch theme {
+        case .light:
+            applyLightTheme()
+        case .dark:
+            applyDarkTheme()
+        case .auto:
+            if systemIsDark {
+                applyDarkTheme()
+            } else {
+                applyLightTheme()
+            }
+        }
+    }
+
+    private func applyLightTheme() {
+        titleLabel.textColor = UIColor.darkGray
+        stackView.backgroundColor = UIColor.white
+        transView.backgroundColor = UIColor(white: 0.1, alpha: 0.3)
+        monthYearPicker.backgroundColor = UIColor.white
+        toolBarView.backgroundColor = UIColor.white
+    }
+
+    private func applyDarkTheme() {
+        titleLabel.textColor = UIColor.white
+        stackView.backgroundColor = UIColor.black
+        transView.backgroundColor = UIColor(white: 1, alpha: 0.3)
+        monthYearPicker.backgroundColor = UIColor.black
+        toolBarView.backgroundColor = UIColor.black
+    }
+
+    private func dismissVC() {
+        dismiss(animated: true, completion: nil)
+    }
+
+    @objc func handleTap() {
+        onBackdropDismissed?()
+        dismissVC()
+    }
+
+    // MARK: - UIPickerViewDataSource
+
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 2
+    }
+
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        if component == monthComponent {
+            return monthRangeForYear(selectedYear).count
+        } else {
+            return maxYear - minYear + 1
+        }
+    }
+
+    // MARK: - UIPickerViewDelegate
+
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        if component == yearComponent {
+            let newYear = minYear + row
+            let previousRange = monthRangeForYear(selectedYear)
+            let previousMonthIndex = previousRange.lowerBound + monthYearPicker.selectedRow(inComponent: monthComponent)
+            selectedYear = newYear
+
+            let newRange = monthRangeForYear(newYear)
+            monthYearPicker.reloadComponent(monthComponent)
+
+            let clampedMonth = min(max(previousMonthIndex, newRange.lowerBound), newRange.upperBound - 1)
+            selectedMonth = clampedMonth
+            monthYearPicker.selectRow(clampedMonth - newRange.lowerBound, inComponent: monthComponent, animated: true)
+        } else {
+            let range = monthRangeForYear(selectedYear)
+            selectedMonth = range.lowerBound + row
+        }
+    }
+
+    func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
+        let title: String
+        if component == monthComponent {
+            let monthIndex = monthRangeForYear(selectedYear).lowerBound + row
+            title = monthNames[monthIndex]
+        } else {
+            title = String(minYear + row)
+        }
+
+        let isDark: Bool
+        if #available(iOS 12.0, *) {
+            switch theme {
+            case .dark:
+                isDark = true
+            case .light:
+                isDark = false
+            case .auto:
+                isDark = traitCollection.userInterfaceStyle == .dark
+            }
+        } else {
+            isDark = false
+        }
+
+        let color = isDark ? UIColor.white : UIColor.black
+        return NSAttributedString(string: title, attributes: [.foregroundColor: color])
+    }
+
+    // MARK: - Private properties
+
+    private lazy var transView: UIView = {
+        let vw = UIView()
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.handleTap))
+        vw.addGestureRecognizer(tapGesture)
+        vw.isUserInteractionEnabled = true
+        return vw
+    }()
+
+    private lazy var stackView: UIStackView = {
+        let sv = UIStackView()
+        sv.axis = NSLayoutConstraint.Axis.vertical
+        sv.distribution = UIStackView.Distribution.fill
+        sv.alignment = UIStackView.Alignment.center
+        sv.spacing = 0.0
+        return sv
+    }()
+
+    private lazy var monthYearPicker: UIPickerView = {
+        let picker = UIPickerView()
+        picker.edgeConstraints( view, width: view.frame.width)
+        picker.dataSource = self
+        picker.delegate = self
+        return picker
+    }()
+
+    private lazy var toolBarView: UIView = {
+
+        let barView = UIView()
+        barView.edgeConstraints( view, height: barViewHeight, width: view.frame.width)
+
+        let doneButton = self.doneButton
+        let cancelButton = self.cancelButton
+
+        barView.addSubview(doneButton)
+        barView.addSubview(cancelButton)
+
+        cancelButton.edgeConstraints( barView, left: 0, top: 0, bottom: 0, width: buttonWidth)
+        doneButton.edgeConstraints( barView, right: 0, top: 0, bottom: 0, width: buttonWidth)
+
+        if let text = titleText {
+            let titleLabel = self.titleLabel
+            titleLabel.text = text
+            barView.addSubview(titleLabel)
+            titleLabel.fillConstraints(bgView: barView, left: buttonWidth, right: -buttonWidth)
+        }
+
+        doneButton.setTitle(doneText, for: .normal)
+
+        if let text = cancelText {
+            cancelButton.setTitle(text, for: .normal)
+        } else {
+            cancelButton.isHidden = true
+        }
+
+        return barView
+    }()
+
+    private lazy var lineLabel: UILabel = {
+        let label = UILabel()
+        label.backgroundColor = lineColor
+        label.edgeConstraints( view, height: lineHeight, width: view.frame.width)
+        return label
+    }()
+
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.font = UIFont(name: "HelveticaNeue-Medium", size: 14)
+        label.numberOfLines = 2
+        return label
+    }()
+
+    private lazy var doneButton: UIButton = {
+        let button = UIButton()
+        button.setTitleColor(buttonColor, for: .normal)
+        button.titleLabel?.font = UIFont(name: "HelveticaNeue-Bold", size: 16)
+        button.addTarget(self, action: #selector(onDoneButton), for: .touchUpInside)
+        return button
+    }()
+
+    private lazy var cancelButton: UIButton = {
+        let button = UIButton()
+        button.setTitleColor(buttonColor, for: .normal)
+        button.titleLabel?.font = UIFont(name: "HelveticaNeue-Bold", size: 16)
+        button.addTarget(self, action: #selector(onCancelButton), for: .touchUpInside)
+        return button
+    }()
+
+    @objc func onDoneButton(sender: UIButton) {
+        var components = DateComponents()
+        components.year = selectedYear
+        components.month = selectedMonth + 1
+        components.day = 1
+        if let date = Calendar.current.date(from: components) {
+            onDateSelected?(date)
+        }
+        dismissVC()
+    }
+
+    @objc func onCancelButton(sender: UIButton) {
+        onCanceled?()
+        dismissVC()
+    }
+}
+
+// MARK: - Private UIView constraint helpers
+
+private extension UIView {
+
+    func edgeConstraints(_ bgView: UIView, left: CGFloat? = nil, right: CGFloat? = nil, top: CGFloat? = nil, bottom: CGFloat? = nil, height: CGFloat? = nil, width: CGFloat? = nil) {
+
+        translatesAutoresizingMaskIntoConstraints = false
+
+        if let left = left { leftAnchor.constraint(equalTo: bgView.leftAnchor, constant: left).isActive = true }
+        if let right = right { rightAnchor.constraint(equalTo: bgView.rightAnchor, constant: right).isActive = true }
+        if let top = top { topAnchor.constraint(equalTo: bgView.topAnchor, constant: top).isActive = true }
+        if let bottom = bottom { bottomAnchor.constraint(equalTo: bgView.bottomAnchor, constant: bottom).isActive = true }
+        if let height = height { heightAnchor.constraint(equalToConstant: height).isActive = true }
+        if let width = width { widthAnchor.constraint(equalToConstant: width).isActive = true }
+    }
+
+    func fillConstraints(bgView: UIView, left: CGFloat = 0, right: CGFloat = 0, top: CGFloat = 0, bottom: CGFloat = 0) {
+        edgeConstraints(bgView, left: left, right: right, top: top, bottom: bottom)
+    }
+}

--- a/packages/datetime-picker/src/definitions.ts
+++ b/packages/datetime-picker/src/definitions.ts
@@ -107,12 +107,12 @@ export interface PresentOptions {
    */
   min?: string;
   /**
-   * Whether you want a date or time or datetime picker.
+   * Whether you want a date, time, datetime, or month-year picker.
    *
    * @since 0.0.1
    * @default 'datetime'
    */
-  mode?: 'date' | 'time' | 'datetime';
+  mode?: 'date' | 'time' | 'datetime' | 'month-year';
   /**
    * Choose the theme that the datetime picker should have.
    * With `auto` the system theme is used.


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).


Add 'month-year' option to the mode parameter that presents a spinner picker with only month and year columns

<img width="300"  alt="android" src="https://github.com/user-attachments/assets/c8763fa2-faec-41b5-b403-a3ad268914b3" />

<img width="300"  alt="ios" src="https://github.com/user-attachments/assets/32d16dfa-40bf-47fd-93ac-679be1fc2c44" />
