### PR TITLE
fix(datetime-picker): show picker dialog on the UI thread on Android

### DIFF
--- a/.changeset/datetime-picker-ui-thread.md
+++ b/.changeset/datetime-picker-ui-thread.md
@@ -1,0 +1,5 @@
+---
+'@capawesome-team/capacitor-datetime-picker': patch
+---
+
+fix(android): show the picker dialog on the UI thread to prevent crashes (`CalledFromWrongThreadException`/`WindowLeaked`) on configuration changes

--- a/packages/datetime-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/datetimepicker/DatetimePickerPlugin.java
+++ b/packages/datetime-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/datetimepicker/DatetimePickerPlugin.java
@@ -29,14 +29,17 @@ public class DatetimePickerPlugin extends Plugin {
 
     @PluginMethod
     public void cancel(PluginCall call) {
-        try {
-            implementation.cancel();
-            call.resolve();
-        } catch (Exception ex) {
-            String message = ex.getLocalizedMessage();
-            Log.e(TAG, message);
-            call.reject(message);
-        }
+        getActivity()
+            .runOnUiThread(() -> {
+                try {
+                    implementation.cancel();
+                    call.resolve();
+                } catch (Exception ex) {
+                    String message = ex.getLocalizedMessage();
+                    Log.e(TAG, message);
+                    call.reject(message);
+                }
+            });
     }
 
     @PluginMethod
@@ -88,48 +91,73 @@ public class DatetimePickerPlugin extends Plugin {
             resultCallback.setCancelListener(() -> call.reject(ERROR_PICKER_CANCELED, ERROR_CODE_CANCELED));
             resultCallback.setDismissListener(() -> call.reject(ERROR_PICKER_DISMISSED, ERROR_CODE_DISMISSED));
 
-            if (mode.equals("datetime")) {
-                implementation.presentDateTimePicker(
-                    date,
-                    minDate,
-                    maxDate,
-                    locale,
-                    cancelButtonText,
-                    doneButtonText,
-                    theme,
-                    resultCallback,
-                    androidDatePickerMode,
-                    androidTimePickerMode
-                );
-            } else if (mode.equals("date")) {
-                implementation.presentDatePicker(
-                    date,
-                    minDate,
-                    maxDate,
-                    locale,
-                    cancelButtonText,
-                    doneButtonText,
-                    theme,
-                    resultCallback,
-                    androidDatePickerMode,
-                    androidTimePickerMode
-                );
-            } else if (mode.equals("time")) {
-                implementation.presentTimePicker(
-                    date,
-                    locale,
-                    cancelButtonText,
-                    doneButtonText,
-                    theme,
-                    resultCallback,
-                    androidDatePickerMode,
-                    androidTimePickerMode
-                );
-            } else if (mode.equals("month")) {
-                implementation.presentMonthPicker(date, minDate, maxDate, locale, cancelButtonText, doneButtonText, theme, resultCallback);
-            } else {
-                call.reject(ERROR_MODE_INVALID);
-            }
+            final Date finalDate = date;
+            final Date finalMinDate = minDate;
+            final Date finalMaxDate = maxDate;
+            final Locale finalLocale = locale;
+            final AndroidDatePickerMode finalAndroidDatePickerMode = androidDatePickerMode;
+            final AndroidTimePickerMode finalAndroidTimePickerMode = androidTimePickerMode;
+
+            getActivity()
+                .runOnUiThread(() -> {
+                    try {
+                        if (mode.equals("datetime")) {
+                            implementation.presentDateTimePicker(
+                                finalDate,
+                                finalMinDate,
+                                finalMaxDate,
+                                finalLocale,
+                                cancelButtonText,
+                                doneButtonText,
+                                theme,
+                                resultCallback,
+                                finalAndroidDatePickerMode,
+                                finalAndroidTimePickerMode
+                            );
+                        } else if (mode.equals("date")) {
+                            implementation.presentDatePicker(
+                                finalDate,
+                                finalMinDate,
+                                finalMaxDate,
+                                finalLocale,
+                                cancelButtonText,
+                                doneButtonText,
+                                theme,
+                                resultCallback,
+                                finalAndroidDatePickerMode,
+                                finalAndroidTimePickerMode
+                            );
+                        } else if (mode.equals("time")) {
+                            implementation.presentTimePicker(
+                                finalDate,
+                                finalLocale,
+                                cancelButtonText,
+                                doneButtonText,
+                                theme,
+                                resultCallback,
+                                finalAndroidDatePickerMode,
+                                finalAndroidTimePickerMode
+                            );
+                        } else if (mode.equals("month")) {
+                            implementation.presentMonthPicker(
+                                finalDate,
+                                finalMinDate,
+                                finalMaxDate,
+                                finalLocale,
+                                cancelButtonText,
+                                doneButtonText,
+                                theme,
+                                resultCallback
+                            );
+                        } else {
+                            call.reject(ERROR_MODE_INVALID);
+                        }
+                    } catch (Exception ex) {
+                        String message = ex.getLocalizedMessage();
+                        Log.e(TAG, message);
+                        call.reject(message);
+                    }
+                });
         } catch (Exception ex) {
             String message = ex.getLocalizedMessage();
             Log.e(TAG, message);


### PR DESCRIPTION
## Description

On Android, the native date/time picker dialog was built and shown directly on
Capacitor's background `CapacitorPlugins` HandlerThread. As a result, the dialog's
view hierarchy was owned by a background thread, and the first configuration change
that reached it (rotation, Dark/Light toggle, font/display-size change, split-screen)
caused the main thread to touch those views and crashed the app
(`CalledFromWrongThreadException` / `WindowLeaked`).

This wraps the dialog creation/show dispatch in `present()` — and the dialog dismissal
in `cancel()` — in `getActivity().runOnUiThread(...)`, so the picker's views are created
on and owned by the UI thread and survive configuration changes.

Closes #879