### PR TITLE
fix(age-signals): resolve compile error when building with Xcode 26.4 or older

### DIFF
--- a/.changeset/wild-mails-doubt.md
+++ b/.changeset/wild-mails-doubt.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-age-signals': patch
+---
+
+fix(ios): resolve compile error when building with Xcode 26.4 or older

--- a/packages/age-signals/ios/Plugin/AgeSignals.swift
+++ b/packages/age-signals/ios/Plugin/AgeSignals.swift
@@ -103,21 +103,26 @@ import DeclaredAgeRange
 
             let declaration: AgeRangeDeclaration?
             if #available(iOS 26.2, *), let value = range.ageRangeDeclaration {
-                if #available(iOS 26.5, *), value == .confirmed {
+                switch value {
+                case .selfDeclared:
+                    declaration = .selfDeclared
+                case .guardianDeclared:
+                    declaration = .guardianDeclared
+                case .checkedByOtherMethod, .guardianCheckedByOtherMethod,
+                     .governmentIDChecked, .guardianGovernmentIDChecked,
+                     .paymentChecked, .guardianPaymentChecked:
                     declaration = .confirmed
-                } else {
-                    switch value {
-                    case .selfDeclared:
-                        declaration = .selfDeclared
-                    case .guardianDeclared:
-                        declaration = .guardianDeclared
-                    case .checkedByOtherMethod, .guardianCheckedByOtherMethod,
-                         .governmentIDChecked, .guardianGovernmentIDChecked,
-                         .paymentChecked, .guardianPaymentChecked:
+                default:
+                    // `.confirmed` requires the iOS 26.5 SDK (Xcode 26.5, Swift 6.3.2).
+                    #if compiler(>=6.3.2)
+                    if #available(iOS 26.5, *), value == .confirmed {
                         declaration = .confirmed
-                    default:
+                    } else {
                         declaration = nil
                     }
+                    #else
+                    declaration = nil
+                    #endif
                 }
             } else {
                 declaration = nil


### PR DESCRIPTION
## Description

The iOS build of `@capawesome/capacitor-age-signals` fails with Xcode 26.4 or older (see [this CI run](https://github.com/capawesome-team/capacitor-plugins/actions/runs/28750292297/job/85248035441)):

```
packages/age-signals/ios/Plugin/AgeSignals.swift:106:55: error: type 'AgeRangeService.AgeRangeDeclaration' has no member 'confirmed'
```

The `.confirmed` enum case only exists in the iOS 26.5 SDK (Xcode 26.5, Swift 6.3.2). The existing `if #available(iOS 26.5, *)` guard is a runtime check only — the symbol must still exist in the SDK at compile time, so the build breaks on the CI runner's `latest-stable` Xcode 26.3 and for any plugin user on Xcode ≤ 26.4.

This PR wraps the `.confirmed` check in `#if compiler(>=6.3.2)` so older toolchains never see the symbol and map that case to `nil`. Behavior with Xcode 26.5+ is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)