### PR TITLE
feat(posthog): add error tracking with captureException and autoCaptureExceptions

### DIFF
--- a/.changeset/posthog-error-tracking.md
+++ b/.changeset/posthog-error-tracking.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-posthog': minor
+---
+
+feat: add error tracking with `captureException(...)` method and `autoCaptureExceptions` configuration option

--- a/package-lock.json
+++ b/package-lock.json
@@ -1560,6 +1560,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/@posthog/core": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.7.1.tgz",
+      "integrity": "sha512-kjK0eFMIpKo9GXIbts8VtAknsoZ18oZorANdtuTj1CbgS28t4ZVq//HAWhnxEuXRTrtkd+SUJ6Ux3j2Af8NCuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -2954,6 +2964,18 @@
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
@@ -6501,15 +6523,17 @@
       }
     },
     "node_modules/posthog-js": {
-      "version": "1.160.3",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.160.3.tgz",
-      "integrity": "sha512-mGvxOIlWPtdPx8EI0MQ81wNKlnH2K0n4RqwQOl044b34BCKiFVzZ7Hc7geMuZNaRAvCi5/5zyGeWHcAYZQxiMQ==",
+      "version": "1.306.2",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.306.2.tgz",
+      "integrity": "sha512-zBEjDvUs5RNTWbyHVjbL16Oigm2buFG2PQRRMC46hfL2HSh+8//zMD5gV3etxkUhjjTltKubK3mkqONMldw9Yg==",
       "dev": true,
-      "license": "MIT",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
+        "@posthog/core": "1.7.1",
+        "core-js": "^3.38.1",
         "fflate": "^0.4.8",
         "preact": "^10.19.3",
-        "web-vitals": "^4.0.1"
+        "web-vitals": "^4.2.4"
       }
     },
     "node_modules/preact": {
@@ -9155,7 +9179,7 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
-        "posthog-js": "1.160.3",
+        "posthog-js": "1.306.2",
         "prettier-plugin-java": "2.6.7",
         "rimraf": "6.1.2",
         "rollup": "4.53.3",

--- a/packages/posthog/CapawesomeCapacitorPosthog.podspec
+++ b/packages/posthog/CapawesomeCapacitorPosthog.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
-  s.dependency 'PostHog', '>= 3.19.1', '< 4.0'
+  s.dependency 'PostHog', '>= 3.56.0', '< 4.0'
   s.swift_version = '5.1'
   s.static_framework = true
 end

--- a/packages/posthog/Package.swift
+++ b/packages/posthog/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
-        .package(url: "https://github.com/PostHog/posthog-ios.git", .upToNextMajor(from: "3.19.1"))
+        .package(url: "https://github.com/PostHog/posthog-ios.git", .upToNextMajor(from: "3.56.0"))
     ],
     targets: [
         .target(

--- a/packages/posthog/README.md
+++ b/packages/posthog/README.md
@@ -66,6 +66,7 @@ This can be useful if you encounter dependency conflicts with other plugins in y
 | **`enableSessionReplay`**               | <code>boolean</code>                                                  | Whether to enable session recording automatically.                                        | <code>false</code>                      | 7.3.0 |
 | **`sessionReplayConfig`**               | <code><a href="#sessionreplayoptions">SessionReplayOptions</a></code> | Session recording configuration options.                                                  |                                         | 7.3.0 |
 | **`captureApplicationLifecycleEvents`** | <code>boolean</code>                                                  | Whether to capture application lifecycle events.                                          | <code>true</code>                       | 8.3.0 |
+| **`autoCaptureExceptions`**             | <code>boolean</code>                                                  | Whether to automatically capture unhandled exceptions.                                    | <code>false</code>                      | 8.5.0 |
 
 ### Examples
 
@@ -81,7 +82,8 @@ In `capacitor.config.json`:
       "uiHost": 'https://eu.posthog.com',
       "enableSessionReplay": undefined,
       "sessionReplayConfig": undefined,
-      "captureApplicationLifecycleEvents": undefined
+      "captureApplicationLifecycleEvents": undefined,
+      "autoCaptureExceptions": undefined
     }
   }
 }
@@ -104,6 +106,7 @@ const config: CapacitorConfig = {
       enableSessionReplay: undefined,
       sessionReplayConfig: undefined,
       captureApplicationLifecycleEvents: undefined,
+      autoCaptureExceptions: undefined,
     },
   },
 };
