### PR TITLE
feat(live-update): release 7.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -434,6 +434,18 @@
         }
       }
     },
+    "node_modules/@changesets/cli/node_modules/@types/node": {
+      "version": "25.0.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.2.tgz",
+      "integrity": "sha512-gWEkeiyYE4vqjON/+Obqcoeffmk0NF15WSBwSs7zwVA2bAbTaE0SJ7P0WNGoJn8uE7fiaV5a7dKYIJriEqOrmA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "node_modules/@changesets/config": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.2.tgz",
@@ -1113,19 +1125,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@jsdevtools/ez-spawn": {
@@ -5193,9 +5192,9 @@
       "license": "MIT"
     },
     "node_modules/native-run": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/native-run/-/native-run-2.0.3.tgz",
-      "integrity": "sha512-U1PllBuzW5d1gfan+88L+Hky2eZx+9gv3Pf6rNBxKbORxi7boHzqiA6QFGSnqMem4j0A9tZ08NMIs5+0m/VS1Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/native-run/-/native-run-2.0.1.tgz",
+      "integrity": "sha512-XfG1FBZLM50J10xH9361whJRC9SHZ0Bub4iNRhhI61C8Jv0e1ud19muex6sNKB51ibQNUJNuYn25MuYET/rE6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6723,6 +6722,22 @@
         }
       }
     },
+    "node_modules/swiftlint/node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -7128,6 +7143,15 @@
       "engines": {
         "node": ">=18.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.1",
@@ -8071,7 +8095,7 @@
     },
     "packages/live-update": {
       "name": "@capawesome/capacitor-live-update",
-      "version": "7.5.0",
+      "version": "7.3.0",
       "funding": [
         {
           "type": "github",
@@ -8084,11 +8108,11 @@
       ],
       "license": "MIT",
       "devDependencies": {
-        "@capacitor/android": "7.6.5",
-        "@capacitor/cli": "7.6.5",
-        "@capacitor/core": "7.6.5",
+        "@capacitor/android": "7.0.0",
+        "@capacitor/cli": "7.0.0",
+        "@capacitor/core": "7.0.0",
         "@capacitor/docgen": "0.3.0",
-        "@capacitor/ios": "7.6.5",
+        "@capacitor/ios": "7.0.0",
         "@ionic/eslint-config": "0.4.0",
         "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
@@ -8101,157 +8125,6 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=7.0.0"
-      }
-    },
-    "packages/live-update/node_modules/@capacitor/android": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-7.6.5.tgz",
-      "integrity": "sha512-FCNSo5bWkqCIuNt2OgG6IUsJJaYlghzbzlFf4IiHkFtir18FCyqHVGHszvtXB+npT7HQ9JQOZ4MQRDsgczKEGQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@capacitor/core": "^7.6.0"
-      }
-    },
-    "packages/live-update/node_modules/@capacitor/cli": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-7.6.5.tgz",
-      "integrity": "sha512-nlhNoWZIL7YcV1JgNP8+p7WAVIG+zwsY20ZQJ0zd+2lLeCx9MijfELLhLzMCq33c2pILwOvLww8HUqZ5uYCvHg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ionic/cli-framework-output": "^2.2.8",
-        "@ionic/utils-subprocess": "^3.0.1",
-        "@ionic/utils-terminal": "^2.3.5",
-        "commander": "^12.1.0",
-        "debug": "^4.4.0",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^11.2.0",
-        "kleur": "^4.1.5",
-        "native-run": "^2.0.3",
-        "open": "^8.4.0",
-        "plist": "^3.1.0",
-        "prompts": "^2.4.2",
-        "rimraf": "^6.0.1",
-        "semver": "^7.6.3",
-        "tar": "^7.5.3",
-        "tslib": "^2.8.1",
-        "xml2js": "^0.6.2"
-      },
-      "bin": {
-        "cap": "bin/capacitor",
-        "capacitor": "bin/capacitor"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "packages/live-update/node_modules/@capacitor/core": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-7.6.5.tgz",
-      "integrity": "sha512-JWyxD9LaK1oY588B/khJIG3Ec4NHI/Ki4v1b4XzqPNt2a27au0F2AhLTwYexV4Bp3Ruxf+8oYqxFAC8/7sGBWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "packages/live-update/node_modules/@capacitor/ios": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-7.6.5.tgz",
-      "integrity": "sha512-jJK3wW65GAsmzgaswoePWDQ7mADIwQNWqWGcOeZyrPP7+lzW5/8gGqu9ASFGbG+GplFfgwRWzd4oH/7xb+lYFw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@capacitor/core": "^7.6.0"
-      }
-    },
-    "packages/live-update/node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/live-update/node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "packages/live-update/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "packages/live-update/node_modules/minizlib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "packages/live-update/node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.1.0",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/live-update/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "packages/live-update/node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "packages/managed-configurations": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -434,6 +434,18 @@
         }
       }
     },
+    "node_modules/@changesets/cli/node_modules/@types/node": {
+      "version": "25.0.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.2.tgz",
+      "integrity": "sha512-gWEkeiyYE4vqjON/+Obqcoeffmk0NF15WSBwSs7zwVA2bAbTaE0SJ7P0WNGoJn8uE7fiaV5a7dKYIJriEqOrmA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "node_modules/@changesets/config": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.2.tgz",
@@ -6710,6 +6722,22 @@
         }
       }
     },
+    "node_modules/swiftlint/node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -7115,6 +7143,15 @@
       "engines": {
         "node": ">=18.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.1",
@@ -8058,7 +8095,7 @@
     },
     "packages/live-update": {
       "name": "@capawesome/capacitor-live-update",
-      "version": "7.5.0",
+      "version": "7.3.0",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -434,18 +434,6 @@
         }
       }
     },
-    "node_modules/@changesets/cli/node_modules/@types/node": {
-      "version": "25.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.2.tgz",
-      "integrity": "sha512-gWEkeiyYE4vqjON/+Obqcoeffmk0NF15WSBwSs7zwVA2bAbTaE0SJ7P0WNGoJn8uE7fiaV5a7dKYIJriEqOrmA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
-    },
     "node_modules/@changesets/config": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.2.tgz",
@@ -1125,6 +1113,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jsdevtools/ez-spawn": {
@@ -5192,9 +5193,9 @@
       "license": "MIT"
     },
     "node_modules/native-run": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/native-run/-/native-run-2.0.1.tgz",
-      "integrity": "sha512-XfG1FBZLM50J10xH9361whJRC9SHZ0Bub4iNRhhI61C8Jv0e1ud19muex6sNKB51ibQNUJNuYn25MuYET/rE6w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/native-run/-/native-run-2.0.3.tgz",
+      "integrity": "sha512-U1PllBuzW5d1gfan+88L+Hky2eZx+9gv3Pf6rNBxKbORxi7boHzqiA6QFGSnqMem4j0A9tZ08NMIs5+0m/VS1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6722,22 +6723,6 @@
         }
       }
     },
-    "node_modules/swiftlint/node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -7143,15 +7128,6 @@
       "engines": {
         "node": ">=18.17"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.1",
@@ -8095,7 +8071,7 @@
     },
     "packages/live-update": {
       "name": "@capawesome/capacitor-live-update",
-      "version": "7.3.0",
+      "version": "7.5.0",
       "funding": [
         {
           "type": "github",
@@ -8108,11 +8084,11 @@
       ],
       "license": "MIT",
       "devDependencies": {
-        "@capacitor/android": "7.0.0",
-        "@capacitor/cli": "7.0.0",
-        "@capacitor/core": "7.0.0",
+        "@capacitor/android": "7.6.5",
+        "@capacitor/cli": "7.6.5",
+        "@capacitor/core": "7.6.5",
         "@capacitor/docgen": "0.3.0",
-        "@capacitor/ios": "7.0.0",
+        "@capacitor/ios": "7.6.5",
         "@ionic/eslint-config": "0.4.0",
         "@ionic/swiftlint-config": "2.0.0",
         "eslint": "8.57.0",
@@ -8125,6 +8101,157 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=7.0.0"
+      }
+    },
+    "packages/live-update/node_modules/@capacitor/android": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-7.6.5.tgz",
+      "integrity": "sha512-FCNSo5bWkqCIuNt2OgG6IUsJJaYlghzbzlFf4IiHkFtir18FCyqHVGHszvtXB+npT7HQ9JQOZ4MQRDsgczKEGQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^7.6.0"
+      }
+    },
+    "packages/live-update/node_modules/@capacitor/cli": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-7.6.5.tgz",
+      "integrity": "sha512-nlhNoWZIL7YcV1JgNP8+p7WAVIG+zwsY20ZQJ0zd+2lLeCx9MijfELLhLzMCq33c2pILwOvLww8HUqZ5uYCvHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/cli-framework-output": "^2.2.8",
+        "@ionic/utils-subprocess": "^3.0.1",
+        "@ionic/utils-terminal": "^2.3.5",
+        "commander": "^12.1.0",
+        "debug": "^4.4.0",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^11.2.0",
+        "kleur": "^4.1.5",
+        "native-run": "^2.0.3",
+        "open": "^8.4.0",
+        "plist": "^3.1.0",
+        "prompts": "^2.4.2",
+        "rimraf": "^6.0.1",
+        "semver": "^7.6.3",
+        "tar": "^7.5.3",
+        "tslib": "^2.8.1",
+        "xml2js": "^0.6.2"
+      },
+      "bin": {
+        "cap": "bin/capacitor",
+        "capacitor": "bin/capacitor"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/live-update/node_modules/@capacitor/core": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-7.6.5.tgz",
+      "integrity": "sha512-JWyxD9LaK1oY588B/khJIG3Ec4NHI/Ki4v1b4XzqPNt2a27au0F2AhLTwYexV4Bp3Ruxf+8oYqxFAC8/7sGBWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "packages/live-update/node_modules/@capacitor/ios": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-7.6.5.tgz",
+      "integrity": "sha512-jJK3wW65GAsmzgaswoePWDQ7mADIwQNWqWGcOeZyrPP7+lzW5/8gGqu9ASFGbG+GplFfgwRWzd4oH/7xb+lYFw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^7.6.0"
+      }
+    },
+    "packages/live-update/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/live-update/node_modules/fs-extra": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "packages/live-update/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "packages/live-update/node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/live-update/node_modules/tar": {
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/live-update/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "packages/live-update/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/managed-configurations": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -434,18 +434,6 @@
         }
       }
     },
-    "node_modules/@changesets/cli/node_modules/@types/node": {
-      "version": "25.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.2.tgz",
-      "integrity": "sha512-gWEkeiyYE4vqjON/+Obqcoeffmk0NF15WSBwSs7zwVA2bAbTaE0SJ7P0WNGoJn8uE7fiaV5a7dKYIJriEqOrmA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
-    },
     "node_modules/@changesets/config": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.2.tgz",
@@ -6722,22 +6710,6 @@
         }
       }
     },
