### PR TITLE
test(live-update): retry Maestro flows to reduce e2e flakiness

### DIFF
--- a/packages/live-update/example/test/run-maestro-flows.mjs
+++ b/packages/live-update/example/test/run-maestro-flows.mjs
@@ -3,6 +3,7 @@ import { readdirSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 
 const dir = '.maestro';
+const MAX_ATTEMPTS = 3;
 const flows = readdirSync(dir)
   .filter((f) => f.endsWith('.yaml'))
   .sort();
@@ -13,9 +14,15 @@ if (flows.length === 0) {
 }
 
 for (const flow of flows) {
-  console.log(`\n=== Running ${flow} ===\n`);
-  const result = spawnSync('maestro', ['test', `${dir}/${flow}`], { stdio: 'inherit' });
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    console.log(`\n=== Running ${flow} (attempt ${attempt}/${MAX_ATTEMPTS}) ===\n`);
+    const result = spawnSync('maestro', ['test', `${dir}/${flow}`], { stdio: 'inherit' });
+    if (result.status === 0) {
+      break;
+    }
+    if (attempt === MAX_ATTEMPTS) {
+      process.exit(result.status ?? 1);
+    }
+    console.log(`\n=== ${flow} failed, retrying... ===\n`);
   }
 }


### PR DESCRIPTION
## Problem

The **E2E (iOS)** job intermittently fails on the `download-checksum-mismatch.yaml` Maestro flow (Live Update plugin), e.g. [run 26736750222](https://github.com/capawesome-team/capacitor-plugins/actions/runs/26736750222).

After tapping "Download Bundle", Maestro polls for `"Checksum mismatch."` densely (~every 200ms) for the full 30s window and never sees it. The failure screenshot shows the filled form with no error toast — so the error genuinely never surfaces in time. Root cause is an intermittent slow/stalled download from `localhost:4000` on the CI iOS simulator (`URLSession`'s own request timeout is 60s > the flow's 30s), so the checksum error can't appear before the flow gives up. This is environmental flakiness.

## Change

Re-run each Maestro flow up to 3 attempts before failing in `run-maestro-flows.mjs`. A single environmental stall no longer fails the whole job, but a genuinely broken flow still fails (3× in a row). Each retry restarts from a clean `launchApp: clearState`.

This is the only e2e runner in the repo (`live-update` is the only package with `e2e:ios`/`e2e:android`), so it covers both platforms.

## Notes

This masks the underlying slow download rather than fixing it. A follow-up root-cause option is shortening the download request timeout so a stall surfaces a fast, visible error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)