### PR TITLE
test(live-update): run each Maestro flow in its own `maestro test` invocation

### DIFF
--- a/packages/live-update/example/package.json
+++ b/packages/live-update/example/package.json
@@ -11,8 +11,8 @@
     "start": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "e2e:android": "adb reverse tcp:4000 tcp:4000 && concurrently -k -s first \"node test/mock-server.mjs\" \"maestro test .maestro\"",
-    "e2e:ios": "concurrently -k -s first \"node test/mock-server.mjs\" \"maestro test .maestro\""
+    "e2e:android": "adb reverse tcp:4000 tcp:4000 && concurrently -k -s first \"node test/mock-server.mjs\" \"node test/run-maestro-flows.mjs\"",
+    "e2e:ios": "concurrently -k -s first \"node test/mock-server.mjs\" \"node test/run-maestro-flows.mjs\""
   },
   "dependencies": {
     "@capacitor/android": "^8.0.0",

--- a/packages/live-update/example/test/run-maestro-flows.mjs
+++ b/packages/live-update/example/test/run-maestro-flows.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import { readdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+const dir = '.maestro';
+const flows = readdirSync(dir)
+  .filter((f) => f.endsWith('.yaml'))
+  .sort();
+
+if (flows.length === 0) {
+  console.error(`No Maestro flows found in ${dir}`);
+  process.exit(1);
+}
+
+for (const flow of flows) {
+  console.log(`\n=== Running ${flow} ===\n`);
+  const result = spawnSync('maestro', ['test', `${dir}/${flow}`], { stdio: 'inherit' });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces `maestro test .maestro` with a small helper script that iterates `.maestro/*.yaml` alphabetically and runs `maestro test` once per flow, stopping on first failure.
- Applies the change to both `e2e:android` and `e2e:ios` in `packages/live-update/example/package.json`.

## Motivation

The iOS Smoke Test has been failing intermittently on `main` with `App crashed or stopped` / `Application com.example.plugin is not running` ~200ms after `launchApp`, while the same flow passes consistently on Android. The pattern is reproducible: the first flow Maestro runs in a shared session passes, the second crashes the app immediately on cold launch. Giving each flow its own Maestro process and a fresh XCTest driver attach removes that shared-session footgun.

This is a minimal first step. If the same crash signature reappears, a follow-up can add `xcrun simctl shutdown/boot` between flows inside the same helper without touching CI or `package.json` again.

## Scalability

Adding a new Maestro flow is now just dropping a `.yaml` into `.maestro/` — no `package.json` or CI changes required. The helper also gives us a single, obvious extension point for future hardening (sim reboot between flows, retry-on-flake, per-flow timing, etc.).

## Test plan

- [ ] CI on this branch runs `E2E (iOS)` for `@capawesome/capacitor-live-update` and both flows pass.
- [ ] CI on this branch runs `E2E (Android)` for `@capawesome/capacitor-live-update` and both flows pass.