-    "node_modules/swiftlint/node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -7143,15 +7115,6 @@
       "engines": {
         "node": ">=18.17"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.1",
@@ -8095,7 +8058,7 @@
     },
     "packages/live-update": {
       "name": "@capawesome/capacitor-live-update",
-      "version": "7.3.0",
+      "version": "7.5.0",
       "funding": [
         {
           "type": "github",

--- a/packages/live-update/CHANGELOG.md
+++ b/packages/live-update/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 7.5.0
+
+### Minor Changes
+
+- [`780fdcebabdac14a8bc93ad4b4d7863a1fbd03de`](https://github.com/capawesome-team/capacitor-plugins/commit/780fdcebabdac14a8bc93ad4b4d7863a1fbd03de) ([#783](https://github.com/capawesome-team/capacitor-plugins/pull/783)): feat: add native channel configuration support
+
+- [`fd6711d63359f77cc00f752b9b6396f9bc6b8541`](https://github.com/capawesome-team/capacitor-plugins/commit/fd6711d63359f77cc00f752b9b6396f9bc6b8541) ([#787](https://github.com/capawesome-team/capacitor-plugins/pull/787)): feat: add `fetchChannels(...)` method
+
+- [`b4181e9af6fe7dd0c8c9c0cbc6d0359a887d50a2`](https://github.com/capawesome-team/capacitor-plugins/commit/b4181e9af6fe7dd0c8c9c0cbc6d0359a887d50a2) ([#785](https://github.com/capawesome-team/capacitor-plugins/pull/785)): feat: track device ID on bundle download
+
+### Patch Changes
+
+- [`04e530df241e3c2dd82dd12b406b6b885f973a4a`](https://github.com/capawesome-team/capacitor-plugins/commit/04e530df241e3c2dd82dd12b406b6b885f973a4a) ([#792](https://github.com/capawesome-team/capacitor-plugins/pull/792)): fix(android): clear zip file attributes before extraction to prevent EACCES errors
+
+- [`f745456d73d53e850edca6434c7c54e191be2bf1`](https://github.com/capawesome-team/capacitor-plugins/commit/f745456d73d53e850edca6434c7c54e191be2bf1) ([#855](https://github.com/capawesome-team/capacitor-plugins/pull/855)): fix(android): prevent crash during bundle cleanup when a directory is unreadable
+
 ## 7.4.0
 
 ### Minor Changes

--- a/packages/live-update/CapawesomeCapacitorLiveUpdate.podspec
+++ b/packages/live-update/CapawesomeCapacitorLiveUpdate.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target  = '14.0'
   s.dependency 'Capacitor'
   s.dependency 'Alamofire', '~> 5.9'
-  s.dependency 'SSZipArchive', '~> 2.2.3'
+  s.dependency 'ZIPFoundation', '~> 0.9.0'
   s.swift_version = '5.1'
   s.static_framework = true
 end

--- a/packages/live-update/Package.swift
+++ b/packages/live-update/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0"),
         .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.9.0")),
-        .package(url: "https://github.com/ZipArchive/ZipArchive.git", .upToNextMinor(from: "2.4.0"))
+        .package(url: "https://github.com/weichsel/ZIPFoundation.git", .upToNextMinor(from: "0.9.0"))
     ],
     targets: [
         .target(
@@ -21,7 +21,7 @@ let package = Package(
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
                 .product(name: "Alamofire", package: "Alamofire"),
-                .product(name: "ZipArchive", package: "ZipArchive")
+                .product(name: "ZIPFoundation", package: "ZIPFoundation")
             ],
             path: "ios/Plugin"),
         .testTarget(

--- a/packages/live-update/README.md
+++ b/packages/live-update/README.md
@@ -54,6 +54,21 @@ npx cap sync
 
 ### Android
 
+#### Channel
+
+If you are using [Versioned Channels](https://capawesome.io/cloud/live-updates/guides/best-practices/#versioned-channels), you can set a default channel directly in your native project by adding a string resource.
+This allows you to tie the channel to the version code at build time.
+
+Add the following to your app's `build.gradle` file:
+
+```groovy
+android {
+    defaultConfig {
+        resValue "string", "capawesome_live_update_default_channel", "production-" + defaultConfig.versionCode
+    }
+}
+```
+
 #### Variables
 
 If needed, you can define the following project variable in your app’s `variables.gradle` file to change the default version of the dependency:
@@ -64,6 +79,18 @@ If needed, you can define the following project variable in your app’s `variab
 This can be useful if you encounter dependency conflicts with other plugins in your project.
 
 ### iOS
+
+#### Channel
+
+If you are using [Versioned Channels](https://capawesome.io/cloud/live-updates/guides/best-practices/#versioned-channels), you can set a default channel directly in your native project by adding a key to your `Info.plist` file.
+This allows you to tie the channel to the build version at build time.
+
+Add the following to your `Info.plist` file:
+
+```xml
+<key>CapawesomeLiveUpdateDefaultChannel</key>
+<string>production-$(CURRENT_PROJECT_VERSION)</string>
+```
 
 #### Privacy manifest
 
@@ -103,7 +130,7 @@ We recommend to declare [`CA92.1`](https://developer.apple.com/documentation/bun
 | **`autoBlockRolledBackBundles`** | <code>boolean</code>                | Whether or not to automatically block bundles that have been rolled back. When enabled, the plugin will automatically block bundles that caused a rollback (up to 100 bundles). When the limit is reached, the oldest blocked bundle is unblocked. Blocked bundles will be skipped in future sync operations. **Attention**: This option has no effect if `readyTimeout` is set to `0`. Only available on Android and iOS. | <code>false</code>                     | 7.3.0 |
 | **`autoDeleteBundles`**          | <code>boolean</code>                | Whether or not to automatically delete unused bundles. When enabled, the plugin will automatically delete unused bundles after calling `ready()`.                                                                                                                                                                                                                                                                          | <code>false</code>                     | 5.0.0 |
 | **`autoUpdateStrategy`**         | <code>'none' \| 'background'</code> | The auto-update strategy for live updates. - `none`: Live updates will not be applied automatically. - `background`: Live updates will be automatically downloaded and applied in the background at app startup and when the app resumes (if the last check was more than 15 minutes ago). Only available on Android and iOS.                                                                                              | <code>'none'</code>                    | 7.3.0 |
-| **`defaultChannel`**             | <code>string</code>                 | The default channel of the app.                                                                                                                                                                                                                                                                                                                                                                                            |                                        | 6.3.0 |
+| **`defaultChannel`**             | <code>string</code>                 | The default channel of the app. This can be overridden by `setChannel()` or the `channel` parameter of `sync()`. It takes priority over the native channel configuration (`CapawesomeLiveUpdateDefaultChannel` in `Info.plist` on iOS or `capawesome_live_update_default_channel` in `strings.xml` on Android).                                                                                                            |                                        | 6.3.0 |
 | **`httpTimeout`**                | <code>number</code>                 | The timeout in milliseconds for HTTP requests.                                                                                                                                                                                                                                                                                                                                                                             | <code>60000</code>                     | 6.4.0 |
 | **`publicKey`**                  | <code>string</code>                 | The public key to verify the integrity of the bundle. The public key must be a PEM-encoded RSA public key.                                                                                                                                                                                                                                                                                                                 |                                        | 6.1.0 |
 | **`readyTimeout`**               | <code>number</code>                 | The timeout in milliseconds to wait for the app to be ready before resetting to the default bundle. It is strongly **recommended** to configure this option (e.g. `10000` ms) so that the plugin can roll back to the default bundle in case of problems. If configured, the plugin will wait for the app to call the `ready()` method before resetting to the default bundle. Set to `0` to disable the timeout.          | <code>0</code>                         | 5.0.0 |
@@ -431,6 +458,15 @@ getChannel() => Promise<GetChannelResult>
 ```
 
 Get the channel that is used for the update.
+
+The channel is resolved in the following order (highest priority first):
+1. `setChannel()` (SharedPreferences on Android / UserDefaults on iOS)
+2. Capacitor config `defaultChannel`
+3. Native config (`CapawesomeLiveUpdateDefaultChannel` in `Info.plist` on iOS or
+   `capawesome_live_update_default_channel` in `strings.xml` on Android)
+
+**Note**: The `channel` parameter of `sync()` takes the highest priority
+but is not persisted and therefore not returned by this method.
 
 Only available on Android and iOS.
 

--- a/packages/live-update/README.md
+++ b/packages/live-update/README.md
@@ -199,6 +199,11 @@ const downloadBundle = async () => {
   await LiveUpdate.downloadBundle({ url: 'https://example.com/1.0.0.zip', bundleId: '1.0.0' });
 };
 
+const fetchChannels = async () => {
+  const result = await LiveUpdate.fetchChannels();
+  return result.channels;
+};
+
 const fetchLatestBundle = async () => {
   await LiveUpdate.fetchLatestBundle();
 };
@@ -303,6 +308,7 @@ const isNewBundleAvailable = async () => {
 * [`clearBlockedBundles()`](#clearblockedbundles)
 * [`deleteBundle(...)`](#deletebundle)
 * [`downloadBundle(...)`](#downloadbundle)
+* [`fetchChannels(...)`](#fetchchannels)
 * [`fetchLatestBundle(...)`](#fetchlatestbundle)
 * [`getBlockedBundles()`](#getblockedbundles)
 * [`getBundles()`](#getbundles)
@@ -389,6 +395,35 @@ Only available on Android and iOS.
 | **`options`** | <code><a href="#downloadbundleoptions">DownloadBundleOptions</a></code> |
 
 **Since:** 5.0.0
+
+--------------------
+
+
+### fetchChannels(...)
+
+```typescript
+fetchChannels(options?: FetchChannelsOptions | undefined) => Promise<FetchChannelsResult>
+```
+
+Fetch channels from [Capawesome Cloud](https://capawesome.io/cloud/).
+
+This is primarily intended for development and QA purposes.
+It allows you to retrieve a list of available channels so you can
+dynamically switch between them using `setChannel(...)`.
+
+**Attention**: Only works for apps with public channels enabled.
+If channels are private, they can still be set using `setChannel(...)`
+but won't be returned by this method.
+
+Only available on Android and iOS.
+
+| Param         | Type                                                                  |
+| ------------- | --------------------------------------------------------------------- |
+| **`options`** | <code><a href="#fetchchannelsoptions">FetchChannelsOptions</a></code> |
+
+**Returns:** <code>Promise&lt;<a href="#fetchchannelsresult">FetchChannelsResult</a>&gt;</code>
+
+**Since:** 7.5.0
 
 --------------------
 
@@ -928,6 +963,30 @@ Remove all listeners for this plugin.
 | **`checksum`**     | <code>string</code>              | The checksum of the self-hosted bundle as a SHA-256 hash in base64 format to verify the integrity of the bundle. **Attention**: Only supported for the `zip` artifact type.                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |                    | 7.1.0 |
 | **`signature`**    | <code>string</code>              | The signature of the self-hosted bundle as a signed SHA-256 hash in base64 format to verify the integrity of the bundle. **Attention**: Only supported for the `zip` artifact type.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |                    | 7.1.0 |
 | **`url`**          | <code>string</code>              | The URL of the bundle to download. For the `zip` artifact type, the URL must point to a ZIP file. For the `manifest` artifact type, the URL serves as the base URL to download the individual files. For example, if the URL is `https://example.com/download`, the plugin will download the file with the href `index.html` from `https://example.com/download?href=index.html`. To **verify the integrity** of the file, the server should return a `X-Checksum` header with the SHA-256 hash in base64 format. To **verify the signature** of the file, the server should return a `X-Signature` header with the signed SHA-256 hash in base64 format. |                    | 5.0.0 |
+
+
+#### FetchChannelsResult
+
+| Prop           | Type                   | Description           | Since |
+| -------------- | ---------------------- | --------------------- | ----- |
+| **`channels`** | <code>Channel[]</code> | The list of channels. | 7.5.0 |
+
+
+#### Channel
+
+| Prop       | Type                | Description                           | Since |
+| ---------- | ------------------- | ------------------------------------- | ----- |
+| **`id`**   | <code>string</code> | The unique identifier of the channel. | 7.5.0 |
+| **`name`** | <code>string</code> | The name of the channel.              | 7.5.0 |
+
+
+#### FetchChannelsOptions
+
+| Prop         | Type                | Description                               | Default         | Since |
+| ------------ | ------------------- | ----------------------------------------- | --------------- | ----- |
+| **`limit`**  | <code>number</code> | The maximum number of channels to return. | <code>50</code> | 7.5.0 |
+| **`offset`** | <code>number</code> | The number of channels to skip.           | <code>0</code>  | 7.5.0 |
+| **`query`**  | <code>string</code> | The query to filter channels by name.     |                 | 7.5.0 |
 
 
 #### FetchLatestBundleResult

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
@@ -1019,6 +1019,10 @@ public class LiveUpdate {
     @Nullable
     private String getChannel() {
         String channel = null;
+        String nativeChannel = getNativeChannel();
+        if (nativeChannel != null) {
+            channel = nativeChannel;
+        }
         if (config.getDefaultChannel() != null) {
             channel = config.getDefaultChannel();
         }
@@ -1026,6 +1030,18 @@ public class LiveUpdate {
             channel = preferences.getChannel();
         }
         return channel;
+    }
+
+    @Nullable
+    private String getNativeChannel() {
+        int resId = plugin
+            .getContext()
+            .getResources()
+            .getIdentifier("capawesome_live_update_default_channel", "string", plugin.getContext().getPackageName());
+        if (resId == 0) {
+            return null;
+        }
+        return plugin.getContext().getResources().getString(resId);
     }
 
     /**

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
@@ -115,6 +115,9 @@ public class LiveUpdate {
         // Check version and reset config if version changed
         checkAndResetConfigIfVersionChanged();
 
+        // Set the device ID on the HTTP client (after any potential config reset)
+        this.httpClient.setDeviceId(getDeviceId());
+
         // Start the rollback timer to rollback to the default bundle
         // if the app is not ready after a certain time
         startRollbackTimer();

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
@@ -606,8 +606,11 @@ public class LiveUpdate {
 
     private void deleteFileRecursively(@NonNull File file) {
         if (file.isDirectory()) {
-            for (File child : file.listFiles()) {
-                deleteFileRecursively(child);
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteFileRecursively(child);
+                }
             }
         }
         file.delete();

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdate.java
@@ -65,6 +65,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import net.lingala.zip4j.ZipFile;
+import net.lingala.zip4j.model.FileHeader;
 import okhttp3.Call;
 import okhttp3.HttpUrl;
 import okhttp3.Response;
@@ -1355,7 +1356,13 @@ public class LiveUpdate {
     private File unzipFile(@NonNull File zipFile) throws IOException {
         File destination = buildTemporaryDirectory();
         String destinationPath = destination.getPath();
-        new ZipFile(zipFile).extractAll(destinationPath);
+        ZipFile zip = new ZipFile(zipFile);
+        // Clear stored Unix permissions to prevent EACCES errors on newer Android versions
+        // where restrictive directory permissions from the zip block file creation.
+        for (FileHeader fileHeader : zip.getFileHeaders()) {
+            fileHeader.setExternalFileAttributes(null);
+        }
+        zip.extractAll(destinationPath);
         return destination;
     }
 

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateHttpClient.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateHttpClient.java
@@ -25,6 +25,9 @@ public class LiveUpdateHttpClient {
     @NonNull
     private final LiveUpdateConfig config;
 
+    @Nullable
+    private String deviceId;
+
     @NonNull
     private final OkHttpClient okHttpClient;
 
@@ -62,8 +65,16 @@ public class LiveUpdateHttpClient {
             .build();
     }
 
+    public void setDeviceId(@NonNull String deviceId) {
+        this.deviceId = deviceId;
+    }
+
     public Call enqueue(String url, NonEmptyCallback<Response> callback) {
-        Request request = new Request.Builder().url(url).build();
+        Request.Builder builder = new Request.Builder().url(url);
+        if (deviceId != null) {
+            builder.addHeader("X-Device-Id", deviceId);
+        }
+        Request request = builder.build();
 
         Call call = okHttpClient.newCall(request);
         call.enqueue(

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateHttpClient.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateHttpClient.java
@@ -57,12 +57,13 @@ public class LiveUpdateHttpClient {
         okhttp3.Dispatcher dispatcher = new okhttp3.Dispatcher();
         dispatcher.setMaxRequestsPerHost(30);
 
-        this.okHttpClient = new OkHttpClient.Builder()
-            .dispatcher(dispatcher)
-            .connectTimeout(httpTimeout, TimeUnit.MILLISECONDS)
-            .readTimeout(httpTimeout, TimeUnit.MILLISECONDS)
-            .writeTimeout(httpTimeout, TimeUnit.MILLISECONDS)
-            .build();
+        this.okHttpClient =
+            new OkHttpClient.Builder()
+                .dispatcher(dispatcher)
+                .connectTimeout(httpTimeout, TimeUnit.MILLISECONDS)
+                .readTimeout(httpTimeout, TimeUnit.MILLISECONDS)
+                .writeTimeout(httpTimeout, TimeUnit.MILLISECONDS)
+                .build();
     }
 
     public void setDeviceId(@NonNull String deviceId) {

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateHttpClient.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdateHttpClient.java
@@ -57,13 +57,12 @@ public class LiveUpdateHttpClient {
         okhttp3.Dispatcher dispatcher = new okhttp3.Dispatcher();
         dispatcher.setMaxRequestsPerHost(30);
 
-        this.okHttpClient =
-            new OkHttpClient.Builder()
-                .dispatcher(dispatcher)
-                .connectTimeout(httpTimeout, TimeUnit.MILLISECONDS)
-                .readTimeout(httpTimeout, TimeUnit.MILLISECONDS)
-                .writeTimeout(httpTimeout, TimeUnit.MILLISECONDS)
-                .build();
+        this.okHttpClient = new OkHttpClient.Builder()
+            .dispatcher(dispatcher)
+            .connectTimeout(httpTimeout, TimeUnit.MILLISECONDS)
+            .readTimeout(httpTimeout, TimeUnit.MILLISECONDS)
+            .writeTimeout(httpTimeout, TimeUnit.MILLISECONDS)
+            .build();
     }
 
     public void setDeviceId(@NonNull String deviceId) {

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdatePlugin.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdatePlugin.java
@@ -37,7 +37,7 @@ import io.capawesome.capacitorjs.plugins.liveupdate.interfaces.Result;
 public class LiveUpdatePlugin extends Plugin {
 
     public static final String TAG = "LiveUpdate";
-    public static final String VERSION = "7.4.0";
+    public static final String VERSION = "7.5.0";
     public static final String SHARED_PREFERENCES_NAME = "CapawesomeLiveUpdate"; // DO NOT CHANGE
     public static final String ERROR_APP_ID_MISSING = "appId must be configured.";
     public static final String ERROR_BUNDLE_EXISTS = "bundle already exists.";

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdatePlugin.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdatePlugin.java
@@ -14,12 +14,14 @@ import io.capawesome.capacitorjs.plugins.liveupdate.classes.events.DownloadBundl
 import io.capawesome.capacitorjs.plugins.liveupdate.classes.events.NextBundleSetEvent;
 import io.capawesome.capacitorjs.plugins.liveupdate.classes.options.DeleteBundleOptions;
 import io.capawesome.capacitorjs.plugins.liveupdate.classes.options.DownloadBundleOptions;
+import io.capawesome.capacitorjs.plugins.liveupdate.classes.options.FetchChannelsOptions;
 import io.capawesome.capacitorjs.plugins.liveupdate.classes.options.FetchLatestBundleOptions;
 import io.capawesome.capacitorjs.plugins.liveupdate.classes.options.SetChannelOptions;
 import io.capawesome.capacitorjs.plugins.liveupdate.classes.options.SetConfigOptions;
 import io.capawesome.capacitorjs.plugins.liveupdate.classes.options.SetCustomIdOptions;
 import io.capawesome.capacitorjs.plugins.liveupdate.classes.options.SetNextBundleOptions;
 import io.capawesome.capacitorjs.plugins.liveupdate.classes.options.SyncOptions;
+import io.capawesome.capacitorjs.plugins.liveupdate.classes.results.FetchChannelsResult;
 import io.capawesome.capacitorjs.plugins.liveupdate.classes.results.FetchLatestBundleResult;
 import io.capawesome.capacitorjs.plugins.liveupdate.classes.results.GetBlockedBundlesResult;
 import io.capawesome.capacitorjs.plugins.liveupdate.classes.results.GetConfigResult;
@@ -173,6 +175,34 @@ public class LiveUpdatePlugin extends Plugin {
             };
 
             implementation.downloadBundle(options, callback);
+        } catch (Exception exception) {
+            rejectCall(call, exception);
+        }
+    }
+
+    @PluginMethod
+    public void fetchChannels(PluginCall call) {
+        try {
+            String appId = config.getAppId();
+            if (appId == null || appId.isEmpty()) {
+                call.reject(ERROR_APP_ID_MISSING);
+                return;
+            }
+
+            FetchChannelsOptions options = new FetchChannelsOptions(call);
+            NonEmptyCallback<FetchChannelsResult> callback = new NonEmptyCallback<>() {
+                @Override
+                public void success(FetchChannelsResult result) {
+                    resolveCall(call, result.toJSObject());
+                }
+
+                @Override
+                public void error(Exception exception) {
+                    rejectCall(call, exception);
+                }
+            };
+
+            implementation.fetchChannels(options, callback);
         } catch (Exception exception) {
             rejectCall(call, exception);
         }

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/classes/api/GetChannelsResponseItem.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/classes/api/GetChannelsResponseItem.java
@@ -1,0 +1,28 @@
+package io.capawesome.capacitorjs.plugins.liveupdate.classes.api;
+
+import androidx.annotation.NonNull;
+import org.json.JSONObject;
+
+public class GetChannelsResponseItem {
+
+    @NonNull
+    private final String id;
+
+    @NonNull
+    private final String name;
+
+    public GetChannelsResponseItem(@NonNull JSONObject responseJson) {
+        this.id = responseJson.optString("id");
+        this.name = responseJson.optString("name");
+    }
+
+    @NonNull
+    public String getId() {
+        return id;
+    }
+
+    @NonNull
+    public String getName() {
+        return name;
+    }
+}

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/classes/options/FetchChannelsOptions.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/classes/options/FetchChannelsOptions.java
@@ -1,0 +1,38 @@
+package io.capawesome.capacitorjs.plugins.liveupdate.classes.options;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.getcapacitor.PluginCall;
+
+public class FetchChannelsOptions {
+
+    @Nullable
+    private final Integer limit;
+
+    @Nullable
+    private final Integer offset;
+
+    @Nullable
+    private final String query;
+
+    public FetchChannelsOptions(@NonNull PluginCall call) {
+        this.limit = call.getInt("limit");
+        this.offset = call.getInt("offset");
+        this.query = call.getString("query");
+    }
+
+    @Nullable
+    public Integer getLimit() {
+        return limit;
+    }
+
+    @Nullable
+    public Integer getOffset() {
+        return offset;
+    }
+
+    @Nullable
+    public String getQuery() {
+        return query;
+    }
+}

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/classes/results/ChannelResult.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/classes/results/ChannelResult.java
@@ -1,0 +1,28 @@
+package io.capawesome.capacitorjs.plugins.liveupdate.classes.results;
+
+import androidx.annotation.NonNull;
+import com.getcapacitor.JSObject;
+import io.capawesome.capacitorjs.plugins.liveupdate.interfaces.Result;
+
+public class ChannelResult implements Result {
+
+    @NonNull
+    private final String id;
+
+    @NonNull
+    private final String name;
+
+    public ChannelResult(@NonNull String id, @NonNull String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @NonNull
+    @Override
+    public JSObject toJSObject() {
+        JSObject result = new JSObject();
+        result.put("id", id);
+        result.put("name", name);
+        return result;
+    }
+}

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/classes/results/FetchChannelsResult.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/classes/results/FetchChannelsResult.java
@@ -1,0 +1,28 @@
+package io.capawesome.capacitorjs.plugins.liveupdate.classes.results;
+
+import androidx.annotation.NonNull;
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
+import io.capawesome.capacitorjs.plugins.liveupdate.interfaces.Result;
+
+public class FetchChannelsResult implements Result {
+
+    @NonNull
+    private final ChannelResult[] channels;
+
+    public FetchChannelsResult(@NonNull ChannelResult[] channels) {
+        this.channels = channels;
+    }
+
+    @NonNull
+    @Override
+    public JSObject toJSObject() {
+        JSObject result = new JSObject();
+        JSArray channelsArray = new JSArray();
+        for (ChannelResult channel : channels) {
+            channelsArray.put(channel.toJSObject());
+        }
+        result.put("channels", channelsArray);
+        return result;
+    }
+}

--- a/packages/live-update/example/capacitor.config.ts
+++ b/packages/live-update/example/capacitor.config.ts
@@ -7,9 +7,9 @@ const config: CapacitorConfig = {
   webDir: 'dist',
   plugins: {
     LiveUpdate: {
-      appId: '62d8e181-726f-45ab-aadc-15cd39bbd298',
+      appId: '5fc57c46-4b64-4209-b924-14fa960ccc88',
       // publicKey:
-      //   '-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoMb8yazAm5rY2ys6nQDgsKdGlQiLStdd7VBYjKKaRT2xwKXCPtsmeBtjvVUH//ae3IHbz7w79CoawKPDqKAPtqILWc3VyAR2hQ6ftoGVxYq5NyuV4UdZozEn9v45Se91gvi7Jc+NakZaPYBAG695X1d9iCdktWINqexQjZWZUEnQjdLoKSdlbtyU0GYiDTkPDUruVBx1YF7W7qOIEr5uhbPF2HKtU6VvsoKOHePfIZQa12rn0Q5s69jb0++ro1zHMZSV6eJox6RJg/7uHOKo5Ri8FRhHHZQxxbP/Pp4FTHvpfQyav2yOuq0l9mAAgzi9txWMfB1AXwZbbUceuE7UjwIDAQAB-----END PUBLIC KEY-----',
+      //   '-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtGTM5t++b2W9u8P7H4x1SGZPfeHyrhkxAIItxizIN9MSlRAdrnAreQVVj76GDdmWe/oKPnDUB/PR0yj2mzK8TqZhUxgh3SMhkxxLRWuicKiiOn9vNL5lHQdQotuh4REsoIwdIdVHQ5km73853NDk33xGb3qrQ7AJXCl3s0YRVfCqJd5Q2HWB9FEWm6Ojmryqwibz3S6lF2sjPqpif0XI2YBlDpjR/BTNKn351DgnxzXwAAW8uJV823DlOlcamGd3yNlv5wf3HMwZCkXPeYmAXs0F+QtrAOtUToURvXHnWX13s9/nx6wAwRPTzpWvPTo+rk8qqwuXJPbkN3F8J8j2twIDAQAB-----END PUBLIC KEY-----',
       // readyTimeout: 10000,
     },
   },

--- a/packages/live-update/example/package-lock.json
+++ b/packages/live-update/example/package-lock.json
@@ -15,13 +15,13 @@
       },
       "devDependencies": {
         "@capacitor/cli": "7.4.4",
-        "@capawesome/cli": "^3.8.0",
+        "@capawesome/cli": "4.11.0",
         "vite": "7.2.2"
       }
     },
     "..": {
       "name": "@capawesome/capacitor-live-update",
-      "version": "7.2.2",
+      "version": "7.5.0",
       "funding": [
         {
           "type": "github",
@@ -118,9 +118,9 @@
       "link": true
     },
     "node_modules/@capawesome/cli": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@capawesome/cli/-/cli-3.8.0.tgz",
-      "integrity": "sha512-S6pUTKAIbVoXyeyZ7NxhqjRtvHvedRz1AI8lLPJmTh/SdIn1gZQeqdaJOD5nebTkv39+y2S1Swxd45tzFaWmFQ==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@capawesome/cli/-/cli-4.11.0.tgz",
+      "integrity": "sha512-TYqo9H0PxWOjPCW9K8fZ5m2oE3vbLGg/8tO/FeESvvascX+hdKQZACjpwMrLpecllT+MubS7mPEaaAddtk+nYA==",
       "dev": true,
       "funding": [
         {
@@ -137,28 +137,28 @@
         "@clack/prompts": "0.7.0",
         "@robingenz/zli": "0.2.0",
         "@sentry/node": "8.55.0",
-        "archiver": "7.0.1",
-        "axios": "1.13.2",
+        "adm-zip": "0.5.16",
+        "axios": "1.16.0",
         "axios-retry": "4.5.0",
-        "c12": "2.0.1",
+        "c12": "3.3.3",
         "consola": "3.3.0",
         "form-data": "4.0.4",
+        "globby": "16.1.1",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
         "mime": "4.0.7",
         "open": "10.2.0",
         "rc9": "2.1.2",
         "semver": "7.6.3",
-        "std-env": "3.9.0",
-        "systeminformation": "5.25.11",
+        "systeminformation": "5.31.6",
         "zod": "4.0.17"
       },
       "bin": {
         "capawesome": "dist/index.js"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@capawesome/cli/node_modules/define-lazy-prop": {
@@ -235,6 +235,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -960,6 +961,44 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -1612,17 +1651,6 @@
         "@opentelemetry/api": "^1.1.0"
       }
     },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@prisma/instrumentation": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-5.22.0.tgz",
@@ -2071,6 +2099,19 @@
         "@opentelemetry/semantic-conventions": "^1.28.0"
       }
     },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.36",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
@@ -2174,19 +2215,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2208,6 +2236,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {
@@ -2246,44 +2284,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/archiver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
-      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^5.0.2",
-        "async": "^3.2.4",
-        "buffer-crc32": "^1.0.0",
-        "readable-stream": "^4.0.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^3.0.0",
-        "zip-stream": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/archiver-utils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
-      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^10.0.0",
-        "graceful-fs": "^4.2.0",
-        "is-stream": "^2.0.1",
-        "lazystream": "^1.0.0",
-        "lodash": "^4.17.15",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -2293,13 +2293,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -2319,15 +2312,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-retry": {
@@ -2343,27 +2336,22 @@
         "axios": "0.x || 1.x"
       }
     },
-    "node_modules/b4a": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
-      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/bare-events": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.1.tgz",
-      "integrity": "sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -2409,49 +2397,17 @@
         "node": ">= 5.10.0"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
-      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
-      "dev": true,
-      "license": "MIT",
+        "fill-range": "^7.1.1"
+      },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=8"
       }
     },
     "node_modules/bundle-name": {
@@ -2471,27 +2427,27 @@
       }
     },
     "node_modules/c12": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/c12/-/c12-2.0.1.tgz",
-      "integrity": "sha512-Z4JgsKXHG37C6PYUtIxCfLJZvo6FyhHJoClwwb9ftUkLpPSkuYqn6Tr+vnaN8hymm0kIbcg6Ey3kv/Q71k5w/A==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.3.tgz",
+      "integrity": "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chokidar": "^4.0.1",
-        "confbox": "^0.1.7",
+        "chokidar": "^5.0.0",
+        "confbox": "^0.2.2",
         "defu": "^6.1.4",
-        "dotenv": "^16.4.5",
-        "giget": "^1.2.3",
-        "jiti": "^2.3.0",
-        "mlly": "^1.7.1",
-        "ohash": "^1.1.4",
-        "pathe": "^1.1.2",
-        "perfect-debounce": "^1.0.0",
-        "pkg-types": "^1.2.0",
+        "dotenv": "^17.2.3",
+        "exsolve": "^1.0.8",
+        "giget": "^2.0.0",
+        "jiti": "^2.6.1",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^2.0.0",
+        "pkg-types": "^2.3.0",
         "rc9": "^2.1.2"
       },
       "peerDependencies": {
-        "magicast": "^0.3.5"
+        "magicast": "*"
       },
       "peerDependenciesMeta": {
         "magicast": {
@@ -2514,16 +2470,16 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -2599,27 +2555,10 @@
         "node": ">=18"
       }
     },
-    "node_modules/compress-commons": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
-      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "crc32-stream": "^6.0.0",
-        "is-stream": "^2.0.1",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2631,40 +2570,6 @@
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
-      }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/crc32-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
-      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/cross-spawn": {
@@ -2741,9 +2646,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2765,9 +2670,9 @@
       "license": "MIT"
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -2920,32 +2825,39 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
-    "node_modules/fast-fifo": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
@@ -2975,10 +2887,23 @@
         }
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -3156,9 +3081,9 @@
       }
     },
     "node_modules/giget": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/giget/-/giget-1.2.5.tgz",
-      "integrity": "sha512-r1ekGw/Bgpi3HLV3h1MRBIlSAdHoIMklpaQ3OQLFcRw9PwAj2rqigvIbg+dBUI51OxVI2jsEtDywDBjSiuf7Ug==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3166,9 +3091,8 @@
         "consola": "^3.4.0",
         "defu": "^6.1.4",
         "node-fetch-native": "^1.6.6",
-        "nypm": "^0.5.4",
-        "pathe": "^2.0.3",
-        "tar": "^6.2.1"
+        "nypm": "^0.6.0",
+        "pathe": "^2.0.3"
       },
       "bin": {
         "giget": "dist/cli.mjs"
@@ -3184,32 +3108,38 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
-    "node_modules/giget/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "is-glob": "^4.0.1"
       },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globby": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.1.1.tgz",
+      "integrity": "sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {
@@ -3302,26 +3232,15 @@
         "node": ">= 14"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/import-in-the-middle": {
       "version": "1.14.2",
@@ -3385,6 +3304,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3393,6 +3322,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-inside-container": {
@@ -3430,6 +3372,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-retry-allowed": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
@@ -3438,19 +3403,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3469,13 +3421,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3483,26 +3428,10 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/jiti": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
-      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3532,66 +3461,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/lazystream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
-      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.0.5"
-      },
-      "engines": {
-        "node": ">= 0.6.3"
-      }
-    },
-    "node_modules/lazystream/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/lazystream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lazystream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3600,6 +3469,43 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime": {
@@ -3639,22 +3545,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minipass": {
@@ -3706,26 +3596,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/mlly": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
-      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "pathe": "^2.0.3",
-        "pkg-types": "^1.3.1",
-        "ufo": "^1.6.1"
-      }
-    },
-    "node_modules/mlly/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
@@ -3793,58 +3663,35 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/nypm": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.5.4.tgz",
-      "integrity": "sha512-X0SNNrZiGU8/e/zAB7sCTtdxWTMSIO73q+xuKgglm2Yvzwlo8UoC5FNySQFCvl84uPaeADkqHUZUkWy4aH4xOA==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.6.tgz",
+      "integrity": "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.0",
+        "citty": "^0.2.2",
         "pathe": "^2.0.3",
-        "pkg-types": "^1.3.1",
-        "tinyexec": "^0.3.2",
-        "ufo": "^1.5.4"
+        "tinyexec": "^1.1.1"
       },
       "bin": {
         "nypm": "dist/cli.mjs"
       },
       "engines": {
-        "node": "^14.16.0 || >=16.10.0"
+        "node": ">=18"
       }
     },
-    "node_modules/nypm/node_modules/consola": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.18.0 || >=16.10.0"
-      }
-    },
-    "node_modules/nypm/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+    "node_modules/nypm/node_modules/citty": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ohash": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.6.tgz",
-      "integrity": "sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3890,27 +3737,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -3922,9 +3752,9 @@
       "license": "MIT"
     },
     "node_modules/perfect-debounce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
-      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
       "dev": true,
       "license": "MIT"
     },
@@ -3983,23 +3813,16 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.1.8",
-        "mlly": "^1.7.4",
-        "pathe": "^2.0.1"
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
+        "pathe": "^2.0.3"
       }
-    },
-    "node_modules/pkg-types/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/plist": {
       "version": "3.1.0",
@@ -4088,23 +3911,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -4130,10 +3936,34 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/rc9": {
@@ -4147,54 +3977,14 @@
         "destr": "^2.0.3"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/readdir-glob": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
-      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
@@ -4235,6 +4025,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rimraf": {
@@ -4395,6 +4196,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4480,6 +4305,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -4516,27 +4354,6 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
-      }
-    },
-    "node_modules/std-env": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
-      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/streamx": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
-      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-fifo": "^1.3.2",
-        "text-decoder": "^1.1.0"
-      },
-      "optionalDependencies": {
-        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string_decoder": {
@@ -4621,9 +4438,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.25.11",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.25.11.tgz",
-      "integrity": "sha512-jI01fn/t47rrLTQB0FTlMCC+5dYx8o0RRF+R4BPiUNsvg5OdY0s9DKMFmJGrx5SwMZQ4cag0Gl6v8oycso9b/g==",
+      "version": "5.31.6",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.6.tgz",
+      "integrity": "sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==",
       "dev": true,
       "license": "MIT",
       "os": [
@@ -4665,18 +4482,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/tar-stream": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
     "node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
@@ -4685,16 +4490,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/text-decoder": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.6.4"
       }
     },
     "node_modules/through2": {
@@ -4723,11 +4518,14 @@
       }
     },
     "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -4746,6 +4544,19 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -4762,19 +4573,25 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
-    "node_modules/ufo": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/undici-types": {
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -5033,21 +4850,6 @@
       "license": "MIT",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/zip-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
-      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^5.0.0",
-        "compress-commons": "^6.0.2",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/zod": {

--- a/packages/live-update/example/package.json
+++ b/packages/live-update/example/package.json
@@ -13,13 +13,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@capacitor/android": "7.6.5",
-    "@capacitor/core": "7.6.5",
-    "@capacitor/ios": "7.6.5",
+    "@capacitor/android": "7.4.4",
+    "@capacitor/core": "7.4.4",
+    "@capacitor/ios": "7.4.4",
     "@capawesome/capacitor-live-update": "file:.."
   },
   "devDependencies": {
-    "@capacitor/cli": "7.6.5",
+    "@capacitor/cli": "7.4.4",
     "@capawesome/cli": "4.11.0",
     "vite": "7.2.2"
   }

--- a/packages/live-update/example/package.json
+++ b/packages/live-update/example/package.json
@@ -13,14 +13,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@capacitor/android": "7.4.4",
-    "@capacitor/core": "7.4.4",
-    "@capacitor/ios": "7.4.4",
+    "@capacitor/android": "7.6.5",
+    "@capacitor/core": "7.6.5",
+    "@capacitor/ios": "7.6.5",
     "@capawesome/capacitor-live-update": "file:.."
   },
   "devDependencies": {
-    "@capacitor/cli": "7.4.4",
-    "@capawesome/cli": "^3.8.0",
+    "@capacitor/cli": "7.6.5",
+    "@capawesome/cli": "4.11.0",
     "vite": "7.2.2"
   }
 }

--- a/packages/live-update/example/src/index.html
+++ b/packages/live-update/example/src/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />

--- a/packages/live-update/example/src/index.html
+++ b/packages/live-update/example/src/index.html
@@ -94,6 +94,9 @@
           <ion-button id="download-bundle-button" expand="block"
             >Download Bundle</ion-button
           >
+          <ion-button id="fetch-channels-button" expand="block"
+            >Fetch Channels</ion-button
+          >
           <ion-button id="fetch-latest-bundle-button" expand="block"
             >Fetch Latest Bundle</ion-button
           >
@@ -114,6 +117,9 @@
           >
           <ion-button id="get-current-bundle-button" expand="block"
             >Get Current Bundle</ion-button
+          >
+          <ion-button id="get-default-channel-button" expand="block"
+            >Get Default Channel</ion-button
           >
           <ion-button id="get-custom-id-button" expand="block"
             >Get Custom ID</ion-button

--- a/packages/live-update/example/src/index.html
+++ b/packages/live-update/example/src/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />

--- a/packages/live-update/example/src/index.html
+++ b/packages/live-update/example/src/index.html
@@ -118,9 +118,6 @@
           <ion-button id="get-current-bundle-button" expand="block"
             >Get Current Bundle</ion-button
           >
-          <ion-button id="get-default-channel-button" expand="block"
-            >Get Default Channel</ion-button
-          >
           <ion-button id="get-custom-id-button" expand="block"
             >Get Custom ID</ion-button
           >

--- a/packages/live-update/example/src/js/script.js
+++ b/packages/live-update/example/src/js/script.js
@@ -87,6 +87,12 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     });
   document
+    .querySelector('#fetch-channels-button')
+    .addEventListener('click', async () => {
+      const result = await LiveUpdate.fetchChannels();
+      console.log(result);
+    });
+  document
     .querySelector('#fetch-latest-bundle-button')
     .addEventListener('click', async () => {
       const channel =
@@ -137,6 +143,12 @@ document.addEventListener('DOMContentLoaded', () => {
     .querySelector('#get-current-bundle-button')
     .addEventListener('click', async () => {
       const result = await LiveUpdate.getCurrentBundle();
+      console.log(result);
+    });
+  document
+    .querySelector('#get-default-channel-button')
+    .addEventListener('click', async () => {
+      const result = await LiveUpdate.getDefaultChannel();
       console.log(result);
     });
   document

--- a/packages/live-update/example/src/js/script.js
+++ b/packages/live-update/example/src/js/script.js
@@ -1,5 +1,20 @@
 import { LiveUpdate } from '@capawesome/capacitor-live-update';
 
+const showToast = async message => {
+  const toast = document.createElement('ion-toast');
+  toast.message = message;
+  toast.duration = 5000;
+  document.body.appendChild(toast);
+  await toast.present();
+};
+
+const originalNativePromise = window.Capacitor.nativePromise;
+window.Capacitor.nativePromise = (pluginName, methodName, options) =>
+  originalNativePromise(pluginName, methodName, options).catch(error => {
+    void showToast(error?.message ?? String(error));
+    throw error;
+  });
+
 document.addEventListener('DOMContentLoaded', () => {
   const addListeners = async () => {
     await LiveUpdate.removeAllListeners().then(() => {
@@ -143,12 +158,6 @@ document.addEventListener('DOMContentLoaded', () => {
     .querySelector('#get-current-bundle-button')
     .addEventListener('click', async () => {
       const result = await LiveUpdate.getCurrentBundle();
-      console.log(result);
-    });
-  document
-    .querySelector('#get-default-channel-button')
-    .addEventListener('click', async () => {
-      const result = await LiveUpdate.getDefaultChannel();
       console.log(result);
     });
   document

--- a/packages/live-update/ios/Plugin.xcodeproj/project.pbxproj
+++ b/packages/live-update/ios/Plugin.xcodeproj/project.pbxproj
@@ -48,6 +48,10 @@
 		7CA1DA9D2D454C0C001EB3D0 /* NextBundleSetEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CA1DA9E2D454C0C001EB3D0 /* NextBundleSetEvent.swift */; };
 		7CB7B8AE2CC9419800833086 /* FetchLatestBundleResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB7B8AD2CC9419000833086 /* FetchLatestBundleResult.swift */; };
 		7CD426B22D155B00003F93F9 /* SetNextBundleOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD426B12D155AFB003F93F9 /* SetNextBundleOptions.swift */; };
+		7CAB13012DEFB100003BC5A2 /* FetchChannelsOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB13002DEFB100003BC5A2 /* FetchChannelsOptions.swift */; };
+		7CAB13032DEFB110003BC5B3 /* ChannelResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB13022DEFB110003BC5B3 /* ChannelResult.swift */; };
+		7CAB13052DEFB120003BC5C4 /* FetchChannelsResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB13042DEFB120003BC5C4 /* FetchChannelsResult.swift */; };
+		7CAB13072DEFB130003BC5D5 /* GetChannelsResponseItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB13062DEFB130003BC5D5 /* GetChannelsResponseItem.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -105,6 +109,10 @@
 		7CA1DA9E2D454C0C001EB3D0 /* NextBundleSetEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextBundleSetEvent.swift; sourceTree = "<group>"; };
 		7CB7B8AD2CC9419000833086 /* FetchLatestBundleResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchLatestBundleResult.swift; sourceTree = "<group>"; };
 		7CD426B12D155AFB003F93F9 /* SetNextBundleOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetNextBundleOptions.swift; sourceTree = "<group>"; };
+		7CAB13002DEFB100003BC5A2 /* FetchChannelsOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchChannelsOptions.swift; sourceTree = "<group>"; };
+		7CAB13022DEFB110003BC5B3 /* ChannelResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelResult.swift; sourceTree = "<group>"; };
+		7CAB13042DEFB120003BC5C4 /* FetchChannelsResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchChannelsResult.swift; sourceTree = "<group>"; };
+		7CAB13062DEFB130003BC5D5 /* GetChannelsResponseItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetChannelsResponseItem.swift; sourceTree = "<group>"; };
 		91781294A431A2A7CC6EB714 /* Pods-Plugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Plugin.release.xcconfig"; path = "Pods/Target Support Files/Pods-Plugin/Pods-Plugin.release.xcconfig"; sourceTree = "<group>"; };
 		96ED1B6440D6672E406C8D19 /* Pods-PluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PluginTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PluginTests/Pods-PluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		F65BB2953ECE002E1EF3E424 /* Pods-PluginTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PluginTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PluginTests/Pods-PluginTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -202,6 +210,7 @@
 			isa = PBXGroup;
 			children = (
 				7CD426B12D155AFB003F93F9 /* SetNextBundleOptions.swift */,
+				7CAB13002DEFB100003BC5A2 /* FetchChannelsOptions.swift */,
 				7C4274D62D1487530066184E /* FetchLatestBundleOptions.swift */,
 				7C4274D42D14874E0066184E /* SyncOptions.swift */,
 				7C2011562BA9661B001FABAD /* DeleteBundleOptions.swift */,
@@ -218,6 +227,8 @@
 			children = (
 				7C4F2B132D149296005E2310 /* GetNextBundleResult.swift */,
 				7C4F2B112D14928F005E2310 /* GetCurrentBundleResult.swift */,
+				7CAB13022DEFB110003BC5B3 /* ChannelResult.swift */,
+				7CAB13042DEFB120003BC5C4 /* FetchChannelsResult.swift */,
 				7CB7B8AD2CC9419000833086 /* FetchLatestBundleResult.swift */,
 				7C2011522BA96555001FABAD /* GetBundlesResult.swift */,
 				7CAB12552DEFA2D0003BB3E6 /* GetBlockedBundlesResult.swift */,
@@ -248,6 +259,7 @@
 			isa = PBXGroup;
 			children = (
 				7C29FB572CBCEE4B007DCB06 /* ManifestItem.swift */,
+				7CAB13062DEFB130003BC5D5 /* GetChannelsResponseItem.swift */,
 				7C9B252B2BBED5DA0007ED74 /* GetLatestBundleResponse.swift */,
 			);
 			path = Api;
@@ -497,6 +509,10 @@
 				7CAB12672DEFA3E0003BB4F7 /* SetConfigOptions.swift in Sources */,
 				7C6715CF2BB1BC920000878A /* SetChannelOptions.swift in Sources */,
 				7C4274D52D1487500066184E /* SyncOptions.swift in Sources */,
+				7CAB13012DEFB100003BC5A2 /* FetchChannelsOptions.swift in Sources */,
+				7CAB13032DEFB110003BC5B3 /* ChannelResult.swift in Sources */,
+				7CAB13052DEFB120003BC5C4 /* FetchChannelsResult.swift in Sources */,
+				7CAB13072DEFB130003BC5D5 /* GetChannelsResponseItem.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/live-update/ios/Plugin.xcodeproj/project.pbxproj
+++ b/packages/live-update/ios/Plugin.xcodeproj/project.pbxproj
@@ -17,8 +17,6 @@
 		7C0C8C492BAB354A005F76D1 /* LiveUpdateConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0C8C482BAB354A005F76D1 /* LiveUpdateConfig.swift */; };
 		7C2011512BA9653B001FABAD /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C2011502BA9653B001FABAD /* Result.swift */; };
 		7C2011532BA96555001FABAD /* GetBundlesResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C2011522BA96555001FABAD /* GetBundlesResult.swift */; };
-		7CAB12562DEFA2D0003BB3E6 /* GetBlockedBundlesResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB12552DEFA2D0003BB3E6 /* GetBlockedBundlesResult.swift */; };
-		7CAB12452DEFA1C0003BB2D5 /* GetDownloadedBundlesResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB12442DEFA1C0003BB2D5 /* GetDownloadedBundlesResult.swift */; };
 		7C2011572BA9661B001FABAD /* DeleteBundleOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C2011562BA9661B001FABAD /* DeleteBundleOptions.swift */; };
 		7C2011592BA966F4001FABAD /* DownloadBundleOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C2011582BA966F4001FABAD /* DownloadBundleOptions.swift */; };
 		7C29FB502CBAB671007DCB06 /* LiveUpdateHttpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C29FB4F2CBAB66C007DCB06 /* LiveUpdateHttpClient.swift */; };
@@ -29,15 +27,12 @@
 		7C33FC432BCBFE27003AA8B4 /* GetVersionCodeResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C33FC422BCBFE27003AA8B4 /* GetVersionCodeResult.swift */; };
 		7C33FC452BCBFE3A003AA8B4 /* GetVersionNameResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C33FC442BCBFE3A003AA8B4 /* GetVersionNameResult.swift */; };
 		7C4274D52D1487500066184E /* SyncOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C4274D42D14874E0066184E /* SyncOptions.swift */; };
-		7CAB12342DEFA1B0003BB1C4 /* IsSyncingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB12332DEFA1B0003BB1C4 /* IsSyncingResult.swift */; };
 		7C4274D72D1487590066184E /* FetchLatestBundleOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C4274D62D1487530066184E /* FetchLatestBundleOptions.swift */; };
 		7C4F2B122D149290005E2310 /* GetCurrentBundleResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C4F2B112D14928F005E2310 /* GetCurrentBundleResult.swift */; };
 		7C4F2B142D149296005E2310 /* GetNextBundleResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C4F2B132D149296005E2310 /* GetNextBundleResult.swift */; };
 		7C62B6512BA9AD220025240F /* CustomError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C62B6502BA9AD220025240F /* CustomError.swift */; };
 		7C6715CF2BB1BC920000878A /* SetChannelOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C6715CE2BB1BC920000878A /* SetChannelOptions.swift */; };
