### PR TITLE
fix(live-update): widen Alamofire dependency range to allow newer 5.x

### DIFF
--- a/.changeset/alamofire-uptonextmajor.md
+++ b/.changeset/alamofire-uptonextmajor.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-live-update': patch
+---
+
+fix: widen the Alamofire dependency range to `>= 5.10.2, < 6.0.0` so it can be used alongside other plugins that require a newer 5.x release

--- a/packages/live-update/CapawesomeCapacitorLiveUpdate.podspec
+++ b/packages/live-update/CapawesomeCapacitorLiveUpdate.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
-  s.dependency 'Alamofire', '~> 5.10.2'
+  s.dependency 'Alamofire', '>= 5.10.2', '< 6.0.0'
   s.dependency 'ZIPFoundation', '~> 0.9.0'
   s.swift_version = '5.1'
   s.static_framework = true

--- a/packages/live-update/Package.swift
+++ b/packages/live-update/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
-        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMinor(from: "5.10.2")),
+        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.10.2")),
         .package(url: "https://github.com/weichsel/ZIPFoundation.git", .upToNextMinor(from: "0.9.0"))
     ],
     targets: [


### PR DESCRIPTION
Widens the Alamofire dependency range so the plugin can be installed alongside other plugins that require a newer 5.x release (e.g. `5.11.x`), without raising the minimum supported version.

## Changes
- `Package.swift`: `.upToNextMinor(from: "5.10.2")` → `.upToNextMajor(from: "5.10.2")` (`>= 5.10.2, < 6.0.0`)
- `CapawesomeCapacitorLiveUpdate.podspec`: `~> 5.10.2` → `>= 5.10.2, < 6.0.0`
- The dev `ios/Podfile` stays pinned to the minimum supported version (`5.10.2`) so the plugin is always built/tested against its floor.

A changeset is included (patch).

Close #872.