@@ -200,6 +203,7 @@ const unregister = async () => {
 
 * [`alias(...)`](#alias)
 * [`capture(...)`](#capture)
+* [`captureException(...)`](#captureexception)
 * [`flush()`](#flush)
 * [`getDistinctId()`](#getdistinctid)
 * [`getFeatureFlag(...)`](#getfeatureflag)
@@ -256,6 +260,23 @@ Capture an event.
 | **`options`** | <code><a href="#captureoptions">CaptureOptions</a></code> |
 
 **Since:** 6.0.0
+
+--------------------
+
+
+### captureException(...)
+
+```typescript
+captureException(options: CaptureExceptionOptions) => Promise<void>
+```
+
+Capture an exception.
+
+| Param         | Type                                                                        |
+| ------------- | --------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#captureexceptionoptions">CaptureExceptionOptions</a></code> |
+
+**Since:** 8.5.0
 
 --------------------
 
@@ -569,6 +590,26 @@ Remove a super property.
 | **`properties`** | <code>Record&lt;string, any&gt;</code> | The properties to send with the event. | 6.0.0 |
 
 
+#### CaptureExceptionOptions
+
+| Prop             | Type                                   | Description                                                                                                                | Default              | Since |
+| ---------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------------------- | ----- |
+| **`message`**    | <code>string</code>                    | The message of the exception.                                                                                              |                      | 8.5.0 |
+| **`name`**       | <code>string</code>                    | The name of the exception. Used as the exception type for grouping.                                                        | <code>'Error'</code> | 8.5.0 |
+| **`stacktrace`** | <code>StackFrame[]</code>              | The stack trace of the exception. Can be generated from an `Error` using [`stacktrace.js`](https://www.stacktracejs.com/). |                      | 8.5.0 |
+| **`properties`** | <code>Record&lt;string, any&gt;</code> | The properties to send with the exception.                                                                                 |                      | 8.5.0 |
+
+
+#### StackFrame
+
+| Prop               | Type                | Description                        | Since |
+| ------------------ | ------------------- | ---------------------------------- | ----- |
+| **`functionName`** | <code>string</code> | The name of the function.          | 8.5.0 |
+| **`fileName`**     | <code>string</code> | The name of the file.              | 8.5.0 |
+| **`lineNumber`**   | <code>number</code> | The line number within the file.   | 8.5.0 |
+| **`columnNumber`** | <code>number</code> | The column number within the file. | 8.5.0 |
+
+
 #### GetDistinctIdResult
 
 | Prop             | Type                | Description              | Since |
@@ -671,6 +712,7 @@ Remove a super property.
 | **`optOut`**                            | <code>boolean</code>                                                  | Whether to opt out of capturing by default. User must call `optIn()` to enable capturing.                                                                                                                                                                                                    | <code>false</code>                      | 8.1.0 |
 | **`sessionReplayConfig`**               | <code><a href="#sessionreplayoptions">SessionReplayOptions</a></code> | Session replay configuration options.                                                                                                                                                                                                                                                        |                                         | 7.3.0 |
 | **`captureApplicationLifecycleEvents`** | <code>boolean</code>                                                  | Whether to capture application lifecycle events. Only available on iOS and Android.                                                                                                                                                                                                          | <code>true</code>                       | 8.3.0 |
+| **`autoCaptureExceptions`**             | <code>boolean</code>                                                  | Whether to automatically capture unhandled exceptions.                                                                                                                                                                                                                                       | <code>false</code>                      | 8.5.0 |
 
 
 #### SessionReplayOptions

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/Posthog.kt
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/Posthog.kt
@@ -2,6 +2,7 @@ package io.capawesome.capacitorjs.plugins.posthog
 
 import com.posthog.PostHog
 import com.posthog.android.PostHogAndroid
+import io.capawesome.capacitorjs.plugins.posthog.classes.options.CaptureExceptionOptions
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.CaptureOptions
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.IdentifyOptions
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.RegisterOptions
@@ -15,6 +16,7 @@ import io.capawesome.capacitorjs.plugins.posthog.classes.options.GetFeatureFlagP
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.GroupOptions
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.IsFeatureEnabledOptions
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.SessionReplayOptions
+import io.capawesome.capacitorjs.plugins.posthog.classes.options.StackFrame
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.UnregisterOptions
 import io.capawesome.capacitorjs.plugins.posthog.classes.results.GetDistinctIdResult
 import io.capawesome.capacitorjs.plugins.posthog.classes.results.GetFeatureFlagPayloadResult
@@ -32,6 +34,7 @@ class Posthog(private val config: PosthogConfig, private val plugin: PosthogPlug
                 config.getEnableSessionReplay(),
                 false,
                 config.getCaptureApplicationLifecycleEvents(),
+                config.getAutoCaptureExceptions(),
                 config.getSessionReplayConfig()
             )
         }
@@ -47,6 +50,37 @@ class Posthog(private val config: PosthogConfig, private val plugin: PosthogPlug
         val properties = options.properties
 
         com.posthog.PostHog.capture(event = event, properties = properties)
+    }
+
+    fun captureException(options: CaptureExceptionOptions) {
+        // Emit the `$exception` event directly instead of handing the SDK a Throwable.
+        // The Throwable path derives the type from the throwable's class name (dropping the
+        // caller's name) and synthesizes a native stack, while we want the JavaScript name
+        // and stack. This mirrors the `$exception_list` payload that posthog-js produces.
+        val name = options.name?.takeIf { it.isNotEmpty() } ?: "Error"
+        val exception = mutableMapOf<String, Any>(
+            "type" to name,
+            "value" to options.message,
+            "mechanism" to mapOf(
+                "type" to "generic",
+                "handled" to true,
+                "synthetic" to false
+            )
+        )
+
+        val frames = createFrames(options.stacktrace)
+        if (frames.isNotEmpty()) {
+            exception["stacktrace"] = mapOf(
+                "type" to "raw",
+                "frames" to frames
+            )
+        }
+
+        val properties = options.properties?.toMutableMap() ?: mutableMapOf()
+        properties["\$exception_level"] = "error"
+        properties["\$exception_list"] = listOf(exception)
+
+        com.posthog.PostHog.capture(event = "\$exception", properties = properties)
     }
 
     fun flush() {
@@ -134,6 +168,7 @@ class Posthog(private val config: PosthogConfig, private val plugin: PosthogPlug
         val enableSessionReplay = options.enableSessionReplay
         val optOut = options.optOut
         val captureApplicationLifecycleEvents = options.captureApplicationLifecycleEvents
+        val autoCaptureExceptions = options.autoCaptureExceptions
         val sessionReplayConfig = options.sessionReplayConfig
 
         setup(
@@ -142,6 +177,7 @@ class Posthog(private val config: PosthogConfig, private val plugin: PosthogPlug
             enableSessionReplay,
             optOut,
             captureApplicationLifecycleEvents,
+            autoCaptureExceptions,
             sessionReplayConfig
         )
     }
@@ -152,12 +188,33 @@ class Posthog(private val config: PosthogConfig, private val plugin: PosthogPlug
         com.posthog.PostHog.unregister(key = key)
     }
 
+    private fun createFrames(stacktrace: List<StackFrame>?): List<Map<String, Any>> {
+        if (stacktrace.isNullOrEmpty()) {
+            return emptyList()
+        }
+        val frames = stacktrace.map { frame ->
+            val map = mutableMapOf<String, Any>(
+                "platform" to "web:javascript",
+                "function" to (frame.functionName ?: "?"),
+                "in_app" to true
+            )
+            frame.fileName?.let { map["filename"] = it }
+            frame.lineNumber?.let { map["lineno"] = it }
+            frame.columnNumber?.let { map["colno"] = it }
+            map
+        }
+        // PostHog stores frames bottom-up (oldest call first), while the JavaScript
+        // stack trace is top-down (most recent call first), so reverse them.
+        return frames.asReversed()
+    }
+
     private fun setup(
         apiKey: String,
         apiHost: String,
         enableSessionReplay: Boolean = false,
         optOut: Boolean = false,
         captureApplicationLifecycleEvents: Boolean = true,
+        autoCaptureExceptions: Boolean = false,
         sessionReplayConfig: SessionReplayOptions? = null
     ) {
         val posthogConfig = PostHogAndroidConfig(
@@ -168,6 +225,7 @@ class Posthog(private val config: PosthogConfig, private val plugin: PosthogPlug
         posthogConfig.captureApplicationLifecycleEvents = captureApplicationLifecycleEvents
         posthogConfig.optOut = optOut
         posthogConfig.sessionReplay = enableSessionReplay
+        posthogConfig.errorTrackingConfig.autoCapture = autoCaptureExceptions
 
         // Configure session replay options if provided
         sessionReplayConfig?.let { replayConfig ->

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/PosthogConfig.java
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/PosthogConfig.java
@@ -14,6 +14,8 @@ public class PosthogConfig {
 
     private boolean captureApplicationLifecycleEvents = true;
 
+    private boolean autoCaptureExceptions = false;
+
     @Nullable
     private SessionReplayOptions sessionReplayConfig = null;
 
@@ -32,6 +34,10 @@ public class PosthogConfig {
 
     public boolean getCaptureApplicationLifecycleEvents() {
         return captureApplicationLifecycleEvents;
+    }
+
+    public boolean getAutoCaptureExceptions() {
+        return autoCaptureExceptions;
     }
 
     @Nullable
@@ -53,6 +59,10 @@ public class PosthogConfig {
 
     public void setCaptureApplicationLifecycleEvents(boolean captureApplicationLifecycleEvents) {
         this.captureApplicationLifecycleEvents = captureApplicationLifecycleEvents;
+    }
+
+    public void setAutoCaptureExceptions(boolean autoCaptureExceptions) {
+        this.autoCaptureExceptions = autoCaptureExceptions;
     }
 
     public void setSessionReplayConfig(@Nullable SessionReplayOptions sessionReplayConfig) {

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/PosthogPlugin.java
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/PosthogPlugin.java
@@ -2,6 +2,7 @@ package io.capawesome.capacitorjs.plugins.posthog;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Logger;
 import com.getcapacitor.Plugin;
@@ -9,6 +10,7 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.AliasOptions;
+import io.capawesome.capacitorjs.plugins.posthog.classes.options.CaptureExceptionOptions;
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.CaptureOptions;
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.GetFeatureFlagOptions;
 import io.capawesome.capacitorjs.plugins.posthog.classes.options.GetFeatureFlagPayloadOptions;
@@ -32,6 +34,7 @@ public class PosthogPlugin extends Plugin {
     public static final String ERROR_DISTINCT_ID_MISSING = "distinctId must be provided.";
     public static final String ERROR_EVENT_MISSING = "event must be provided.";
     public static final String ERROR_KEY_MISSING = "key must be provided.";
+    public static final String ERROR_MESSAGE_MISSING = "message must be provided.";
     public static final String ERROR_SCREEN_TITLE_MISSING = "screenTitle must be provided.";
     public static final String ERROR_TYPE_MISSING = "type must be provided.";
     public static final String ERROR_VALUE_MISSING = "value must be provided.";
@@ -80,6 +83,27 @@ public class PosthogPlugin extends Plugin {
             CaptureOptions options = new CaptureOptions(event, properties);
 
             implementation.capture(options);
+            call.resolve();
+        } catch (Exception exception) {
+            rejectCall(call, exception);
+        }
+    }
+
+    @PluginMethod
+    public void captureException(PluginCall call) {
+        try {
+            String message = call.getString("message");
+            if (message == null) {
+                call.reject(ERROR_MESSAGE_MISSING);
+                return;
+            }
+            String name = call.getString("name");
+            JSArray stacktrace = call.getArray("stacktrace");
+            JSObject properties = call.getObject("properties");
+
+            CaptureExceptionOptions options = new CaptureExceptionOptions(message, name, stacktrace, properties);
+
+            implementation.captureException(options);
             call.resolve();
         } catch (Exception exception) {
             rejectCall(call, exception);
@@ -288,6 +312,7 @@ public class PosthogPlugin extends Plugin {
             Boolean enableSessionReplay = call.getBoolean("enableSessionReplay", false);
             Boolean optOut = call.getBoolean("optOut", false);
             Boolean captureApplicationLifecycleEvents = call.getBoolean("captureApplicationLifecycleEvents", true);
+            Boolean autoCaptureExceptions = call.getBoolean("autoCaptureExceptions", false);
 
             SetupOptions options = new SetupOptions(apiKey, apiHost);
             options.setEnableSessionReplay(enableSessionReplay != null ? enableSessionReplay : false);
@@ -295,6 +320,7 @@ public class PosthogPlugin extends Plugin {
             options.setCaptureApplicationLifecycleEvents(
                 captureApplicationLifecycleEvents != null ? captureApplicationLifecycleEvents : true
             );
+            options.setAutoCaptureExceptions(autoCaptureExceptions != null ? autoCaptureExceptions : false);
 
             JSObject sessionReplayConfigObject = call.getObject("sessionReplayConfig");
             if (sessionReplayConfigObject != null) {
@@ -346,6 +372,8 @@ public class PosthogPlugin extends Plugin {
         boolean captureApplicationLifecycleEvents = getConfig()
             .getBoolean("captureApplicationLifecycleEvents", config.getCaptureApplicationLifecycleEvents());
         config.setCaptureApplicationLifecycleEvents(captureApplicationLifecycleEvents);
+        boolean autoCaptureExceptions = getConfig().getBoolean("autoCaptureExceptions", config.getAutoCaptureExceptions());
+        config.setAutoCaptureExceptions(autoCaptureExceptions);
 
         JSONObject sessionReplayConfigObject = getConfig().getObject("sessionReplayConfig");
         if (sessionReplayConfigObject != null) {

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/classes/options/CaptureExceptionOptions.java
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/classes/options/CaptureExceptionOptions.java
@@ -1,0 +1,72 @@
+package io.capawesome.capacitorjs.plugins.posthog.classes.options;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
+import io.capawesome.capacitorjs.plugins.posthog.PosthogHelper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class CaptureExceptionOptions {
+
+    @NonNull
+    private final String message;
+
+    @Nullable
+    private final String name;
+
+    @Nullable
+    private final List<StackFrame> stacktrace;
+
+    @Nullable
+    private final Map<String, Object> properties;
+
+    public CaptureExceptionOptions(
+        @NonNull String message,
+        @Nullable String name,
+        @Nullable JSArray stacktrace,
+        @Nullable JSObject properties
+    ) throws JSONException {
+        this.message = message;
+        this.name = name;
+        this.stacktrace = createStackFrames(stacktrace);
+        this.properties = PosthogHelper.createHashMapFromJSONObject(properties);
+    }
+
+    @NonNull
+    public String getMessage() {
+        return message;
+    }
+
+    @Nullable
+    public String getName() {
+        return name;
+    }
+
+    @Nullable
+    public List<StackFrame> getStacktrace() {
+        return stacktrace;
+    }
+
+    @Nullable
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+
+    @Nullable
+    private static List<StackFrame> createStackFrames(@Nullable JSArray stacktrace) throws JSONException {
+        if (stacktrace == null) {
+            return null;
+        }
+        List<StackFrame> frames = new ArrayList<>();
+        for (int i = 0; i < stacktrace.length(); i++) {
+            JSONObject frame = stacktrace.getJSONObject(i);
+            frames.add(new StackFrame(frame));
+        }
+        return frames;
+    }
+}

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/classes/options/SetupOptions.java
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/classes/options/SetupOptions.java
@@ -21,6 +21,9 @@ public class SetupOptions {
     private Boolean captureApplicationLifecycleEvents;
 
     @Nullable
+    private Boolean autoCaptureExceptions;
+
+    @Nullable
     private SessionReplayOptions sessionReplayConfig;
 
     public SetupOptions(@NonNull String apiKey, @NonNull String apiHost) {
@@ -60,6 +63,14 @@ public class SetupOptions {
 
     public void setCaptureApplicationLifecycleEvents(boolean captureApplicationLifecycleEvents) {
         this.captureApplicationLifecycleEvents = captureApplicationLifecycleEvents;
+    }
+
+    public boolean getAutoCaptureExceptions() {
+        return autoCaptureExceptions != null ? autoCaptureExceptions : false;
+    }
+
+    public void setAutoCaptureExceptions(boolean autoCaptureExceptions) {
+        this.autoCaptureExceptions = autoCaptureExceptions;
     }
 
     @Nullable

--- a/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/classes/options/StackFrame.java
+++ b/packages/posthog/android/src/main/java/io/capawesome/capacitorjs/plugins/posthog/classes/options/StackFrame.java
@@ -1,0 +1,47 @@
+package io.capawesome.capacitorjs.plugins.posthog.classes.options;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import org.json.JSONObject;
+
+public class StackFrame {
+
+    @Nullable
+    private final String functionName;
+
+    @Nullable
+    private final String fileName;
+
+    @Nullable
+    private final Integer lineNumber;
+
+    @Nullable
+    private final Integer columnNumber;
+
+    public StackFrame(@NonNull JSONObject frame) {
+        this.functionName = frame.isNull("functionName") ? null : frame.optString("functionName", null);
+        this.fileName = frame.isNull("fileName") ? null : frame.optString("fileName", null);
+        this.lineNumber = frame.has("lineNumber") && !frame.isNull("lineNumber") ? frame.optInt("lineNumber") : null;
+        this.columnNumber = frame.has("columnNumber") && !frame.isNull("columnNumber") ? frame.optInt("columnNumber") : null;
+    }
+
+    @Nullable
+    public String getFunctionName() {
+        return functionName;
+    }
+
+    @Nullable
+    public String getFileName() {
+        return fileName;
+    }
+
+    @Nullable
+    public Integer getLineNumber() {
+        return lineNumber;
+    }
+
+    @Nullable
+    public Integer getColumnNumber() {
+        return columnNumber;
+    }
+}

--- a/packages/posthog/ios/Plugin.xcodeproj/project.pbxproj
+++ b/packages/posthog/ios/Plugin.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		7C27475A2D3BFF7800589048 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C2747592D3BFF7200589048 /* Result.swift */; };
 		7C27475D2D3C032D00589048 /* CustomError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C27475C2D3C032A00589048 /* CustomError.swift */; };
 		7C28C8C22C8AE99100271553 /* AliasOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C28C8C12C8AE99100271553 /* AliasOptions.swift */; };
+		A1B2C3D52F0C113000AABB02 /* CaptureExceptionOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42F0C113000AABB02 /* CaptureExceptionOptions.swift */; };
+		A1B2C3D72F0C113000AABB03 /* StackFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D62F0C113000AABB03 /* StackFrame.swift */; };
 		7C28C8C42C8AE99E00271553 /* CaptureOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C28C8C32C8AE99E00271553 /* CaptureOptions.swift */; };
 		7C28C8C62C8AE9AC00271553 /* IdentifyOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C28C8C52C8AE9AC00271553 /* IdentifyOptions.swift */; };
 		7C28C8C82C8AE9B800271553 /* RegisterOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C28C8C72C8AE9B800271553 /* RegisterOptions.swift */; };
@@ -67,6 +69,8 @@
 		7C2747592D3BFF7200589048 /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		7C27475C2D3C032A00589048 /* CustomError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomError.swift; sourceTree = "<group>"; };
 		7C28C8C12C8AE99100271553 /* AliasOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasOptions.swift; sourceTree = "<group>"; };
+		A1B2C3D42F0C113000AABB02 /* CaptureExceptionOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureExceptionOptions.swift; sourceTree = "<group>"; };
+		A1B2C3D62F0C113000AABB03 /* StackFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackFrame.swift; sourceTree = "<group>"; };
 		7C28C8C32C8AE99E00271553 /* CaptureOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureOptions.swift; sourceTree = "<group>"; };
 		7C28C8C52C8AE9AC00271553 /* IdentifyOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifyOptions.swift; sourceTree = "<group>"; };
 		7C28C8C72C8AE9B800271553 /* RegisterOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterOptions.swift; sourceTree = "<group>"; };
@@ -193,6 +197,8 @@
 				7C2747512D3BFF0300589048 /* IsFeatureEnabledOptions.swift */,
 				7C27474C2D3BFEF000589048 /* GetFeatureFlagOptions.swift */,
 				7C28C8C12C8AE99100271553 /* AliasOptions.swift */,
+				A1B2C3D42F0C113000AABB02 /* CaptureExceptionOptions.swift */,
+				A1B2C3D62F0C113000AABB03 /* StackFrame.swift */,
 				7C28C8C32C8AE99E00271553 /* CaptureOptions.swift */,
 				7C28C8C52C8AE9AC00271553 /* IdentifyOptions.swift */,
 				7C28C8C72C8AE9B800271553 /* RegisterOptions.swift */,
@@ -418,6 +424,8 @@
 				9BD9F4D32EA7141600408A6E /* SessionReplayOptions.swift in Sources */,
 				7C28C8CE2C8AE9D800271553 /* UnregisterOptions.swift in Sources */,
 				7C28C8C22C8AE99100271553 /* AliasOptions.swift in Sources */,
+				A1B2C3D52F0C113000AABB02 /* CaptureExceptionOptions.swift in Sources */,
+				A1B2C3D72F0C113000AABB03 /* StackFrame.swift in Sources */,
 				030596E12D79853F001EC5F7 /* GetFeatureFlagPayloadResult.swift in Sources */,
 				B1D2E3F52F0C112300AABB01 /* GetDistinctIdResult.swift in Sources */,
 				7C2747502D3BFEFE00589048 /* GetFeatureFlagResult.swift in Sources */,

--- a/packages/posthog/ios/Plugin/Classes/Options/CaptureExceptionOptions.swift
+++ b/packages/posthog/ios/Plugin/Classes/Options/CaptureExceptionOptions.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Capacitor
+
+@objc public class CaptureExceptionOptions: NSObject {
+    private var message: String
+    private var name: String?
+    private var stacktrace: [StackFrame]?
+    private var properties: [String: Any]?
+
+    init(message: String, name: String?, stacktrace: JSArray?, properties: JSObject?) {
+        self.message = message
+        self.name = name
+        self.stacktrace = CaptureExceptionOptions.createStackFrames(stacktrace)
+        self.properties = PosthogHelper.createHashMapFromJSObject(properties)
+    }
+
+    func getMessage() -> String {
+        return message
+    }
+
+    func getName() -> String? {
+        return name
+    }
+
+    func getStacktrace() -> [StackFrame]? {
+        return stacktrace
+    }
+
+    func getProperties() -> [String: Any]? {
+        return properties
+    }
+
+    private static func createStackFrames(_ stacktrace: JSArray?) -> [StackFrame]? {
+        guard let stacktrace = stacktrace else {
+            return nil
+        }
+        var frames: [StackFrame] = []
+        for element in stacktrace {
+            if let frame = element as? JSObject {
+                frames.append(StackFrame(frame))
+            }
+        }
+        return frames
+    }
+}

--- a/packages/posthog/ios/Plugin/Classes/Options/SetupOptions.swift
+++ b/packages/posthog/ios/Plugin/Classes/Options/SetupOptions.swift
@@ -6,6 +6,7 @@ import Foundation
     private var enableSessionReplay: Bool
     private var optOut: Bool
     private var captureApplicationLifecycleEvents: Bool
+    private var autoCaptureExceptions: Bool
     private var sessionReplayConfig: SessionReplayOptions?
 
     init(
@@ -14,6 +15,7 @@ import Foundation
         enableSessionReplay: Bool,
         optOut: Bool,
         captureApplicationLifecycleEvents: Bool,
+        autoCaptureExceptions: Bool,
         sessionReplayConfig: [String: Any]?
     ) {
         self.apiKey = apiKey
@@ -21,6 +23,7 @@ import Foundation
         self.enableSessionReplay = enableSessionReplay
         self.optOut = optOut
         self.captureApplicationLifecycleEvents = captureApplicationLifecycleEvents
+        self.autoCaptureExceptions = autoCaptureExceptions
 
         if let config = sessionReplayConfig {
             self.sessionReplayConfig = SessionReplayOptions(
@@ -52,6 +55,10 @@ import Foundation
 
     func getCaptureApplicationLifecycleEvents() -> Bool {
         return captureApplicationLifecycleEvents
+    }
+
+    func getAutoCaptureExceptions() -> Bool {
+        return autoCaptureExceptions
     }
 
     func getSessionReplayConfig() -> SessionReplayOptions? {

--- a/packages/posthog/ios/Plugin/Classes/Options/StackFrame.swift
+++ b/packages/posthog/ios/Plugin/Classes/Options/StackFrame.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Capacitor
+
+@objc public class StackFrame: NSObject {
+    private var functionName: String?
+    private var fileName: String?
+    private var lineNumber: Int?
+    private var columnNumber: Int?
+
+    init(_ frame: JSObject) {
+        self.functionName = frame["functionName"] as? String
+        self.fileName = frame["fileName"] as? String
+        self.lineNumber = (frame["lineNumber"] as? NSNumber)?.intValue
+        self.columnNumber = (frame["columnNumber"] as? NSNumber)?.intValue
+    }
+
+    func getFunctionName() -> String? {
+        return functionName
+    }
+
+    func getFileName() -> String? {
+        return fileName
+    }
+
+    func getLineNumber() -> Int? {
+        return lineNumber
+    }
+
+    func getColumnNumber() -> Int? {
+        return columnNumber
+    }
+}

--- a/packages/posthog/ios/Plugin/Enums/CustomError.swift
+++ b/packages/posthog/ios/Plugin/Enums/CustomError.swift
@@ -6,6 +6,7 @@ public enum CustomError: Error {
     case distinctIdMissing
     case eventMissing
     case keyMissing
+    case messageMissing
     case screenTitleMissing
     case typeMissing
     case valueMissing
@@ -24,6 +25,8 @@ extension CustomError: LocalizedError {
             return NSLocalizedString("event must be provided.", comment: "eventMissing")
         case .keyMissing:
             return NSLocalizedString("key must be provided.", comment: "keyMissing")
+        case .messageMissing:
+            return NSLocalizedString("message must be provided.", comment: "messageMissing")
         case .screenTitleMissing:
             return NSLocalizedString("screenTitle must be provided.", comment: "screenTitleMissing")
         case .typeMissing:

--- a/packages/posthog/ios/Plugin/Posthog.swift
+++ b/packages/posthog/ios/Plugin/Posthog.swift
@@ -10,6 +10,7 @@ import PostHog
                 apiHost: config.apiHost,
                 enableSessionReplay: config.enableSessionReplay,
                 captureApplicationLifecycleEvents: config.captureApplicationLifecycleEvents,
+                autoCaptureExceptions: config.autoCaptureExceptions,
                 sessionReplayConfig: config.sessionReplayConfig
             )
 
@@ -31,6 +32,65 @@ import PostHog
         let properties = options.getProperties()
 
         PostHogSDK.shared.capture(event, properties: properties)
+    }
+
+    @objc public func captureException(_ options: CaptureExceptionOptions) {
+        // Emit the `$exception` event directly instead of handing the SDK an `Error`.
+        // The `Error` path re-derives the type from the error domain and discards the
+        // JavaScript stack in favour of a native one, while we want the JavaScript name
+        // and stack. This mirrors the `$exception_list` payload that posthog-js produces.
+        let name = options.getName() ?? ""
+        var exception: [String: Any] = [
+            "type": name.isEmpty ? "Error" : name,
+            "value": options.getMessage(),
+            "mechanism": [
+                "type": "generic",
+                "handled": true,
+                "synthetic": false
+            ]
+        ]
+
+        let frames = Posthog.createFrames(options.getStacktrace())
+        if !frames.isEmpty {
+            exception["stacktrace"] = [
+                "type": "raw",
+                "frames": frames
+            ]
+        }
+
+        var properties: [String: Any] = [:]
+        options.getProperties()?.forEach { properties[$0.key] = $0.value }
+        properties["$exception_level"] = "error"
+        properties["$exception_list"] = [exception]
+
+        PostHogSDK.shared.capture("$exception", properties: properties)
+    }
+
+    private static func createFrames(_ stacktrace: [StackFrame]?) -> [[String: Any]] {
+        guard let stacktrace = stacktrace, !stacktrace.isEmpty else {
+            return []
+        }
+        var frames: [[String: Any]] = []
+        for frame in stacktrace {
+            var map: [String: Any] = [
+                "platform": "web:javascript",
+                "function": frame.getFunctionName() ?? "?",
+                "in_app": true
+            ]
+            if let fileName = frame.getFileName() {
+                map["filename"] = fileName
+            }
+            if let lineNumber = frame.getLineNumber() {
+                map["lineno"] = lineNumber
+            }
+            if let columnNumber = frame.getColumnNumber() {
+                map["colno"] = columnNumber
+            }
+            frames.append(map)
+        }
+        // PostHog stores frames bottom-up (oldest call first), while the JavaScript
+        // stack trace is top-down (most recent call first), so reverse them.
+        return frames.reversed()
     }
 
     @objc public func flush() {
@@ -120,9 +180,18 @@ import PostHog
         let enableSessionReplay = options.getEnableSessionReplay()
         let optOut = options.getOptOut()
         let captureApplicationLifecycleEvents = options.getCaptureApplicationLifecycleEvents()
+        let autoCaptureExceptions = options.getAutoCaptureExceptions()
         let sessionReplayConfig = options.getSessionReplayConfig()
 
-        setup(apiKey: apiKey, apiHost: apiHost, enableSessionReplay: enableSessionReplay, optOut: optOut, captureApplicationLifecycleEvents: captureApplicationLifecycleEvents, sessionReplayConfig: sessionReplayConfig)
+        setup(
+            apiKey: apiKey,
+            apiHost: apiHost,
+            enableSessionReplay: enableSessionReplay,
+            optOut: optOut,
+            captureApplicationLifecycleEvents: captureApplicationLifecycleEvents,
+            autoCaptureExceptions: autoCaptureExceptions,
+            sessionReplayConfig: sessionReplayConfig
+        )
     }
 
     @objc public func startSessionRecording() {
@@ -133,11 +202,12 @@ import PostHog
         PostHogSDK.shared.stopSessionRecording()
     }
 
-    private func setup(apiKey: String, apiHost: String, enableSessionReplay: Bool = false, optOut: Bool = false, captureApplicationLifecycleEvents: Bool = true, sessionReplayConfig: SessionReplayOptions? = nil) {
+    private func setup(apiKey: String, apiHost: String, enableSessionReplay: Bool = false, optOut: Bool = false, captureApplicationLifecycleEvents: Bool = true, autoCaptureExceptions: Bool = false, sessionReplayConfig: SessionReplayOptions? = nil) {
         let config = PostHogConfig(apiKey: apiKey, host: apiHost)
         config.captureScreenViews = false
         config.optOut = optOut
         config.captureApplicationLifecycleEvents = captureApplicationLifecycleEvents
+        config.errorTrackingConfig.autoCapture = autoCaptureExceptions
         config.sessionReplay = enableSessionReplay
         config.sessionReplayConfig.screenshotMode = sessionReplayConfig?.getScreenshotMode() ?? false
         config.sessionReplayConfig.maskAllImages = sessionReplayConfig?.getMaskAllImages() ?? true

--- a/packages/posthog/ios/Plugin/Posthog.swift
+++ b/packages/posthog/ios/Plugin/Posthog.swift
@@ -90,7 +90,7 @@ import PostHog
         }
         // PostHog stores frames bottom-up (oldest call first), while the JavaScript
         // stack trace is top-down (most recent call first), so reverse them.
-        return frames.reversed()
+        return Array(frames.reversed())
     }
 
     @objc public func flush() {

--- a/packages/posthog/ios/Plugin/PosthogConfig.swift
+++ b/packages/posthog/ios/Plugin/PosthogConfig.swift
@@ -5,5 +5,6 @@ public struct PosthogConfig {
     var apiHost = "https://us.i.posthog.com"
     var enableSessionReplay = false
     var captureApplicationLifecycleEvents = true
+    var autoCaptureExceptions = false
     var sessionReplayConfig: SessionReplayOptions?
 }

--- a/packages/posthog/ios/Plugin/PosthogPlugin.swift
+++ b/packages/posthog/ios/Plugin/PosthogPlugin.swift
@@ -14,6 +14,7 @@ public class PosthogPlugin: CAPPlugin, CAPBridgedPlugin {
     public let pluginMethods: [CAPPluginMethod] = [
         CAPPluginMethod(name: "alias", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "capture", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "captureException", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "flush", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getDistinctId", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getFeatureFlag", returnType: CAPPluginReturnPromise),
@@ -62,6 +63,21 @@ public class PosthogPlugin: CAPPlugin, CAPBridgedPlugin {
         let options = CaptureOptions(event: event, properties: properties)
 
         implementation?.capture(options)
+        call.resolve()
+    }
+
+    @objc func captureException(_ call: CAPPluginCall) {
+        guard let message = call.getString("message") else {
+            call.reject(CustomError.messageMissing.localizedDescription)
+            return
+        }
+        let name = call.getString("name")
+        let stacktrace = call.getArray("stacktrace")
+        let properties = call.getObject("properties")
+
+        let options = CaptureExceptionOptions(message: message, name: name, stacktrace: stacktrace, properties: properties)
+
+        implementation?.captureException(options)
         call.resolve()
     }
 
@@ -206,6 +222,7 @@ public class PosthogPlugin: CAPPlugin, CAPBridgedPlugin {
         let enableSessionReplay = call.getBool("enableSessionReplay", false)
         let optOut = call.getBool("optOut", false)
         let captureApplicationLifecycleEvents = call.getBool("captureApplicationLifecycleEvents", true)
+        let autoCaptureExceptions = call.getBool("autoCaptureExceptions", false)
         let sessionReplayConfig = call.getObject("sessionReplayConfig")
 
         let options = SetupOptions(
@@ -214,6 +231,7 @@ public class PosthogPlugin: CAPPlugin, CAPBridgedPlugin {
             enableSessionReplay: enableSessionReplay,
             optOut: optOut,
             captureApplicationLifecycleEvents: captureApplicationLifecycleEvents,
+            autoCaptureExceptions: autoCaptureExceptions,
             sessionReplayConfig: sessionReplayConfig
         )
 
@@ -253,6 +271,7 @@ public class PosthogPlugin: CAPPlugin, CAPBridgedPlugin {
             "captureApplicationLifecycleEvents",
             config.captureApplicationLifecycleEvents
         )
+        config.autoCaptureExceptions = getConfig().getBoolean("autoCaptureExceptions", config.autoCaptureExceptions)
 
         if let sessionReplayConfigDict = getConfig().getObject("sessionReplayConfig") as? [String: Any] {
             config.sessionReplayConfig = SessionReplayOptions(

--- a/packages/posthog/ios/Podfile
+++ b/packages/posthog/ios/Podfile
@@ -9,7 +9,7 @@ end
 
 target 'Plugin' do
   capacitor_pods
-  pod 'PostHog', '>= 3.19.1', '< 4.0'
+  pod 'PostHog', '>= 3.56.0', '< 4.0'
 end
 
 target 'PluginTests' do

--- a/packages/posthog/package.json
+++ b/packages/posthog/package.json
@@ -66,7 +66,7 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
-    "posthog-js": "1.160.3",
+    "posthog-js": "1.306.2",
     "prettier-plugin-java": "2.6.7",
     "rimraf": "6.1.2",
     "rollup": "4.53.3",

--- a/packages/posthog/src/definitions.ts
+++ b/packages/posthog/src/definitions.ts
@@ -58,6 +58,13 @@ declare module '@capacitor/cli' {
        * @default true
        */
       captureApplicationLifecycleEvents?: boolean;
+      /**
+       * Whether to automatically capture unhandled exceptions.
+       *
+       * @since 8.5.0
+       * @default false
+       */
+      autoCaptureExceptions?: boolean;
     };
   }
 }
@@ -75,6 +82,12 @@ export interface PosthogPlugin {
    * @since 6.0.0
    */
   capture(options: CaptureOptions): Promise<void>;
+  /**
+   * Capture an exception.
+   *
+   * @since 8.5.0
+   */
+  captureException(options: CaptureExceptionOptions): Promise<void>;
   /**
    * Flush all events in the queue.
    *
@@ -228,6 +241,70 @@ export interface CaptureOptions {
    * @since 6.0.0
    */
   properties?: Record<string, any>;
+}
+
+/**
+ * @since 8.5.0
+ */
+export interface CaptureExceptionOptions {
+  /**
+   * The message of the exception.
+   *
+   * @since 8.5.0
+   */
+  message: string;
+  /**
+   * The name of the exception. Used as the exception type for grouping.
+   *
+   * @since 8.5.0
+   * @default 'Error'
+   * @example 'TypeError'
+   */
+  name?: string;
+  /**
+   * The stack trace of the exception.
+   *
+   * Can be generated from an `Error` using [`stacktrace.js`](https://www.stacktracejs.com/).
+   *
+   * @since 8.5.0
+   */
+  stacktrace?: StackFrame[];
+  /**
+   * The properties to send with the exception.
+   *
+   * @since 8.5.0
+   */
+  properties?: Record<string, any>;
+}
+
+/**
+ * @since 8.5.0
+ */
+export interface StackFrame {
+  /**
+   * The name of the function.
+   *
+   * @since 8.5.0
+   */
+  functionName?: string;
+  /**
+   * The name of the file.
+   *
+   * @since 8.5.0
+   */
+  fileName?: string;
+  /**
+   * The line number within the file.
+   *
+   * @since 8.5.0
+   */
+  lineNumber?: number;
+  /**
+   * The column number within the file.
+   *
+   * @since 8.5.0
+   */
+  columnNumber?: number;
 }
 
 /**
@@ -485,6 +562,13 @@ export interface SetupOptions {
    * @default true
    */
   captureApplicationLifecycleEvents?: boolean;
+  /**
+   * Whether to automatically capture unhandled exceptions.
+   *
+   * @since 8.5.0
+   * @default false
+   */
+  autoCaptureExceptions?: boolean;
 }
 
 /**

--- a/packages/posthog/src/web.ts
+++ b/packages/posthog/src/web.ts
@@ -4,6 +4,7 @@ import type { PostHogConfig } from 'posthog-js';
 
 import type {
   AliasOptions,
+  CaptureExceptionOptions,
   CaptureOptions,
   GetDistinctIdResult,
   GetFeatureFlagOptions,
@@ -19,6 +20,7 @@ import type {
   RegisterOptions,
   ScreenOptions,
   SetupOptions,
+  StackFrame,
   UnregisterOptions,
 } from './definitions';
 
@@ -29,6 +31,21 @@ export class PosthogWeb extends WebPlugin implements PosthogPlugin {
 
   async capture(options: CaptureOptions): Promise<void> {
     posthog.capture(options.event, options.properties);
+  }
+
+  async captureException(options: CaptureExceptionOptions): Promise<void> {
+    const error = new Error(options.message);
+    if (options.name) {
+      error.name = options.name;
+    }
+    if (options.stacktrace?.length) {
+      error.stack = this.createStackString(
+        error.name,
+        options.message,
+        options.stacktrace,
+      );
+    }
+    posthog.captureException(error, options.properties);
   }
 
   async flush(): Promise<void> {
@@ -49,7 +66,8 @@ export class PosthogWeb extends WebPlugin implements PosthogPlugin {
   async getFeatureFlagPayload(
     options: GetFeatureFlagPayloadOptions,
   ): Promise<GetFeatureFlagPayloadResult> {
-    return { value: posthog.getFeatureFlagPayload(options.key) };
+    const value = posthog.getFeatureFlagPayload(options.key) ?? null;
+    return { value: value as GetFeatureFlagPayloadResult['value'] };
   }
 
   async group(options: GroupOptions): Promise<void> {
@@ -116,6 +134,9 @@ export class PosthogWeb extends WebPlugin implements PosthogPlugin {
     if (options.cookielessMode) {
       config.cookieless_mode = options.cookielessMode;
     }
+    if (options.autoCaptureExceptions) {
+      config.capture_exceptions = true;
+    }
 
     // Configure session recording if enabled
     if (options.enableSessionReplay) {
@@ -148,6 +169,20 @@ export class PosthogWeb extends WebPlugin implements PosthogPlugin {
 
   private throwUnimplementedError(): never {
     throw this.unimplemented('Not implemented on web.');
+  }
+
+  private createStackString(
+    name: string,
+    message: string,
+    stacktrace: StackFrame[],
+  ): string {
+    const lines = stacktrace.map(frame => {
+      const location = [frame.fileName, frame.lineNumber, frame.columnNumber]
+        .filter(value => value !== undefined)
+        .join(':');
+      return `    at ${frame.functionName ?? '?'} (${location})`;
+    });
+    return [`${name}: ${message}`, ...lines].join('\n');
   }
 
   private getApiHost(apiHost?: string, host?: string): string {


### PR DESCRIPTION
Adds error tracking support to the PostHog plugin across Web, Android, and iOS.

## Changes

- Add `captureException(options)` method to manually capture exceptions with an optional name, stack trace, and properties.
- Add `autoCaptureExceptions` configuration option (`setup(...)` and Capacitor configuration) to automatically capture unhandled exceptions. Defaults to `false`.

## Design

- The stack trace is passed as a structured `StackFrame[]` (e.g. generated via [`stacktrace.js`](https://www.stacktracejs.com/)), including the column number for accurate server-side source map symbolication.
- On native, exceptions are emitted as explicit `$exception_list` events so the JavaScript exception name and stack are preserved, mirroring what `posthog-js` produces on the web. Frames are mapped as `web:javascript` so a single source map pipeline covers all platforms.
- On the web, the reconstructed `Error` is handed to `posthog.captureException(...)`.

## Dependencies

- Bump the minimum iOS PostHog SDK to `>= 3.56.0` (required for `errorTrackingConfig.autoCapture`).
- Bump the development `posthog-js` dependency to `1.306.2`.

Closes #645
Close #886