-		7CAB12672DEFA3E0003BB4F7 /* SetConfigOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB12662DEFA3E0003BB4F7 /* SetConfigOptions.swift */; };
 		7C6715D12BB1BC9E0000878A /* SetCustomIdOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C6715D02BB1BC9E0000878A /* SetCustomIdOptions.swift */; };
-		7CAB12782DEFA3F0003BB5F8 /* GetConfigResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB12772DEFA3F0003BB5F8 /* GetConfigResult.swift */; };
 		7C6715D32BB1BCAB0000878A /* GetChannelResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C6715D22BB1BCAB0000878A /* GetChannelResult.swift */; };
 		7C6715D52BB1BCB70000878A /* GetDeviceIdResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C6715D42BB1BCB70000878A /* GetDeviceIdResult.swift */; };
 		7C6715D72BB1BCC20000878A /* GetCustomIdResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C6715D62BB1BCC20000878A /* GetCustomIdResult.swift */; };
@@ -46,12 +41,17 @@
 		7CA18F442C5E1FFE00D0BE5B /* ReadyResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CA18F432C5E1FFE00D0BE5B /* ReadyResult.swift */; };
 		7CA1DA9C2D454C0B001EB3D0 /* DownloadBundleProgressEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CA1DA9B2D454C0A001EB3D0 /* DownloadBundleProgressEvent.swift */; };
 		7CA1DA9D2D454C0C001EB3D0 /* NextBundleSetEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CA1DA9E2D454C0C001EB3D0 /* NextBundleSetEvent.swift */; };
