### PR TITLE
feat(posthog): add error tracking with captureException and autoCaptureExceptions

### DIFF
--- a/.changeset/wide-clouds-laugh.md
+++ b/.changeset/wide-clouds-laugh.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-posthog': major
+---
+
+feat: bump PostHog versions and add error tracking with captureException and autoCaptureExceptions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1560,6 +1560,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/@posthog/core": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.7.1.tgz",
+      "integrity": "sha512-kjK0eFMIpKo9GXIbts8VtAknsoZ18oZorANdtuTj1CbgS28t4ZVq//HAWhnxEuXRTrtkd+SUJ6Ux3j2Af8NCuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -2954,6 +2964,18 @@
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
@@ -6501,15 +6523,17 @@
       }
     },
     "node_modules/posthog-js": {
-      "version": "1.160.3",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.160.3.tgz",
-      "integrity": "sha512-mGvxOIlWPtdPx8EI0MQ81wNKlnH2K0n4RqwQOl044b34BCKiFVzZ7Hc7geMuZNaRAvCi5/5zyGeWHcAYZQxiMQ==",
+      "version": "1.306.2",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.306.2.tgz",
+      "integrity": "sha512-zBEjDvUs5RNTWbyHVjbL16Oigm2buFG2PQRRMC46hfL2HSh+8//zMD5gV3etxkUhjjTltKubK3mkqONMldw9Yg==",
       "dev": true,
-      "license": "MIT",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
+        "@posthog/core": "1.7.1",
+        "core-js": "^3.38.1",
         "fflate": "^0.4.8",
         "preact": "^10.19.3",
-        "web-vitals": "^4.0.1"
+        "web-vitals": "^4.2.4"
       }
     },
     "node_modules/preact": {
@@ -9155,7 +9179,7 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "posthog-js": "1.160.3",
+        "posthog-js": "1.306.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",

--- a/packages/posthog/CapawesomeCapacitorPosthog.podspec
+++ b/packages/posthog/CapawesomeCapacitorPosthog.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
-  s.dependency 'PostHog', '>= 3.19.1', '< 4.0'
+  s.dependency 'PostHog', '>= 3.56.0', '< 4.0'
   s.swift_version = '5.1'
   s.static_framework = true
 end

--- a/packages/posthog/Package.swift
+++ b/packages/posthog/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
-        .package(url: "https://github.com/PostHog/posthog-ios.git", .upToNextMajor(from: "3.19.1"))
+        .package(url: "https://github.com/PostHog/posthog-ios.git", .upToNextMajor(from: "3.56.0"))
     ],
     targets: [
         .target(

--- a/packages/posthog/README.md
+++ b/packages/posthog/README.md
@@ -48,7 +48,7 @@ npx cap sync
 If needed, you can define the following project variable in your app’s `variables.gradle` file to change the default version of the dependency:
 
 - `$androidxCoreKtxVersion` version of `androidx.core:core-ktx` (default: `1.13.1`)
-- `$posthogVersion` version of `com.posthog:posthog-android` (default: `3.27.2`)
+- `$posthogVersion` version of `com.posthog:posthog-android` (default: `3.32.0`)
 
 This can be useful if you encounter dependency conflicts with other plugins in your project.
 
@@ -66,6 +66,7 @@ This can be useful if you encounter dependency conflicts with other plugins in y
 | **`enableSessionReplay`**               | <code>boolean</code>                                                  | Whether to enable session recording automatically.                                        | <code>false</code>                      | 7.3.0 |
 | **`sessionReplayConfig`**               | <code><a href="#sessionreplayoptions">SessionReplayOptions</a></code> | Session recording configuration options.                                                  |                                         | 7.3.0 |
 | **`captureApplicationLifecycleEvents`** | <code>boolean</code>                                                  | Whether to capture application lifecycle events.                                          | <code>true</code>                       | 8.3.0 |
+| **`autoCaptureExceptions`**             | <code>boolean</code>                                                  | Whether to automatically capture exceptions.                                              | <code>false</code>                      | 8.5.0 |
 
 ### Examples
 
@@ -81,7 +82,8 @@ In `capacitor.config.json`:
       "uiHost": 'https://eu.posthog.com',
       "enableSessionReplay": undefined,
       "sessionReplayConfig": undefined,
-      "captureApplicationLifecycleEvents": undefined
+      "captureApplicationLifecycleEvents": undefined,
+      "autoCaptureExceptions": undefined
     }
   }
 }
@@ -104,6 +106,7 @@ const config: CapacitorConfig = {
       enableSessionReplay: undefined,
       sessionReplayConfig: undefined,
       captureApplicationLifecycleEvents: undefined,
+      autoCaptureExceptions: undefined,
     },
   },
 };
