### PR TITLE
fix(apple-sign-in): surface real iOS sign-in errors and harden controller lifecycle

### DIFF
--- a/.changeset/apple-sign-in-error-surfacing.md
+++ b/.changeset/apple-sign-in-error-surfacing.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-apple-sign-in': patch
+---
+
+fix: surface the underlying iOS sign-in error code and message, run the authorization request on the main thread, and retain the authorization controller until completion

--- a/packages/apple-sign-in/ios/Plugin/AppleSignIn.swift
+++ b/packages/apple-sign-in/ios/Plugin/AppleSignIn.swift
@@ -4,6 +4,7 @@ import AuthenticationServices
 @objc public class AppleSignIn: NSObject {
 
     private var completion: ((_ result: SignInResult?, _ error: Error?) -> Void)?
+    private var authorizationController: ASAuthorizationController?
 
     @objc public func signIn(_ options: SignInOptions, presentationContextProvider: ASAuthorizationControllerPresentationContextProviding, completion: @escaping (_ result: SignInResult?, _ error: Error?) -> Void) {
         self.completion = completion
@@ -17,15 +18,19 @@ import AuthenticationServices
             request.nonce = nonce
         }
 
-        let controller = ASAuthorizationController(authorizationRequests: [request])
-        controller.delegate = self
-        controller.presentationContextProvider = presentationContextProvider
-        controller.performRequests()
+        DispatchQueue.main.async {
+            let controller = ASAuthorizationController(authorizationRequests: [request])
+            controller.delegate = self
+            controller.presentationContextProvider = presentationContextProvider
+            self.authorizationController = controller
+            controller.performRequests()
+        }
     }
 }
 
 extension AppleSignIn: ASAuthorizationControllerDelegate {
     public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        authorizationController = nil
         guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential else {
             completion?(nil, CustomError.signInFailed)
             completion = nil
@@ -37,11 +42,12 @@ extension AppleSignIn: ASAuthorizationControllerDelegate {
     }
 
     public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        authorizationController = nil
         let asError = error as? ASAuthorizationError
         if asError?.code == .canceled {
             completion?(nil, CustomError.signInCanceled)
         } else {
-            completion?(nil, CustomError.signInFailed)
+            completion?(nil, error)
         }
         completion = nil
     }

--- a/packages/apple-sign-in/ios/Plugin/AppleSignInPlugin.swift
+++ b/packages/apple-sign-in/ios/Plugin/AppleSignInPlugin.swift
@@ -43,6 +43,8 @@ public class AppleSignInPlugin: CAPPlugin, CAPBridgedPlugin {
         var code: String?
         if let customError = error as? CustomError {
             code = customError.code
+        } else if let authorizationError = error as? ASAuthorizationError {
+            code = String(authorizationError.code.rawValue)
         }
         call.reject(error.localizedDescription, code)
     }


### PR DESCRIPTION
## What

Improves the iOS implementation of `@capawesome/capacitor-apple-sign-in`:

- **Surface the real error.** `didCompleteWithError` previously collapsed every non-cancel error into a generic `"Sign in failed."` with no error code. It now forwards the underlying `ASAuthorizationError`, so the rejection carries Apple's localized message and the numeric code (e.g. `1001`). User cancellation still maps to the documented `SIGN_IN_CANCELED` code.
- **Run on the main thread.** Capacitor invokes plugin methods on a background queue; `ASAuthorizationController.performRequests()` drives UI and must run on the main thread. The request setup is now wrapped in `DispatchQueue.main.async`.
- **Retain the controller.** The `ASAuthorizationController` was a local variable and could be deallocated mid-flow (its delegate is held weakly). It's now retained in a property until a delegate callback fires.

## Why

Reported in [discussion #890](https://github.com/capawesome-team/capacitor-plugins/discussions/890): a user hitting a bare `ASAuthorizationError 1001` had to patch the plugin via `patch-package` just to see the real error code, because the plugin discarded it. Surfacing the underlying error makes such issues diagnosable out of the box. The main-thread dispatch and controller retention are correct best practices for `AuthenticationServices`.

> Note: the main-thread/retain changes are correctness hardening and are not expected to resolve the environmental 1001 from that specific report.

## Testing

- `xcodebuild -scheme CapawesomeCapacitorAppleSignIn -destination generic/platform=iOS build` → **BUILD SUCCEEDED**
- No new SwiftLint violations introduced.