-		7CB7B8AE2CC9419800833086 /* FetchLatestBundleResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB7B8AD2CC9419000833086 /* FetchLatestBundleResult.swift */; };
-		7CD426B22D155B00003F93F9 /* SetNextBundleOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD426B12D155AFB003F93F9 /* SetNextBundleOptions.swift */; };
+		7CAB12342DEFA1B0003BB1C4 /* IsSyncingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB12332DEFA1B0003BB1C4 /* IsSyncingResult.swift */; };
+		7CAB12452DEFA1C0003BB2D5 /* GetDownloadedBundlesResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB12442DEFA1C0003BB2D5 /* GetDownloadedBundlesResult.swift */; };
+		7CAB12562DEFA2D0003BB3E6 /* GetBlockedBundlesResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB12552DEFA2D0003BB3E6 /* GetBlockedBundlesResult.swift */; };
+		7CAB12672DEFA3E0003BB4F7 /* SetConfigOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB12662DEFA3E0003BB4F7 /* SetConfigOptions.swift */; };
+		7CAB12782DEFA3F0003BB5F8 /* GetConfigResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB12772DEFA3F0003BB5F8 /* GetConfigResult.swift */; };
 		7CAB13012DEFB100003BC5A2 /* FetchChannelsOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB13002DEFB100003BC5A2 /* FetchChannelsOptions.swift */; };
 		7CAB13032DEFB110003BC5B3 /* ChannelResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB13022DEFB110003BC5B3 /* ChannelResult.swift */; };
 		7CAB13052DEFB120003BC5C4 /* FetchChannelsResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB13042DEFB120003BC5C4 /* FetchChannelsResult.swift */; };
 		7CAB13072DEFB130003BC5D5 /* GetChannelsResponseItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAB13062DEFB130003BC5D5 /* GetChannelsResponseItem.swift */; };