@@ -200,6 +203,7 @@ const unregister = async () => {
 
 * [`alias(...)`](#alias)
 * [`capture(...)`](#capture)
+* [`captureException(...)`](#captureexception)
 * [`flush()`](#flush)
 * [`getDistinctId()`](#getdistinctid)
 * [`getFeatureFlag(...)`](#getfeatureflag)
@@ -256,6 +260,23 @@ Capture an event.
 | **`options`** | <code><a href="#captureoptions">CaptureOptions</a></code> |
 
 **Since:** 6.0.0
+
+--------------------
+
+
+### captureException(...)
+
+```typescript
+captureException(options: CaptureExceptionOptions) => Promise<void>
+```
+
+Capture an exception.
+
+| Param         | Type                                                                        |
+| ------------- | --------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#captureexceptionoptions">CaptureExceptionOptions</a></code> |
+
+**Since:** 8.5.0
 
 --------------------
 
@@ -569,6 +590,16 @@ Remove a super property.
 | **`properties`** | <code>Record&lt;string, any&gt;</code> | The properties to send with the event. | 6.0.0 |
 
 
+#### CaptureExceptionOptions
+
+| Prop             | Type                                   | Description                                | Since |
+| ---------------- | -------------------------------------- | ------------------------------------------ | ----- |
+| **`message`**    | <code>string</code>                    | The exception message.                     | 8.5.0 |
+| **`name`**       | <code>string</code>                    | The exception name.                        | 8.5.0 |
+| **`stack`**      | <code>string</code>                    | The exception stack trace.                 | 8.5.0 |
+| **`properties`** | <code>Record&lt;string, any&gt;</code> | The properties to send with the exception. | 8.5.0 |
+
+
 #### GetDistinctIdResult
 
 | Prop             | Type                | Description              | Since |
@@ -671,6 +702,7 @@ Remove a super property.
 | **`optOut`**                            | <code>boolean</code>                                                  | Whether to opt out of capturing by default. User must call `optIn()` to enable capturing.                                                                                                                                                                                                    | <code>false</code>                      | 8.1.0 |
 | **`sessionReplayConfig`**               | <code><a href="#sessionreplayoptions">SessionReplayOptions</a></code> | Session replay configuration options.                                                                                                                                                                                                                                                        |                                         | 7.3.0 |
 | **`captureApplicationLifecycleEvents`** | <code>boolean</code>                                                  | Whether to capture application lifecycle events. Only available on iOS and Android.                                                                                                                                                                                                          | <code>true</code>                       | 8.3.0 |
+| **`autoCaptureExceptions`**             | <code>boolean</code>                                                  | Whether to automatically capture exceptions.                                                                                                                                                                                                                                                 | <code>false</code>                      | 8.5.0 |
 
 
 #### SessionReplayOptions

--- a/packages/posthog/android/build.gradle
+++ b/packages/posthog/android/build.gradle
@@ -6,7 +6,7 @@ ext {
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.3.0'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.7.0'
     androidxCoreKtxVersion = project.hasProperty('androidxCoreKtxVersion') ? rootProject.ext.androidxCoreKtxVersion : '1.13.1'
-    posthogVersion = project.hasProperty('posthogVersion') ? rootProject.ext.posthogVersion : '3.27.2'
+    posthogVersion = project.hasProperty('posthogVersion') ? rootProject.ext.posthogVersion : '3.32.0'
 }
 
 buildscript {

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/Posthog.kt
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/Posthog.kt
@@ -2,6 +2,7 @@ package io.capawesome.capacitorjs.plugins.posthog
 
 import com.posthog.PostHog
 import com.posthog.android.PostHogAndroid
+import io.capawesome.capacitorjs.plugins.posthog.classes.options.CaptureExceptionOptions
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.CaptureOptions
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.IdentifyOptions
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.RegisterOptions
@@ -32,6 +33,7 @@ class Posthog(private val config: PosthogConfig, private val plugin: PosthogPlug
                 config.getEnableSessionReplay(),
                 false,
                 config.getCaptureApplicationLifecycleEvents(),
+                config.getAutoCaptureExceptions(),
                 config.getSessionReplayConfig()
             )
         }
@@ -47,6 +49,103 @@ class Posthog(private val config: PosthogConfig, private val plugin: PosthogPlug
         val properties = options.properties
 
         com.posthog.PostHog.capture(event = event, properties = properties)
+    }
+
+    fun captureException(options: CaptureExceptionOptions) {
+        // Build the $exception event explicitly instead of handing the SDK a Throwable:
+        // that path derives the type from the throwable's class name (dropping the caller's
+        // name) and synthesizes a native stack. Emitting $exception_list directly mirrors
+        // what posthog-js produces on the web.
+        val exception = mutableMapOf<String, Any>(
+            "type" to (options.name?.takeIf { it.isNotEmpty() } ?: "Error"),
+            "value" to options.message,
+            "mechanism" to mapOf(
+                "type" to "generic",
+                "handled" to true,
+                "synthetic" to false
+            )
+        )
+
+        val frames = parseStackFrames(options.stack)
+        if (frames.isNotEmpty()) {
+            exception["stacktrace"] = mapOf(
+                "type" to "raw",
+                "frames" to frames
+            )
+        }
+
+        val properties = options.properties?.toMutableMap() ?: mutableMapOf()
+        properties["\$exception_level"] = "error"
+        properties["\$exception_list"] = listOf(exception)
+
+        com.posthog.PostHog.capture(event = "\$exception", properties = properties)
+    }
+
+    /**
+     * Parse a JavaScript error stack into PostHog `web:javascript` frames.
+     *
+     * PostHog stores frames bottom-up (oldest call first, crash site last) while JS
+     * stacks are top-down, so the parsed frames are reversed to match.
+     */
+    private fun parseStackFrames(stack: String?): List<Map<String, Any>> {
+        if (stack.isNullOrEmpty()) return emptyList()
+
+        val frames = mutableListOf<Map<String, Any>>()
+        for (rawLine in stack.split("\n")) {
+            val line = rawLine.trim()
+            if (line.isEmpty()) continue
+            parseStackLine(line)?.let { frames.add(it) }
+        }
+
+        return frames.asReversed()
+    }
+
+    /**
+     * Parse one stack line in either V8 (`at fn (file:line:col)`) or
+     * JSC/Gecko (`fn@file:line:col`) format.
+     */
+    private fun parseStackLine(line: String): Map<String, Any>? {
+        var functionName = "?"
+        val location: String
+
+        if (line.startsWith("at ")) {
+            val body = line.substring(3).trim()
+            val open = body.indexOf('(')
+            if (open >= 0 && body.endsWith(")")) {
+                functionName = body.substring(0, open).trim().ifEmpty { "?" }
+                location = body.substring(open + 1, body.length - 1)
+            } else {
+                location = body
+            }
+        } else {
+            val at = line.indexOf('@')
+            if (at < 0) return null
+            functionName = line.substring(0, at).ifEmpty { "?" }
+            location = line.substring(at + 1)
+        }
+
+        if (location.isEmpty()) return null
+
+        val frame = mutableMapOf<String, Any>(
+            "platform" to "web:javascript",
+            "function" to functionName,
+            "in_app" to true
+        )
+
+        // Split `file:line:col` from the right; the filename itself may contain
+        // colons (e.g. `https://host:443/app.js`).
+        val parts = location.split(":")
+        val colno = if (parts.size >= 3) parts.last().toIntOrNull() else null
+        val lineno = if (parts.size >= 3) parts[parts.size - 2].toIntOrNull() else null
+        if (colno != null && lineno != null) {
+            frame["filename"] = parts.subList(0, parts.size - 2).joinToString(":")
+            frame["lineno"] = lineno
+            frame["colno"] = colno
+        } else {
+            frame["filename"] = location
+        }
+
+        return frame
     }
 
     fun flush() {
@@ -134,6 +233,7 @@ class Posthog(private val config: PosthogConfig, private val plugin: PosthogPlug
         val enableSessionReplay = options.enableSessionReplay
         val optOut = options.optOut
         val captureApplicationLifecycleEvents = options.captureApplicationLifecycleEvents
+        val autoCaptureExceptions = options.autoCaptureExceptions
         val sessionReplayConfig = options.sessionReplayConfig
 
         setup(
@@ -142,6 +242,7 @@ class Posthog(private val config: PosthogConfig, private val plugin: PosthogPlug
             enableSessionReplay,
             optOut,
             captureApplicationLifecycleEvents,
+            autoCaptureExceptions,
             sessionReplayConfig
         )
     }
@@ -158,6 +259,7 @@ class Posthog(private val config: PosthogConfig, private val plugin: PosthogPlug
         enableSessionReplay: Boolean = false,
         optOut: Boolean = false,
         captureApplicationLifecycleEvents: Boolean = true,
+        autoCaptureExceptions: Boolean = false,
         sessionReplayConfig: SessionReplayOptions? = null
     ) {
         val posthogConfig = PostHogAndroidConfig(
@@ -168,6 +270,7 @@ class Posthog(private val config: PosthogConfig, private val plugin: PosthogPlug
         posthogConfig.captureApplicationLifecycleEvents = captureApplicationLifecycleEvents
         posthogConfig.optOut = optOut
         posthogConfig.sessionReplay = enableSessionReplay
+        posthogConfig.errorTrackingConfig.autoCapture = autoCaptureExceptions
 
         // Configure session replay options if provided
         sessionReplayConfig?.let { replayConfig ->

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/PosthogConfig.java
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/PosthogConfig.java
@@ -14,6 +14,8 @@ public class PosthogConfig {
 
     private boolean captureApplicationLifecycleEvents = true;
 
+    private boolean autoCaptureExceptions = false;
+
     @Nullable
     private SessionReplayOptions sessionReplayConfig = null;
 
@@ -32,6 +34,10 @@ public class PosthogConfig {
 
     public boolean getCaptureApplicationLifecycleEvents() {
         return captureApplicationLifecycleEvents;
+    }
+
+    public boolean getAutoCaptureExceptions() {
+        return autoCaptureExceptions;
     }
 
     @Nullable
@@ -53,6 +59,10 @@ public class PosthogConfig {
 
     public void setCaptureApplicationLifecycleEvents(boolean captureApplicationLifecycleEvents) {
         this.captureApplicationLifecycleEvents = captureApplicationLifecycleEvents;
+    }
+
+    public void setAutoCaptureExceptions(boolean autoCaptureExceptions) {
+        this.autoCaptureExceptions = autoCaptureExceptions;
     }
 
     public void setSessionReplayConfig(@Nullable SessionReplayOptions sessionReplayConfig) {

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/PosthogPlugin.java
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/PosthogPlugin.java
@@ -9,6 +9,7 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.AliasOptions;
+import io.capawesome.capacitorjs.plugins.posthog.classes.options.CaptureExceptionOptions;
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.CaptureOptions;
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.GetFeatureFlagOptions;
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.GetFeatureFlagPayloadOptions;
@@ -32,6 +33,7 @@ public class PosthogPlugin extends Plugin {
     public static final String ERROR_DISTINCT_ID_MISSING = "distinctId must be provided.";
     public static final String ERROR_EVENT_MISSING = "event must be provided.";
     public static final String ERROR_KEY_MISSING = "key must be provided.";
+    public static final String ERROR_MESSAGE_MISSING = "message must be provided.";
     public static final String ERROR_SCREEN_TITLE_MISSING = "screenTitle must be provided.";
     public static final String ERROR_TYPE_MISSING = "type must be provided.";
     public static final String ERROR_VALUE_MISSING = "value must be provided.";
@@ -80,6 +82,27 @@ public class PosthogPlugin extends Plugin {
             CaptureOptions options = new CaptureOptions(event, properties);
 
             implementation.capture(options);
+            call.resolve();
+        } catch (Exception exception) {
+            rejectCall(call, exception);
+        }
+    }
+
+    @PluginMethod
+    public void captureException(PluginCall call) {
+        try {
+            String message = call.getString("message");
+            if (message == null) {
+                call.reject(ERROR_MESSAGE_MISSING);
+                return;
+            }
+            String name = call.getString("name");
+            String stack = call.getString("stack");
+            JSObject properties = call.getObject("properties");
+
+            CaptureExceptionOptions options = new CaptureExceptionOptions(message, name, stack, properties);
+
+            implementation.captureException(options);
             call.resolve();
         } catch (Exception exception) {
             rejectCall(call, exception);
@@ -288,6 +311,7 @@ public class PosthogPlugin extends Plugin {
             Boolean enableSessionReplay = call.getBoolean("enableSessionReplay", false);
             Boolean optOut = call.getBoolean("optOut", false);
             Boolean captureApplicationLifecycleEvents = call.getBoolean("captureApplicationLifecycleEvents", true);
+            Boolean autoCaptureExceptions = call.getBoolean("autoCaptureExceptions", false);
 
             SetupOptions options = new SetupOptions(apiKey, apiHost);
             options.setEnableSessionReplay(enableSessionReplay != null ? enableSessionReplay : false);
@@ -295,6 +319,7 @@ public class PosthogPlugin extends Plugin {
             options.setCaptureApplicationLifecycleEvents(
                 captureApplicationLifecycleEvents != null ? captureApplicationLifecycleEvents : true
             );
+            options.setAutoCaptureExceptions(autoCaptureExceptions != null ? autoCaptureExceptions : false);
 
             JSObject sessionReplayConfigObject = call.getObject("sessionReplayConfig");
             if (sessionReplayConfigObject != null) {
@@ -346,6 +371,8 @@ public class PosthogPlugin extends Plugin {
         boolean captureApplicationLifecycleEvents = getConfig()
             .getBoolean("captureApplicationLifecycleEvents", config.getCaptureApplicationLifecycleEvents());
         config.setCaptureApplicationLifecycleEvents(captureApplicationLifecycleEvents);
+        boolean autoCaptureExceptions = getConfig().getBoolean("autoCaptureExceptions", config.getAutoCaptureExceptions());
+        config.setAutoCaptureExceptions(autoCaptureExceptions);
 
         JSONObject sessionReplayConfigObject = getConfig().getObject("sessionReplayConfig");
         if (sessionReplayConfigObject != null) {

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/classes/options/CaptureExceptionOptions.java
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/classes/options/CaptureExceptionOptions.java
@@ -1,0 +1,51 @@
+package io.capawesome.capacitorjs.plugins.posthog.classes.options;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.getcapacitor.JSObject;
+import io.capawesome.capacitorjs.plugins.posthog.PosthogHelper;
+import java.util.Map;
+import org.json.JSONException;
+
+public class CaptureExceptionOptions {
+
+    @NonNull
+    private String message;
+
+    @Nullable
+    private String name;
+
+    @Nullable
+    private String stack;
+
+    @Nullable
+    private Map<String, Object> properties;
+
+    public CaptureExceptionOptions(@NonNull String message, @Nullable String name, @Nullable String stack, @Nullable JSObject properties)
+        throws JSONException {
+        this.message = message;
+        this.name = name;
+        this.stack = stack;
+        this.properties = PosthogHelper.createHashMapFromJSONObject(properties);
+    }
+
+    @NonNull
+    public String getMessage() {
+        return message;
+    }
+
+    @Nullable
+    public String getName() {
+        return name;
+    }
+
+    @Nullable
+    public String getStack() {
+        return stack;
+    }
+
+    @Nullable
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+}

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/classes/options/SetupOptions.java
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/classes/options/SetupOptions.java
@@ -21,6 +21,9 @@ public class SetupOptions {
     private Boolean captureApplicationLifecycleEvents;
 
     @Nullable
+    private Boolean autoCaptureExceptions;
+
+    @Nullable
     private SessionReplayOptions sessionReplayConfig;
 
     public SetupOptions(@NonNull String apiKey, @NonNull String apiHost) {
@@ -60,6 +63,14 @@ public class SetupOptions {
 
     public void setCaptureApplicationLifecycleEvents(boolean captureApplicationLifecycleEvents) {
         this.captureApplicationLifecycleEvents = captureApplicationLifecycleEvents;
+    }
+
+    public boolean getAutoCaptureExceptions() {
+        return autoCaptureExceptions != null ? autoCaptureExceptions : false;
+    }
+
+    public void setAutoCaptureExceptions(boolean autoCaptureExceptions) {
+        this.autoCaptureExceptions = autoCaptureExceptions;
     }
 
     @Nullable

--- a/packages/posthog/ios/Plugin.xcodeproj/project.pbxproj
+++ b/packages/posthog/ios/Plugin.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		7C27475A2D3BFF7800589048 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C2747592D3BFF7200589048 /* Result.swift */; };
 		7C27475D2D3C032D00589048 /* CustomError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C27475C2D3C032A00589048 /* CustomError.swift */; };
 		7C28C8C22C8AE99100271553 /* AliasOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C28C8C12C8AE99100271553 /* AliasOptions.swift */; };
+		A1B2C3D52F0C113000AABB02 /* CaptureExceptionOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42F0C113000AABB02 /* CaptureExceptionOptions.swift */; };
 		7C28C8C42C8AE99E00271553 /* CaptureOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C28C8C32C8AE99E00271553 /* CaptureOptions.swift */; };
 		7C28C8C62C8AE9AC00271553 /* IdentifyOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C28C8C52C8AE9AC00271553 /* IdentifyOptions.swift */; };
 		7C28C8C82C8AE9B800271553 /* RegisterOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C28C8C72C8AE9B800271553 /* RegisterOptions.swift */; };
@@ -67,6 +68,7 @@
 		7C2747592D3BFF7200589048 /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		7C27475C2D3C032A00589048 /* CustomError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomError.swift; sourceTree = "<group>"; };
 		7C28C8C12C8AE99100271553 /* AliasOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasOptions.swift; sourceTree = "<group>"; };
+		A1B2C3D42F0C113000AABB02 /* CaptureExceptionOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureExceptionOptions.swift; sourceTree = "<group>"; };
 		7C28C8C32C8AE99E00271553 /* CaptureOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureOptions.swift; sourceTree = "<group>"; };
 		7C28C8C52C8AE9AC00271553 /* IdentifyOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifyOptions.swift; sourceTree = "<group>"; };
 		7C28C8C72C8AE9B800271553 /* RegisterOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterOptions.swift; sourceTree = "<group>"; };
@@ -193,6 +195,7 @@
 				7C2747512D3BFF0300589048 /* IsFeatureEnabledOptions.swift */,
 				7C27474C2D3BFEF000589048 /* GetFeatureFlagOptions.swift */,
 				7C28C8C12C8AE99100271553 /* AliasOptions.swift */,
+				A1B2C3D42F0C113000AABB02 /* CaptureExceptionOptions.swift */,
 				7C28C8C32C8AE99E00271553 /* CaptureOptions.swift */,
 				7C28C8C52C8AE9AC00271553 /* IdentifyOptions.swift */,
 				7C28C8C72C8AE9B800271553 /* RegisterOptions.swift */,
@@ -409,6 +412,7 @@
 				50E1A94820377CB70090CE1A /* PosthogPlugin.swift in Sources */,
 				7C28C8CC2C8AE9CD00271553 /* SetupOptions.swift in Sources */,
 				7C28C8D02C8AEA2E00271553 /* PosthogHelper.swift in Sources */,
+				A1B2C3D52F0C113000AABB02 /* CaptureExceptionOptions.swift in Sources */,
 				7C27474D2D3BFEF100589048 /* GetFeatureFlagOptions.swift in Sources */,
 				7C27475A2D3BFF7800589048 /* Result.swift in Sources */,
 				7C2747522D3BFF0400589048 /* IsFeatureEnabledOptions.swift in Sources */,

--- a/packages/posthog/ios/Plugin/Classes/Options/CaptureExceptionOptions.swift
+++ b/packages/posthog/ios/Plugin/Classes/Options/CaptureExceptionOptions.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Capacitor
+
+@objc public class CaptureExceptionOptions: NSObject {
+    private var message: String
+    private var name: String?
+    private var stack: String?
+    private var properties: [String: Any]?
+
+    init(message: String, name: String?, stack: String?, properties: JSObject?) {
+        self.message = message
+        self.name = name
+        self.stack = stack
+        self.properties = PosthogHelper.createHashMapFromJSObject(properties)
+    }
+
+    func getMessage() -> String {
+        return message
+    }
+
+    func getName() -> String? {
+        return name
+    }
+
+    func getStack() -> String? {
+        return stack
+    }
+
+    func getProperties() -> [String: Any]? {
+        return properties
+    }
+}

--- a/packages/posthog/ios/Plugin/Classes/Options/SetupOptions.swift
+++ b/packages/posthog/ios/Plugin/Classes/Options/SetupOptions.swift
@@ -6,6 +6,7 @@ import Foundation
     private var enableSessionReplay: Bool
     private var optOut: Bool
     private var captureApplicationLifecycleEvents: Bool
+    private var autoCaptureExceptions: Bool
     private var sessionReplayConfig: SessionReplayOptions?
 
     init(
@@ -14,6 +15,7 @@ import Foundation
         enableSessionReplay: Bool,
         optOut: Bool,
         captureApplicationLifecycleEvents: Bool,
+        autoCaptureExceptions: Bool,
         sessionReplayConfig: [String: Any]?
     ) {
         self.apiKey = apiKey
@@ -21,6 +23,7 @@ import Foundation
         self.enableSessionReplay = enableSessionReplay
         self.optOut = optOut
         self.captureApplicationLifecycleEvents = captureApplicationLifecycleEvents
+        self.autoCaptureExceptions = autoCaptureExceptions
 
         if let config = sessionReplayConfig {
             self.sessionReplayConfig = SessionReplayOptions(
@@ -52,6 +55,10 @@ import Foundation
 
     func getCaptureApplicationLifecycleEvents() -> Bool {
         return captureApplicationLifecycleEvents
+    }
+
+    func getAutoCaptureExceptions() -> Bool {
+        return autoCaptureExceptions
     }
 
     func getSessionReplayConfig() -> SessionReplayOptions? {

--- a/packages/posthog/ios/Plugin/Enums/CustomError.swift
+++ b/packages/posthog/ios/Plugin/Enums/CustomError.swift
@@ -6,6 +6,7 @@ public enum CustomError: Error {
     case distinctIdMissing
     case eventMissing
     case keyMissing
+    case messageMissing
     case screenTitleMissing
     case typeMissing
     case valueMissing
@@ -24,6 +25,8 @@ extension CustomError: LocalizedError {
             return NSLocalizedString("event must be provided.", comment: "eventMissing")
         case .keyMissing:
             return NSLocalizedString("key must be provided.", comment: "keyMissing")
+        case .messageMissing:
+            return NSLocalizedString("message must be provided.", comment: "messageMissing")
         case .screenTitleMissing:
             return NSLocalizedString("screenTitle must be provided.", comment: "screenTitleMissing")
         case .typeMissing:

--- a/packages/posthog/ios/Plugin/Posthog.swift
+++ b/packages/posthog/ios/Plugin/Posthog.swift
@@ -10,6 +10,7 @@ import PostHog
                 apiHost: config.apiHost,
                 enableSessionReplay: config.enableSessionReplay,
                 captureApplicationLifecycleEvents: config.captureApplicationLifecycleEvents,
+                autoCaptureExceptions: config.autoCaptureExceptions,
                 sessionReplayConfig: config.sessionReplayConfig
             )
 
@@ -31,6 +32,104 @@ import PostHog
         let properties = options.getProperties()
 
         PostHogSDK.shared.capture(event, properties: properties)
+    }
+
+    @objc public func captureException(_ options: CaptureExceptionOptions) {
+        // Build the $exception event explicitly instead of handing the SDK a synthetic
+        // NSError: that path re-derives the type from the error domain, appends " (Code: N)"
+        // to the message, and discards the JS stack in favour of a native one. Emitting
+        // $exception_list directly mirrors what posthog-js produces on the web.
+        let name = options.getName() ?? ""
+        var exception: [String: Any] = [
+            "type": name.isEmpty ? "Error" : name,
+            "value": options.getMessage(),
+            "mechanism": [
+                "type": "generic",
+                "handled": true,
+                "synthetic": false
+            ]
+        ]
+
+        let frames = Posthog.parseStackFrames(options.getStack())
+        if !frames.isEmpty {
+            exception["stacktrace"] = [
+                "type": "raw",
+                "frames": frames
+            ]
+        }
+
+        var properties: [String: Any] = [:]
+        options.getProperties()?.forEach { properties[$0.key] = $0.value }
+        properties["$exception_level"] = "error"
+        properties["$exception_list"] = [exception]
+
+        PostHogSDK.shared.capture("$exception", properties: properties)
+    }
+
+    /// Parse a JavaScript error stack into PostHog `web:javascript` frames.
+    ///
+    /// PostHog stores frames bottom-up (oldest call first, crash site last) while JS
+    /// stacks are top-down, so the parsed frames are reversed to match.
+    private static func parseStackFrames(_ stack: String?) -> [[String: Any]] {
+        guard let stack = stack, !stack.isEmpty else { return [] }
+
+        var frames: [[String: Any]] = []
+        for rawLine in stack.split(separator: "\n") {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty { continue }
+            if let frame = parseStackLine(line) {
+                frames.append(frame)
+            }
+        }
+
+        return frames.reversed()
+    }
+
+    /// Parse one stack line in either V8 (`at fn (file:line:col)`) or
+    /// JSC/Gecko (`fn@file:line:col`) format.
+    private static func parseStackLine(_ line: String) -> [String: Any]? {
+        var functionName = "?"
+        let location: String
+
+        if line.hasPrefix("at ") {
+            let body = line.dropFirst(3).trimmingCharacters(in: .whitespaces)
+            if let open = body.firstIndex(of: "("), body.hasSuffix(")") {
+                let name = body[..<open].trimmingCharacters(in: .whitespaces)
+                functionName = name.isEmpty ? "?" : name
+                location = String(body[body.index(after: open)..<body.index(before: body.endIndex)])
+            } else {
+                location = String(body)
+            }
+        } else if let atIndex = line.firstIndex(of: "@") {
+            let name = String(line[..<atIndex])
+            functionName = name.isEmpty ? "?" : name
+            location = String(line[line.index(after: atIndex)...])
+        } else {
+            return nil
+        }
+
+        if location.isEmpty { return nil }
+
+        var frame: [String: Any] = [
+            "platform": "web:javascript",
+            "function": functionName,
+            "in_app": true
+        ]
+
+        // Split `file:line:col` from the right; the filename itself may contain
+        // colons (e.g. `https://host:443/app.js`).
+        let parts = location.components(separatedBy: ":")
+        if parts.count >= 3,
+           let colno = Int(parts[parts.count - 1]),
+           let lineno = Int(parts[parts.count - 2]) {
+            frame["filename"] = parts[0..<(parts.count - 2)].joined(separator: ":")
+            frame["lineno"] = lineno
+            frame["colno"] = colno
+        } else {
+            frame["filename"] = location
+        }
+
+        return frame
     }
 
     @objc public func flush() {
@@ -120,9 +219,18 @@ import PostHog
         let enableSessionReplay = options.getEnableSessionReplay()
         let optOut = options.getOptOut()
         let captureApplicationLifecycleEvents = options.getCaptureApplicationLifecycleEvents()
+        let autoCaptureExceptions = options.getAutoCaptureExceptions()
         let sessionReplayConfig = options.getSessionReplayConfig()
 
-        setup(apiKey: apiKey, apiHost: apiHost, enableSessionReplay: enableSessionReplay, optOut: optOut, captureApplicationLifecycleEvents: captureApplicationLifecycleEvents, sessionReplayConfig: sessionReplayConfig)
+        setup(
+            apiKey: apiKey,
+            apiHost: apiHost,
+            enableSessionReplay: enableSessionReplay,
+            optOut: optOut,
+            captureApplicationLifecycleEvents: captureApplicationLifecycleEvents,
+            autoCaptureExceptions: autoCaptureExceptions,
+            sessionReplayConfig: sessionReplayConfig
+        )
     }
 
     @objc public func startSessionRecording() {
@@ -133,11 +241,20 @@ import PostHog
         PostHogSDK.shared.stopSessionRecording()
     }
 
-    private func setup(apiKey: String, apiHost: String, enableSessionReplay: Bool = false, optOut: Bool = false, captureApplicationLifecycleEvents: Bool = true, sessionReplayConfig: SessionReplayOptions? = nil) {
+    private func setup(
+        apiKey: String,
+        apiHost: String,
+        enableSessionReplay: Bool = false,
+        optOut: Bool = false,
+        captureApplicationLifecycleEvents: Bool = true,
+        autoCaptureExceptions: Bool = false,
+        sessionReplayConfig: SessionReplayOptions? = nil
+    ) {
         let config = PostHogConfig(apiKey: apiKey, host: apiHost)
         config.captureScreenViews = false
         config.optOut = optOut
         config.captureApplicationLifecycleEvents = captureApplicationLifecycleEvents
+        config.errorTrackingConfig.autoCapture = autoCaptureExceptions
         config.sessionReplay = enableSessionReplay
         config.sessionReplayConfig.screenshotMode = sessionReplayConfig?.getScreenshotMode() ?? false
         config.sessionReplayConfig.maskAllImages = sessionReplayConfig?.getMaskAllImages() ?? true

--- a/packages/posthog/ios/Plugin/PosthogConfig.swift
+++ b/packages/posthog/ios/Plugin/PosthogConfig.swift
@@ -5,5 +5,6 @@ public struct PosthogConfig {
     var apiHost = "https://us.i.posthog.com"
     var enableSessionReplay = false
     var captureApplicationLifecycleEvents = true
+    var autoCaptureExceptions = false
     var sessionReplayConfig: SessionReplayOptions?
 }

--- a/packages/posthog/ios/Plugin/PosthogPlugin.swift
+++ b/packages/posthog/ios/Plugin/PosthogPlugin.swift
@@ -14,6 +14,7 @@ public class PosthogPlugin: CAPPlugin, CAPBridgedPlugin {
     public let pluginMethods: [CAPPluginMethod] = [
         CAPPluginMethod(name: "alias", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "capture", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "captureException", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "flush", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getDistinctId", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getFeatureFlag", returnType: CAPPluginReturnPromise),
@@ -62,6 +63,21 @@ public class PosthogPlugin: CAPPlugin, CAPBridgedPlugin {
         let options = CaptureOptions(event: event, properties: properties)
 
         implementation?.capture(options)
+        call.resolve()
+    }
+
+    @objc func captureException(_ call: CAPPluginCall) {
+        guard let message = call.getString("message") else {
+            call.reject(CustomError.messageMissing.localizedDescription)
+            return
+        }
+        let name = call.getString("name")
+        let stack = call.getString("stack")
+        let properties = call.getObject("properties")
+
+        let options = CaptureExceptionOptions(message: message, name: name, stack: stack, properties: properties)
+
+        implementation?.captureException(options)
         call.resolve()
     }
 
@@ -206,6 +222,7 @@ public class PosthogPlugin: CAPPlugin, CAPBridgedPlugin {
         let enableSessionReplay = call.getBool("enableSessionReplay", false)
         let optOut = call.getBool("optOut", false)
         let captureApplicationLifecycleEvents = call.getBool("captureApplicationLifecycleEvents", true)
+        let autoCaptureExceptions = call.getBool("autoCaptureExceptions", false)
         let sessionReplayConfig = call.getObject("sessionReplayConfig")
 
         let options = SetupOptions(
@@ -214,6 +231,7 @@ public class PosthogPlugin: CAPPlugin, CAPBridgedPlugin {
             enableSessionReplay: enableSessionReplay,
             optOut: optOut,
             captureApplicationLifecycleEvents: captureApplicationLifecycleEvents,
+            autoCaptureExceptions: autoCaptureExceptions,
             sessionReplayConfig: sessionReplayConfig
         )
 
@@ -253,6 +271,7 @@ public class PosthogPlugin: CAPPlugin, CAPBridgedPlugin {
             "captureApplicationLifecycleEvents",
             config.captureApplicationLifecycleEvents
         )
+        config.autoCaptureExceptions = getConfig().getBoolean("autoCaptureExceptions", config.autoCaptureExceptions)
 
         if let sessionReplayConfigDict = getConfig().getObject("sessionReplayConfig") as? [String: Any] {
             config.sessionReplayConfig = SessionReplayOptions(

--- a/packages/posthog/ios/Podfile
+++ b/packages/posthog/ios/Podfile
@@ -9,7 +9,7 @@ end
 
 target 'Plugin' do
   capacitor_pods
-  pod 'PostHog', '>= 3.19.1', '< 4.0'
+  pod 'PostHog', '>= 3.56.0', '< 4.0'
 end
 
 target 'PluginTests' do

--- a/packages/posthog/package.json
+++ b/packages/posthog/package.json
@@ -66,7 +66,7 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "posthog-js": "1.160.3",
+    "posthog-js": "1.306.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/posthog/src/definitions.ts
+++ b/packages/posthog/src/definitions.ts
@@ -58,6 +58,13 @@ declare module '@capacitor/cli' {
        * @default true
        */
       captureApplicationLifecycleEvents?: boolean;
+      /**
+       * Whether to automatically capture exceptions.
+       *
+       * @since 8.5.0
+       * @default false
+       */
+      autoCaptureExceptions?: boolean;
     };
   }
 }
@@ -75,6 +82,12 @@ export interface PosthogPlugin {
    * @since 6.0.0
    */
   capture(options: CaptureOptions): Promise<void>;
+  /**
+   * Capture an exception.
+   *
+   * @since 8.5.0
+   */
+  captureException(options: CaptureExceptionOptions): Promise<void>;
   /**
    * Flush all events in the queue.
    *
@@ -226,6 +239,37 @@ export interface CaptureOptions {
    * The properties to send with the event.
    *
    * @since 6.0.0
+   */
+  properties?: Record<string, any>;
+}
+
+/**
+ * @since 8.5.0
+ */
+export interface CaptureExceptionOptions {
+  /**
+   * The exception message.
+   *
+   * @since 8.5.0
+   */
+  message: string;
+  /**
+   * The exception name.
+   *
+   * @since 8.5.0
+   * @example 'TypeError'
+   */
+  name?: string;
+  /**
+   * The exception stack trace.
+   *
+   * @since 8.5.0
+   */
+  stack?: string;
+  /**
+   * The properties to send with the exception.
+   *
+   * @since 8.5.0
    */
   properties?: Record<string, any>;
 }
@@ -485,6 +529,13 @@ export interface SetupOptions {
    * @default true
    */
   captureApplicationLifecycleEvents?: boolean;
+  /**
+   * Whether to automatically capture exceptions.
+   *
+   * @since 8.5.0
+   * @default false
+   */
+  autoCaptureExceptions?: boolean;
 }
 
 /**

--- a/packages/posthog/src/web.ts
+++ b/packages/posthog/src/web.ts
@@ -4,6 +4,7 @@ import type { PostHogConfig } from 'posthog-js';
 
 import type {
   AliasOptions,
+  CaptureExceptionOptions,
   CaptureOptions,
   GetDistinctIdResult,
   GetFeatureFlagOptions,
@@ -31,6 +32,17 @@ export class PosthogWeb extends WebPlugin implements PosthogPlugin {
     posthog.capture(options.event, options.properties);
   }
 
+  async captureException(options: CaptureExceptionOptions): Promise<void> {
+    const error = new Error(options.message);
+    if (options.name) {
+      error.name = options.name;
+    }
+    if (options.stack) {
+      error.stack = options.stack;
+    }
+    posthog.captureException(error, options.properties);
+  }
+
   async flush(): Promise<void> {
     this.throwUnimplementedError();
   }
@@ -49,7 +61,8 @@ export class PosthogWeb extends WebPlugin implements PosthogPlugin {
   async getFeatureFlagPayload(
     options: GetFeatureFlagPayloadOptions,
   ): Promise<GetFeatureFlagPayloadResult> {
-    return { value: posthog.getFeatureFlagPayload(options.key) };
+    const value = posthog.getFeatureFlagPayload(options.key) ?? null;
+    return { value: value as GetFeatureFlagPayloadResult['value'] };
   }
 
   async group(options: GroupOptions): Promise<void> {
@@ -115,6 +128,9 @@ export class PosthogWeb extends WebPlugin implements PosthogPlugin {
     }
     if (options.cookielessMode) {
       config.cookieless_mode = options.cookielessMode;
+    }
+    if (options.autoCaptureExceptions) {
+      config.capture_exceptions = true;
     }
 
     // Configure session recording if enabled


### PR DESCRIPTION
Adds `captureException(options)` method and `autoCaptureExceptions` config flag across iOS, Android, and web platforms. Native platforms emit exceptions as explicit `$exception_list` events to preserve caller details consistent with posthog-js behavior.

Bumps Posthog to latest version.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/contributing/pull-requests/).

Closes #645