### PR TITLE
fix(live-update): widen Alamofire dependency range to allow newer 5.x

### DIFF
--- a/packages/live-update/CapawesomeCapacitorLiveUpdate.podspec
+++ b/packages/live-update/CapawesomeCapacitorLiveUpdate.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'
-  s.dependency 'Alamofire', '~> 5.9.0'
+  s.dependency 'Alamofire', '~> 5.9'
   s.dependency 'ZIPFoundation', '~> 0.9.0'
   s.swift_version = '5.1'
   s.static_framework = true


### PR DESCRIPTION
Widens the Alamofire dependency range so the plugin can be installed alongside other plugins that require a newer 5.x release (e.g. `5.11.x`), without raising the minimum supported version.

## Changes
- `CapawesomeCapacitorLiveUpdate.podspec`: `~> 5.9.0` (`< 5.10.0`) → `~> 5.9` (`>= 5.9.0, < 6.0.0`)
- The dev `ios/Podfile` stays pinned to the minimum supported version (`5.9.0`) so the plugin is always built/tested against its floor.

(There is no `Package.swift` on this branch.)