+		7CB7B8AE2CC9419800833086 /* FetchLatestBundleResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB7B8AD2CC9419000833086 /* FetchLatestBundleResult.swift */; };
+		7CD426B22D155B00003F93F9 /* SetNextBundleOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD426B12D155AFB003F93F9 /* SetNextBundleOptions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -77,9 +77,7 @@
 		5E23F77F099397094342571A /* Pods-Plugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Plugin.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Plugin/Pods-Plugin.debug.xcconfig"; sourceTree = "<group>"; };
 		7C0C8C482BAB354A005F76D1 /* LiveUpdateConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveUpdateConfig.swift; sourceTree = "<group>"; };
 		7C2011502BA9653B001FABAD /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
-		7CAB12552DEFA2D0003BB3E6 /* GetBlockedBundlesResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBlockedBundlesResult.swift; sourceTree = "<group>"; };
 		7C2011522BA96555001FABAD /* GetBundlesResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBundlesResult.swift; sourceTree = "<group>"; };
-		7CAB12442DEFA1C0003BB2D5 /* GetDownloadedBundlesResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDownloadedBundlesResult.swift; sourceTree = "<group>"; };
 		7C2011562BA9661B001FABAD /* DeleteBundleOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteBundleOptions.swift; sourceTree = "<group>"; };
 		7C2011582BA966F4001FABAD /* DownloadBundleOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadBundleOptions.swift; sourceTree = "<group>"; };
 		7C29FB4F2CBAB66C007DCB06 /* LiveUpdateHttpClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveUpdateHttpClient.swift; sourceTree = "<group>"; };
@@ -90,11 +88,8 @@
 		7C33FC422BCBFE27003AA8B4 /* GetVersionCodeResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetVersionCodeResult.swift; sourceTree = "<group>"; };
 		7C33FC442BCBFE3A003AA8B4 /* GetVersionNameResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetVersionNameResult.swift; sourceTree = "<group>"; };
 		7C4274D42D14874E0066184E /* SyncOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncOptions.swift; sourceTree = "<group>"; };
-		7CAB12332DEFA1B0003BB1C4 /* IsSyncingResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IsSyncingResult.swift; sourceTree = "<group>"; };
 		7C4274D62D1487530066184E /* FetchLatestBundleOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchLatestBundleOptions.swift; sourceTree = "<group>"; };
-		7CAB12662DEFA3E0003BB4F7 /* SetConfigOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetConfigOptions.swift; sourceTree = "<group>"; };
 		7C4F2B112D14928F005E2310 /* GetCurrentBundleResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCurrentBundleResult.swift; sourceTree = "<group>"; };
-		7CAB12772DEFA3F0003BB5F8 /* GetConfigResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetConfigResult.swift; sourceTree = "<group>"; };
 		7C4F2B132D149296005E2310 /* GetNextBundleResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetNextBundleResult.swift; sourceTree = "<group>"; };
 		7C62B6502BA9AD220025240F /* CustomError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomError.swift; sourceTree = "<group>"; };
 		7C6715CE2BB1BC920000878A /* SetChannelOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetChannelOptions.swift; sourceTree = "<group>"; };
@@ -107,12 +102,17 @@
 		7CA18F432C5E1FFE00D0BE5B /* ReadyResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadyResult.swift; sourceTree = "<group>"; };
 		7CA1DA9B2D454C0A001EB3D0 /* DownloadBundleProgressEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadBundleProgressEvent.swift; sourceTree = "<group>"; };
 		7CA1DA9E2D454C0C001EB3D0 /* NextBundleSetEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextBundleSetEvent.swift; sourceTree = "<group>"; };
-		7CB7B8AD2CC9419000833086 /* FetchLatestBundleResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchLatestBundleResult.swift; sourceTree = "<group>"; };
-		7CD426B12D155AFB003F93F9 /* SetNextBundleOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetNextBundleOptions.swift; sourceTree = "<group>"; };
+		7CAB12332DEFA1B0003BB1C4 /* IsSyncingResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IsSyncingResult.swift; sourceTree = "<group>"; };
+		7CAB12442DEFA1C0003BB2D5 /* GetDownloadedBundlesResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDownloadedBundlesResult.swift; sourceTree = "<group>"; };
+		7CAB12552DEFA2D0003BB3E6 /* GetBlockedBundlesResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBlockedBundlesResult.swift; sourceTree = "<group>"; };
+		7CAB12662DEFA3E0003BB4F7 /* SetConfigOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetConfigOptions.swift; sourceTree = "<group>"; };
+		7CAB12772DEFA3F0003BB5F8 /* GetConfigResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetConfigResult.swift; sourceTree = "<group>"; };
 		7CAB13002DEFB100003BC5A2 /* FetchChannelsOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchChannelsOptions.swift; sourceTree = "<group>"; };
 		7CAB13022DEFB110003BC5B3 /* ChannelResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelResult.swift; sourceTree = "<group>"; };
 		7CAB13042DEFB120003BC5C4 /* FetchChannelsResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchChannelsResult.swift; sourceTree = "<group>"; };
 		7CAB13062DEFB130003BC5D5 /* GetChannelsResponseItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetChannelsResponseItem.swift; sourceTree = "<group>"; };
+		7CB7B8AD2CC9419000833086 /* FetchLatestBundleResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchLatestBundleResult.swift; sourceTree = "<group>"; };
+		7CD426B12D155AFB003F93F9 /* SetNextBundleOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetNextBundleOptions.swift; sourceTree = "<group>"; };
 		91781294A431A2A7CC6EB714 /* Pods-Plugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Plugin.release.xcconfig"; path = "Pods/Target Support Files/Pods-Plugin/Pods-Plugin.release.xcconfig"; sourceTree = "<group>"; };
 		96ED1B6440D6672E406C8D19 /* Pods-PluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PluginTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PluginTests/Pods-PluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		F65BB2953ECE002E1EF3E424 /* Pods-PluginTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PluginTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PluginTests/Pods-PluginTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -434,14 +434,14 @@
 				"${BUILT_PRODUCTS_DIR}/Capacitor/Capacitor.framework",
 				"${BUILT_PRODUCTS_DIR}/CapacitorCordova/Cordova.framework",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
-				"${BUILT_PRODUCTS_DIR}/SSZipArchive/SSZipArchive.framework",
+				"${BUILT_PRODUCTS_DIR}/ZIPFoundation/ZIPFoundation.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Capacitor.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Cordova.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SSZipArchive.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZIPFoundation.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/packages/live-update/ios/Plugin/Classes/Options/FetchChannelsOptions.swift
+++ b/packages/live-update/ios/Plugin/Classes/Options/FetchChannelsOptions.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Capacitor
+
+@objc public class FetchChannelsOptions: NSObject {
+    private var limit: Int?
+    private var offset: Int?
+    private var query: String?
+
+    init(_ call: CAPPluginCall) {
+        self.limit = call.getInt("limit") as Int?
+        self.offset = call.getInt("offset") as Int?
+        self.query = call.getString("query")
+    }
+
+    func getLimit() -> Int? {
+        return limit
+    }
+
+    func getOffset() -> Int? {
+        return offset
+    }
+
+    func getQuery() -> String? {
+        return query
+    }
+}

--- a/packages/live-update/ios/Plugin/Classes/Results/ChannelResult.swift
+++ b/packages/live-update/ios/Plugin/Classes/Results/ChannelResult.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Capacitor
+
+@objc public class ChannelResult: NSObject, Result {
+    private let id: String
+    private let name: String
+
+    init(id: String, name: String) {
+        self.id = id
+        self.name = name
+    }
+
+    public func toJSObject() -> AnyObject {
+        var result = JSObject()
+        result["id"] = id
+        result["name"] = name
+        return result as AnyObject
+    }
+}

--- a/packages/live-update/ios/Plugin/Classes/Results/FetchChannelsResult.swift
+++ b/packages/live-update/ios/Plugin/Classes/Results/FetchChannelsResult.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Capacitor
+
+@objc public class FetchChannelsResult: NSObject, Result {
+    private let channels: [ChannelResult]
+
+    init(channels: [ChannelResult]) {
+        self.channels = channels
+    }
+
+    public func toJSObject() -> AnyObject {
+        var result = JSObject()
+        result["channels"] = channels.map { $0.toJSObject() }
+        return result as AnyObject
+    }
+}

--- a/packages/live-update/ios/Plugin/LiveUpdate.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdate.swift
@@ -608,6 +608,9 @@ import CommonCrypto
 
     private func getChannel() -> String? {
         var channel: String?
+        if let nativeChannel = getNativeChannel() {
+            channel = nativeChannel
+        }
         if let _ = config.defaultChannel {
             channel = config.defaultChannel
         }
@@ -615,6 +618,10 @@ import CommonCrypto
             channel = preferences.getChannel()
         }
         return channel
+    }
+
+    private func getNativeChannel() -> String? {
+        return Bundle.main.object(forInfoDictionaryKey: "CapawesomeLiveUpdateDefaultChannel") as? String
     }
 
     /// - Returns: The sha256 checksum of the file at the given URL.

--- a/packages/live-update/ios/Plugin/LiveUpdate.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdate.swift
@@ -1,10 +1,6 @@
 import Foundation
 import CryptoKit
-#if canImport(ZipArchive)
-import ZipArchive
-#else
-import SSZipArchive
-#endif
+import ZIPFoundation
 import Capacitor
 import Alamofire
 import CommonCrypto
@@ -356,7 +352,7 @@ import CommonCrypto
 
     private func addBundleOfTypeZip(bundleId: String, zipFile: URL) async throws {
         // Unzip the bundle
-        let unzippedDirectory = self.unzipFile(zipFile: zipFile)
+        let unzippedDirectory = try self.unzipFile(zipFile: zipFile)
         // Add the bundle
         try self.addBundle(bundleId: bundleId, directory: unzippedDirectory)
     }
@@ -963,9 +959,10 @@ import CommonCrypto
         }
     }
 
-    private func unzipFile(zipFile: URL) -> URL {
+    private func unzipFile(zipFile: URL) throws -> URL {
         let destinationDirectory = zipFile.deletingPathExtension()
-        SSZipArchive.unzipFile(atPath: zipFile.path, toDestination: destinationDirectory.path)
+        try FileManager.default.createDirectory(at: destinationDirectory, withIntermediateDirectories: true, attributes: nil)
+        try FileManager.default.unzipItem(at: zipFile, to: destinationDirectory)
         return destinationDirectory
     }
 

--- a/packages/live-update/ios/Plugin/LiveUpdate.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdate.swift
@@ -87,6 +87,36 @@ import CommonCrypto
         }
     }
 
+    @objc public func fetchChannels(_ options: FetchChannelsOptions) async throws -> FetchChannelsResult {
+        var parameters = [String: String]()
+        if let limit = options.getLimit() {
+            parameters["limit"] = String(limit)
+        }
+        if let offset = options.getOffset() {
+            parameters["offset"] = String(offset)
+        }
+        if let query = options.getQuery() {
+            parameters["query"] = query
+        }
+        var urlComponents = URLComponents(string: "https://\(config.serverDomain)/v1/apps/\(getAppId() ?? "")/channels")!
+        if !parameters.isEmpty {
+            urlComponents.queryItems = parameters.map { URLQueryItem(name: $0.key, value: $0.value) }
+        }
+        let url = try urlComponents.asURL()
+        let response = try await self.httpClient.request(url: url, type: [GetChannelsResponseItem].self)
+        if let error = response.error {
+            if let urlError = error.underlyingError as? URLError {
+                if urlError.code == .timedOut {
+                    throw urlError
+                }
+            }
+            throw error
+        }
+        let items = response.value ?? []
+        let channels = items.map { ChannelResult(id: $0.id, name: $0.name) }
+        return FetchChannelsResult(channels: channels)
+    }
+
     @objc public func fetchLatestBundle(_ options: FetchLatestBundleOptions) async throws -> FetchLatestBundleResult {
         let response: GetLatestBundleResponse? = try await self.fetchLatestBundle(options)
         return FetchLatestBundleResult(artifactType: response?.artifactType, bundleId: response?.bundleId, checksum: response?.checksum, customProperties: response?.customProperties, downloadUrl: response?.url, signature: response?.signature)

--- a/packages/live-update/ios/Plugin/LiveUpdate.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdate.swift
@@ -38,6 +38,9 @@ import CommonCrypto
         // Check version and reset config if version changed
         checkAndResetConfigIfVersionChanged()
 
+        // Set the device ID on the HTTP client (after any potential config reset)
+        self.httpClient.setDeviceId(getDeviceId())
+
         // Start the rollback timer to rollback to the default bundle
         // if the app is not ready after a certain time
         startRollbackTimer()

--- a/packages/live-update/ios/Plugin/LiveUpdateHttpClient.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdateHttpClient.swift
@@ -5,6 +5,7 @@ import Alamofire
 public class LiveUpdateHttpClient: NSObject {
 
     private let config: LiveUpdateConfig
+    private var deviceId: String?
 
     public static func getChecksumFromResponse(response: HTTPURLResponse) -> String? {
         guard let headers = response.allHeaderFields as? [String: String] else { return nil }
@@ -20,10 +21,17 @@ public class LiveUpdateHttpClient: NSObject {
         self.config = config
     }
 
+    public func setDeviceId(_ deviceId: String) {
+        self.deviceId = deviceId
+    }
+
     public func download(url: URL, destination: @escaping DownloadRequest.Destination, callback: ((Progress) -> Void)?) async throws -> AFDownloadResponse<Data> {
         var request = URLRequest(url: url)
         request.httpMethod = HTTPMethod.get.rawValue
         request.timeoutInterval = Double(config.httpTimeout) / 1000.0
+        if let deviceId = deviceId, !deviceId.isEmpty {
+            request.setValue(deviceId, forHTTPHeaderField: "X-Device-Id")
+        }
         return try await withCheckedThrowingContinuation { continuation in
             AF.download(request, to: destination).downloadProgress { progress in
                 if let callback = callback {
@@ -39,6 +47,9 @@ public class LiveUpdateHttpClient: NSObject {
         var request = URLRequest(url: url)
         request.httpMethod = HTTPMethod.get.rawValue
         request.timeoutInterval = Double(config.httpTimeout) / 1000.0
+        if let deviceId = deviceId, !deviceId.isEmpty {
+            request.setValue(deviceId, forHTTPHeaderField: "X-Device-Id")
+        }
         return try await withCheckedThrowingContinuation { continuation in
             AF.request(request).validate().responseDecodable(of: type) { response in
                 continuation.resume(returning: response)

--- a/packages/live-update/ios/Plugin/LiveUpdatePlugin.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdatePlugin.swift
@@ -17,6 +17,7 @@ public class LiveUpdatePlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "clearBlockedBundles", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "deleteBundle", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "downloadBundle", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "fetchChannels", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "fetchLatestBundle", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getBlockedBundles", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getBundles", returnType: CAPPluginReturnPromise),
@@ -105,6 +106,25 @@ public class LiveUpdatePlugin: CAPPlugin, CAPBridgedPlugin {
 
                 try await implementation?.downloadBundle(options)
                 self.resolveCall(call)
+            } catch {
+                rejectCall(call, error)
+            }
+        }
+    }
+
+    @objc func fetchChannels(_ call: CAPPluginCall) {
+        Task {
+            do {
+                guard let appId = config?.appId, !appId.isEmpty else {
+                    call.reject(CustomError.appIdMissing.localizedDescription)
+                    return
+                }
+
+                let options = FetchChannelsOptions(call)
+                let result = try await implementation?.fetchChannels(options)
+                if let result = result?.toJSObject() as? JSObject {
+                    self.resolveCall(call, result)
+                }
             } catch {
                 rejectCall(call, error)
             }

--- a/packages/live-update/ios/Plugin/LiveUpdatePlugin.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdatePlugin.swift
@@ -8,7 +8,7 @@ import Capacitor
 @objc(LiveUpdatePlugin)
 public class LiveUpdatePlugin: CAPPlugin, CAPBridgedPlugin {
     public static let tag = "LiveUpdate"
-    public static let version = "7.4.0"
+    public static let version = "7.5.0"
     public static let userDefaultsPrefix = "CapawesomeLiveUpdate" // DO NOT CHANGE
 
     public let identifier = "LiveUpdatePlugin"

--- a/packages/live-update/ios/Plugin/Protocols/Api/GetChannelsResponseItem.swift
+++ b/packages/live-update/ios/Plugin/Protocols/Api/GetChannelsResponseItem.swift
@@ -1,0 +1,4 @@
+public struct GetChannelsResponseItem: Codable {
+    var id: String
+    var name: String
+}

--- a/packages/live-update/ios/Podfile
+++ b/packages/live-update/ios/Podfile
@@ -23,7 +23,7 @@ end
 target 'Plugin' do
   capacitor_pods
   pod 'Alamofire', '5.9.0'
-  pod 'SSZipArchive', '2.2.3'
+  pod 'ZIPFoundation', '~> 0.9.0'
 end
 
 target 'PluginTests' do

--- a/packages/live-update/package.json
+++ b/packages/live-update/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capawesome/capacitor-live-update",
-  "version": "7.4.0",
+  "version": "7.5.0",
   "description": "Capacitor plugin to update your app remotely in real-time.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/packages/live-update/package.json
+++ b/packages/live-update/package.json
@@ -65,11 +65,11 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "7.0.0",
-    "@capacitor/cli": "7.0.0",
-    "@capacitor/core": "7.0.0",
+    "@capacitor/android": "7.6.5",
+    "@capacitor/cli": "7.6.5",
+    "@capacitor/core": "7.6.5",
     "@capacitor/docgen": "0.3.0",
-    "@capacitor/ios": "7.0.0",
+    "@capacitor/ios": "7.6.5",
     "@ionic/eslint-config": "0.4.0",
     "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",

--- a/packages/live-update/package.json
+++ b/packages/live-update/package.json
@@ -65,11 +65,11 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "7.6.5",
-    "@capacitor/cli": "7.6.5",
-    "@capacitor/core": "7.6.5",
+    "@capacitor/android": "7.0.0",
+    "@capacitor/cli": "7.0.0",
+    "@capacitor/core": "7.0.0",
     "@capacitor/docgen": "0.3.0",
-    "@capacitor/ios": "7.6.5",
+    "@capacitor/ios": "7.0.0",
     "@ionic/eslint-config": "0.4.0",
     "@ionic/swiftlint-config": "2.0.0",
     "eslint": "8.57.0",

--- a/packages/live-update/src/definitions.ts
+++ b/packages/live-update/src/definitions.ts
@@ -57,6 +57,11 @@ declare module '@capacitor/cli' {
       /**
        * The default channel of the app.
        *
+       * This can be overridden by `setChannel()` or the `channel` parameter of `sync()`.
+       * It takes priority over the native channel configuration
+       * (`CapawesomeLiveUpdateDefaultChannel` in `Info.plist` on iOS or `capawesome_live_update_default_channel`
+       * in `strings.xml` on Android).
+       *
        * @since 6.3.0
        * @example 'production'
        */
