### PR TITLE
fix(live-update): widen Alamofire range to allow 5.11.x

### DIFF
--- a/packages/live-update/Package.swift
+++ b/packages/live-update/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
-        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMinor(from: "5.10.2")),
+        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMinor(from: "5.11.2")),
         .package(url: "https://github.com/weichsel/ZIPFoundation.git", .upToNextMinor(from: "0.9.0"))
     ],
     targets: [


### PR DESCRIPTION
## Summary

The current Alamofire pin in `packages/live-update/Package.swift` —

```swift
.package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMinor(from: "5.10.2")),
```

— resolves to `>=5.10.2 <5.11.0`, which conflicts with [`@capgo/capacitor-social-login`](https://github.com/Cap-go/capacitor-social-login)'s pin of `.upToNextMajor(from: "5.11.2")` (`>=5.11.2 <6.0.0`). Any Capacitor app that uses both plugins fails SPM resolution with:

```
Failed to resolve dependencies: 'capacitor-live-update' depends on 'alamofire'
5.10.2..<5.11.0 and 'capacitor-social-login' depends on 'alamofire' 5.11.2..<6.0.0.
```

This blocks live-update adoption in apps that already have Apple/Google sign-in via Capgo Social Login.

## Change

Relax the constraint to `.upToNextMinor(from: "5.11.2")`:

```diff
- .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMinor(from: "5.10.2")),
+ .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMinor(from: "5.11.2")),
```

This puts both plugins on overlapping ranges. Stays out of 5.12 deliberately — the 5.12 `AuthenticationInterceptor` semantics change doesn't affect this plugin, but principle of least change.

## Risk

Reviewed Alamofire's [CHANGELOG](https://github.com/Alamofire/Alamofire/blob/master/CHANGELOG.md) 5.10.2 → 5.11.2 for breaking changes to APIs this plugin uses (`AF.download`, `AF.request`):

- **5.11.0** introduced "lazy Request setup" — Requests are inert until `resume()`'d. **Auto-resume still fires when response handlers are attached**, which is the standard Capacitor plugin pattern, so existing call sites are unaffected.
- **5.11.0** requires Xcode 16 + Swift 6 compiler. Most Capacitor 8 apps targeting iOS 18+ should already be on Xcode 16.
- **5.11.1 / 5.11.2** are pure bug-fix releases.

## Repro / test plan

1. `npm install @capgo/capacitor-social-login@latest @capawesome/capacitor-live-update@8.2.3`
2. `npx cap sync ios`
3. Open Xcode → SPM fails to resolve.
4. With this patch (or locally via `patch-package`): SPM resolves successfully, both plugins build, live-update bundles download as expected.

## Local validation

Tested locally in a production Capacitor 8 app via `patch-package` with the same one-line change. Plugin builds, `LiveUpdate.ready()` succeeds, `nextBundleSet` fires, bundle download/install round-trip works on iOS 18 / Xcode 16.