@@ -165,6 +170,15 @@ export interface LiveUpdatePlugin {
   getBundles(): Promise<GetBundlesResult>;
   /**
    * Get the channel that is used for the update.
+   *
+   * The channel is resolved in the following order (highest priority first):
+   * 1. `setChannel()` (SharedPreferences on Android / UserDefaults on iOS)
+   * 2. Capacitor config `defaultChannel`
+   * 3. Native config (`CapawesomeLiveUpdateDefaultChannel` in `Info.plist` on iOS or
+   *    `capawesome_live_update_default_channel` in `strings.xml` on Android)
+   *
+   * **Note**: The `channel` parameter of `sync()` takes the highest priority
+   * but is not persisted and therefore not returned by this method.
    *
    * Only available on Android and iOS.
    *

--- a/packages/live-update/src/definitions.ts
+++ b/packages/live-update/src/definitions.ts
@@ -139,6 +139,22 @@ export interface LiveUpdatePlugin {
    */
   downloadBundle(options: DownloadBundleOptions): Promise<void>;
   /**
+   * Fetch channels from [Capawesome Cloud](https://capawesome.io/cloud/).
+   *
+   * This is primarily intended for development and QA purposes.
+   * It allows you to retrieve a list of available channels so you can
+   * dynamically switch between them using `setChannel(...)`.
+   *
+   * **Attention**: Only works for apps with public channels enabled.
+   * If channels are private, they can still be set using `setChannel(...)`
+   * but won't be returned by this method.
+   *
+   * Only available on Android and iOS.
+   *
+   * @since 7.5.0
+   */
+  fetchChannels(options?: FetchChannelsOptions): Promise<FetchChannelsResult>;
+  /**
    * Fetch the latest bundle using the [Capawesome Cloud](https://capawesome.io/cloud/).
    *
    * Only available on Android and iOS.
@@ -479,6 +495,62 @@ export interface DownloadBundleOptions {
    * @example 'https://example.com/bundle.zip'
    */
   url: string;
+}
+
+/**
+ * @since 7.5.0
+ */
+export interface FetchChannelsOptions {
+  /**
+   * The maximum number of channels to return.
+   *
+   * @since 7.5.0
+   * @default 50
+   */
+  limit?: number;
+  /**
+   * The number of channels to skip.
+   *
+   * @since 7.5.0
+   * @default 0
+   */
+  offset?: number;
+  /**
+   * The query to filter channels by name.
+   *
+   * @since 7.5.0
+   */
+  query?: string;
+}
+
+/**
+ * @since 7.5.0
+ */
+export interface FetchChannelsResult {
+  /**
+   * The list of channels.
+   *
+   * @since 7.5.0
+   */
+  channels: Channel[];
+}
+
+/**
+ * @since 7.5.0
+ */
+export interface Channel {
+  /**
+   * The unique identifier of the channel.
+   *
+   * @since 7.5.0
+   */
+  id: string;
+  /**
+   * The name of the channel.
+   *
+   * @since 7.5.0
+   */
+  name: string;
 }
 
 /**

--- a/packages/live-update/src/web.ts
+++ b/packages/live-update/src/web.ts
@@ -3,6 +3,7 @@ import { WebPlugin } from '@capacitor/core';
 import type {
   DeleteBundleOptions,
   DownloadBundleOptions,
+  FetchChannelsResult,
   FetchLatestBundleResult,
   GetBlockedBundlesResult,
   GetBundleResult,
@@ -37,6 +38,10 @@ export class LiveUpdateWeb extends WebPlugin implements LiveUpdatePlugin {
   }
 
   public async downloadBundle(_options: DownloadBundleOptions): Promise<void> {
+    this.throwUnimplementedError();
+  }
+
+  public async fetchChannels(): Promise<FetchChannelsResult> {
     this.throwUnimplementedError();
   }
 


### PR DESCRIPTION
Backports the Capacitor-7-compatible features and fixes from the 8.x release line into a new **7.5.0** release.

## Included (8.x → 7.5.0)

### Minor
- feat: add native channel configuration support (#783)
- feat: add `fetchChannels(...)` method (#787)
- feat: track device ID on bundle download (#785)

### Patch
- fix(android): clear zip file attributes before extraction to prevent EACCES errors (#792)
- fix(android): prevent crash during bundle cleanup when a directory is unreadable (#855)
- refactor(ios): replace SSZipArchive with ZIPFoundation for bundle extraction

## Excluded (not applicable to Capacitor 7)
- Capacitor 8 migration / dependency bumps / min-iOS-16
- Minimum iOS 15 deployment target (#721)
- AGP 9.0 ProGuard fix (#776) — Capacitor-8-era Android Gradle Plugin

## Verification
- TypeScript build + eslint: clean
- Android: `./gradlew clean build test` → **BUILD SUCCESSFUL**
- iOS: `pod install` + `xcodebuild` → **BUILD SUCCEEDED**

`@since` tags for new APIs are set to `7.5.0` (the version where they become available on the v7 line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
