### PR TITLE
docs: use human-readable plugin names as README headings

### DIFF
--- a/packages/accelerometer/README.md
+++ b/packages/accelerometer/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-accelerometer
+# Capacitor Accelerometer Plugin
 
 Capacitor plugin to capture the acceleration force along the x, y, and z axes.
 

--- a/packages/accessibility-preferences/README.md
+++ b/packages/accessibility-preferences/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-accessibility-preferences
+# Capacitor Accessibility Preferences Plugin
 
 Capacitor plugin for reading the user's system accessibility preferences.
 

--- a/packages/age-signals/README.md
+++ b/packages/age-signals/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-age-signals
+# Capacitor Age Signals Plugin
 
 Capacitor plugin to use the [Play Age Signals API](https://developer.android.com/google/play/age-signals/overview) (Android) and [DeclaredAgeRange](https://developer.apple.com/documentation/declaredagerange/) (iOS) to request age signals about the user.
 

--- a/packages/android-battery-optimization/README.md
+++ b/packages/android-battery-optimization/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-android-battery-optimization
+# Capacitor Android Battery Optimization Plugin
 
 Capacitor plugin for Android to manage battery optimization settings, request exemptions, and enhance app performance under Doze and App Standby modes.
 

--- a/packages/android-dark-mode-support/README.md
+++ b/packages/android-dark-mode-support/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-android-dark-mode-support
+# Capacitor Android Dark Mode Support Plugin
 
 Capacitor plugin for seamless Android dark mode support. Enhance user experience with `prefers-color-scheme` CSS media feature compatibility.
 

--- a/packages/android-edge-to-edge-support/README.md
+++ b/packages/android-edge-to-edge-support/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-android-edge-to-edge-support
+# Capacitor Android Edge-to-Edge Support Plugin
 
 Capacitor plugin to support [edge-to-edge](https://developer.android.com/develop/ui/views/layout/edge-to-edge) display on Android with advanced features like setting the background color of the status bar and navigation bar.
 

--- a/packages/android-foreground-service/README.md
+++ b/packages/android-foreground-service/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-android-foreground-service
+# Capacitor Android Foreground Service Plugin
 
 Capacitor plugin to run a foreground service on Android.
 

--- a/packages/android-sms-retriever/README.md
+++ b/packages/android-sms-retriever/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-android-sms-retriever
+# Capacitor Android SMS Retriever Plugin
 
 Capacitor plugin for OTP autofill on Android via the SMS User Consent and Phone Number Hint APIs.
 

--- a/packages/app-icon/README.md
+++ b/packages/app-icon/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-app-icon
+# Capacitor App Icon Plugin
 
 Capacitor plugin to change the app icon at runtime.
 

--- a/packages/app-integrity/README.md
+++ b/packages/app-integrity/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-app-integrity
+# Capacitor App Integrity Plugin
 
 Capacitor plugin to verify app and device integrity using the Play Integrity API (Android) and App Attest (iOS).
 

--- a/packages/app-language/README.md
+++ b/packages/app-language/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-app-language
+# Capacitor App Language Plugin
 
 Capacitor plugin to manage the app's own language override, independent of the device language.
 

--- a/packages/app-review/README.md
+++ b/packages/app-review/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-app-review
+# Capacitor App Review Plugin
 
 Capacitor plugin that allows users to submit app store reviews and ratings.
 

--- a/packages/app-shortcuts/README.md
+++ b/packages/app-shortcuts/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-app-shortcuts
+# Capacitor App Shortcuts Plugin
 
 Capacitor plugin to manage app shortcuts and quick actions.
 

--- a/packages/app-tracking-transparency/README.md
+++ b/packages/app-tracking-transparency/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-app-tracking-transparency
+# Capacitor App Tracking Transparency Plugin
 
 Capacitor plugin for the [App Tracking Transparency](https://developer.apple.com/documentation/apptrackingtransparency) framework.
 

--- a/packages/app-update/README.md
+++ b/packages/app-update/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-app-update
+# Capacitor App Update Plugin
 
 Capacitor plugin that assists with native app updates.
 It supports retrieving app update information on **Android** and **iOS** and supports [in-app updates](https://developer.android.com/guide/playcore/in-app-updates) on **Android**.

--- a/packages/apple-sign-in/README.md
+++ b/packages/apple-sign-in/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-apple-sign-in
+# Capacitor Apple Sign-In Plugin
 
 Unofficial Capacitor plugin to sign-in with Apple.[^1]
 

--- a/packages/asset-manager/README.md
+++ b/packages/asset-manager/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-asset-manager
+# Capacitor Asset Manager Plugin
 
 Capacitor plugin to access native asset files.
 

--- a/packages/audio-player/README.md
+++ b/packages/audio-player/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-audio-player
+# Capacitor Audio Player Plugin
 
 Capacitor plugin to play audio with background support.
 

--- a/packages/audio-recorder/README.md
+++ b/packages/audio-recorder/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-audio-recorder
+# Capacitor Audio Recorder Plugin
 
 Capacitor plugin for seamless audio recording using the device's microphone. Supports Android, iOS, and Web with advanced features and high performance.
 

--- a/packages/audio-session/README.md
+++ b/packages/audio-session/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-audio-session
+# Capacitor Audio Session Plugin
 
 Capacitor plugin to configure and observe the iOS [audio session](https://developer.apple.com/documentation/avfaudio/avaudiosession).
 

--- a/packages/background-task/README.md
+++ b/packages/background-task/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-background-task
+# Capacitor Background Task Plugin
 
 Capacitor plugin for running background tasks.
 

--- a/packages/badge/README.md
+++ b/packages/badge/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-badge
+# Capacitor Badge Plugin
 
 Capacitor plugin to access and update the badge number of the app icon.
 

--- a/packages/barometer/README.md
+++ b/packages/barometer/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-barometer
+# Capacitor Barometer Plugin
 
 Capacitor plugin to obtain the static air pressure, which is measured in hectopascals (hPa).
 

--- a/packages/battery/README.md
+++ b/packages/battery/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-battery
+# Capacitor Battery Plugin
 
 Capacitor plugin to access battery information.
 

--- a/packages/biometrics/README.md
+++ b/packages/biometrics/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-biometrics
+# Capacitor Biometrics Plugin
 
 Capacitor plugin to request biometric authentication, such as using face recognition or fingerprint recognition.
 

--- a/packages/bluetooth-low-energy/README.md
+++ b/packages/bluetooth-low-energy/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-bluetooth-low-energy
+# Capacitor Bluetooth Low Energy Plugin
 
 Capacitor plugin for Bluetooth Low Energy (BLE) communication in the central and peripheral role with advanced features like headless tasks, foreground services, and more.[^1][^2]
 

--- a/packages/cloudinary/README.md
+++ b/packages/cloudinary/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-cloudinary
+# Capacitor Cloudinary Plugin
 
 Unofficial Capacitor plugin for [Cloudinary SDK](https://cloudinary.com/documentation/cloudinary_sdks).[^1]
 

--- a/packages/compass/README.md
+++ b/packages/compass/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-compass
+# Capacitor Compass Plugin
 
 Capacitor plugin for reading the device compass heading.
 

--- a/packages/contacts/README.md
+++ b/packages/contacts/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-contacts
+# Capacitor Contacts Plugin
 
 Capacitor plugin to read, write, or select device contacts. Supports Android, iOS and Web with advanced features like contact groups, pagination, and native modals.
 

--- a/packages/datetime-picker/README.md
+++ b/packages/datetime-picker/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-datetime-picker
+# Capacitor Datetime Picker Plugin
 
 Capacitor plugin for seamless date and time selection with advanced features like localization, theming, and more. Available for Android and iOS.
 

--- a/packages/facebook-sign-in/README.md
+++ b/packages/facebook-sign-in/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-facebook-sign-in
+# Capacitor Facebook Sign-In Plugin
 
 Unofficial Capacitor plugin to sign-in with Facebook.[^1]
 

--- a/packages/file-compressor/README.md
+++ b/packages/file-compressor/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-file-compressor
+# Capacitor File Compressor Plugin
 
 Capacitor plugin for efficient file compression with support for image formats like PNG, JPEG, and WebP.
 

--- a/packages/file-opener/README.md
+++ b/packages/file-opener/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-file-opener
+# Capacitor File Opener Plugin
 
 Capacitor plugin to open a file with the default application.
 

--- a/packages/file-picker/README.md
+++ b/packages/file-picker/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-file-picker
+# Capacitor File Picker Plugin
 
 Capacitor plugin that allows the user to select a file, directory, image, or video from the device's file system or gallery.
 

--- a/packages/formbricks/README.md
+++ b/packages/formbricks/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-formbricks
+# Capacitor Formbricks Plugin
 
 Unofficial Capacitor plugin for [Formbricks](https://formbricks.com/).[^1]
 

--- a/packages/geocoder/README.md
+++ b/packages/geocoder/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-geocoder
+# Capacitor Geocoder Plugin
 
 Capacitor plugin for handling geocoding and reverse geocoding.
 

--- a/packages/google-sign-in/README.md
+++ b/packages/google-sign-in/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-google-sign-in
+# Capacitor Google Sign-In Plugin
 
 Unofficial Capacitor plugin to sign-in with Google.[^1]
 

--- a/packages/grafana-faro/README.md
+++ b/packages/grafana-faro/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-grafana-faro
+# Capacitor Grafana Faro Plugin
 
 Unofficial Capacitor plugin for [Grafana Faro](https://grafana.com/oss/faro/).[^1]
 

--- a/packages/gyroscope/README.md
+++ b/packages/gyroscope/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-gyroscope
+# Capacitor Gyroscope Plugin
 
 Capacitor plugin to read the device's gyroscope sensor.
 

--- a/packages/in-app-browser/README.md
+++ b/packages/in-app-browser/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-in-app-browser
+# Capacitor In-App Browser Plugin
 
 Capacitor plugin to open URLs in the external browser, the system browser or an embedded web view.
 

--- a/packages/install-referrer/README.md
+++ b/packages/install-referrer/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-install-referrer
+# Capacitor Install Referrer Plugin
 
 Capacitor plugin for reading install attribution data from the [Play Install Referrer](https://developer.android.com/google/play/installreferrer) and [Apple Ad Services](https://developer.apple.com/documentation/adservices).
 

--- a/packages/keep-awake/README.md
+++ b/packages/keep-awake/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-keep-awake
+# Capacitor Keep Awake Plugin
 
 Capacitor plugin to keep the screen awake.
 

--- a/packages/libsql/README.md
+++ b/packages/libsql/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-libsql
+# Capacitor libSQL Plugin
 
 Capacitor plugin for [libSQL](https://docs.turso.tech/libsql) databases.[^1]
 

--- a/packages/live-update/README.md
+++ b/packages/live-update/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-live-update
+# Capacitor Live Update Plugin
 
 Capacitor plugin that allows you to update your app remotely in real-time without requiring users to download a new version from the app store, known as Over-the-Air (OTA) updates.
 

--- a/packages/localization/README.md
+++ b/packages/localization/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-localization
+# Capacitor Localization Plugin
 
 Capacitor plugin to read the user's localization preferences, such as preferred locales, time zone, and regional formatting settings.
 

--- a/packages/mail-composer/README.md
+++ b/packages/mail-composer/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-mail-composer
+# Capacitor Mail Composer Plugin
 
 Capacitor plugin to open the native email composer.
 

--- a/packages/managed-configurations/README.md
+++ b/packages/managed-configurations/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-managed-configurations
+# Capacitor Managed Configurations Plugin
 
 Capacitor plugin to access managed configuration settings.
 

--- a/packages/maps-launcher/README.md
+++ b/packages/maps-launcher/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-maps-launcher
+# Capacitor Maps Launcher Plugin
 
 Capacitor plugin to launch navigation apps with turn-by-turn directions.
 

--- a/packages/media-session/README.md
+++ b/packages/media-session/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-media-session
+# Capacitor Media Session Plugin
 
 Capacitor plugin to interact with media controllers, volume keys and media buttons.
 

--- a/packages/navigation-bar/README.md
+++ b/packages/navigation-bar/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-navigation-bar
+# Capacitor Navigation Bar Plugin
 
 Capacitor plugin to set the background color and button style of the navigation bar.
 

--- a/packages/nfc/README.md
+++ b/packages/nfc/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-nfc
+# Capacitor NFC Plugin
 
 Capacitor plugin for NFC tag reading, writing, and emulation. Supports Android, iOS, and Web with advanced features like HCE and raw command handling.
 

--- a/packages/nodejs/README.md
+++ b/packages/nodejs/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-nodejs
+# Capacitor Node.js Plugin
 
 Capacitor plugin for running [Node.js](https://nodejs.org/) in mobile apps.[^1][^2]
 

--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-oauth
+# Capacitor OAuth Plugin
 
 Capacitor plugin for communicating with OAuth 2.0 and OpenID Connect providers.[^1][^2]
 

--- a/packages/passkeys/README.md
+++ b/packages/passkeys/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-passkeys
+# Capacitor Passkeys Plugin
 
 Capacitor plugin to create and authenticate with [passkeys](https://fidoalliance.org/passkeys/) based on the [WebAuthn](https://www.w3.org/TR/webauthn-2/) standard.
 

--- a/packages/password-autofill/README.md
+++ b/packages/password-autofill/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-password-autofill
+# Capacitor Password Autofill Plugin
 
 Capacitor plugin for saving passwords to the platform credential store.
 

--- a/packages/pedometer/README.md
+++ b/packages/pedometer/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-pedometer
+# Capacitor Pedometer Plugin
 
 Capacitor plugin to retrieve motion data, such as the number of steps and other information about the distance traveled.
 

--- a/packages/photo-editor/README.md
+++ b/packages/photo-editor/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-photo-editor
+# Capacitor Photo Editor Plugin
 
 Capacitor plugin that allows the user to edit a photo.
 

--- a/packages/pixlive/README.md
+++ b/packages/pixlive/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-pixlive
+# Capacitor PixLive Plugin
 
 Unofficial Capacitor plugin for [PixLive SDK](https://www.vidinoti.com/) by Vidinoti.
 

--- a/packages/posthog/README.md
+++ b/packages/posthog/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-posthog
+# Capacitor PostHog Plugin
 
 Unofficial Capacitor plugin for [PostHog](https://posthog.com/).[^1]
 

--- a/packages/printer/README.md
+++ b/packages/printer/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-printer
+# Capacitor Printer Plugin
 
 Capacitor plugin for seamless printing on Android and iOS. Supports base64, files, HTML, PDFs, and web views.
 

--- a/packages/privacy-screen/README.md
+++ b/packages/privacy-screen/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-privacy-screen
+# Capacitor Privacy Screen Plugin
 
 Capacitor plugin to hide sensitive app content in the app switcher, block screenshots, and detect when a screenshot is taken.
 

--- a/packages/purchases/README.md
+++ b/packages/purchases/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-purchases
+# Capacitor Purchases Plugin
 
 Capacitor plugin to support in-app purchases.
 

--- a/packages/realtimekit/README.md
+++ b/packages/realtimekit/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-realtimekit
+# Capacitor RealtimeKit Plugin
 
 Unofficial Capacitor plugin for using the [RealtimeKit SDK](https://docs.realtime.cloudflare.com/).[^1]
 

--- a/packages/root-detection/README.md
+++ b/packages/root-detection/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-root-detection
+# Capacitor Root Detection Plugin
 
 Capacitor plugin for detecting rooted and jailbroken devices.
 

--- a/packages/screen-brightness/README.md
+++ b/packages/screen-brightness/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-screen-brightness
+# Capacitor Screen Brightness Plugin
 
 Capacitor plugin for reading and controlling the screen brightness.
 

--- a/packages/screen-orientation/README.md
+++ b/packages/screen-orientation/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-screen-orientation
+# Capacitor Screen Orientation Plugin
 
 Capacitor plugin to lock/unlock the screen orientation.
 

--- a/packages/screenshot/README.md
+++ b/packages/screenshot/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-screenshot
+# Capacitor Screenshot Plugin
 
 Capacitor plugin for taking screenshots.
 

--- a/packages/secure-preferences/README.md
+++ b/packages/secure-preferences/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-secure-preferences
+# Capacitor Secure Preferences Plugin
 
 Capacitor plugin to securely store key/value pairs such as passwords, tokens or other sensitive information.
 

--- a/packages/shake/README.md
+++ b/packages/shake/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-shake
+# Capacitor Shake Plugin
 
 Capacitor plugin to detect shake gestures.
 

--- a/packages/share-target/README.md
+++ b/packages/share-target/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-share-target
+# Capacitor Share Target Plugin
 
 Capacitor plugin to receive content such as text, links, and files from other apps.
 

--- a/packages/silent-mode/README.md
+++ b/packages/silent-mode/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-silent-mode
+# Capacitor Silent Mode Plugin
 
 Capacitor plugin to detect whether the device is in silent mode.
 

--- a/packages/sim/README.md
+++ b/packages/sim/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-sim
+# Capacitor SIM Plugin
 
 Capacitor plugin for reading SIM card and carrier information.
 

--- a/packages/sms-composer/README.md
+++ b/packages/sms-composer/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-sms-composer
+# Capacitor SMS Composer Plugin
 
 Capacitor plugin to open the native SMS composer prefilled with recipients and a message body.
 

--- a/packages/speech-recognition/README.md
+++ b/packages/speech-recognition/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-speech-recognition
+# Capacitor Speech Recognition Plugin
 
 Capacitor plugin to transcribe speech into text (also known as speech-to-text) with advanced features like silence detection, contextual strings, and more.
 

--- a/packages/speech-synthesis/README.md
+++ b/packages/speech-synthesis/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-speech-synthesis
+# Capacitor Speech Synthesis Plugin
 
 Capacitor plugin for synthesizing speech from text (also known as text-to-speech) with advanced features like voice selection, pitch, and rate control.
 

--- a/packages/sqlite/README.md
+++ b/packages/sqlite/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-sqlite
+# Capacitor SQLite Plugin
 
 Capacitor plugin to access SQLite databases with support for encryption, transactions, and schema migrations.[^1][^2][^3]
 

--- a/packages/square-mobile-payments/README.md
+++ b/packages/square-mobile-payments/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-square-mobile-payments
+# Capacitor Square Mobile Payments Plugin
 
 Unofficial Capacitor plugin for [Square Mobile Payments SDK](https://developer.squareup.com/docs/mobile-payments-sdk).[^1]
 

--- a/packages/superwall/README.md
+++ b/packages/superwall/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-superwall
+# Capacitor Superwall Plugin
 
 Unofficial Capacitor plugin for [Superwall SDK](https://superwall.com/).[^1]
 

--- a/packages/thermal-state/README.md
+++ b/packages/thermal-state/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-thermal-state
+# Capacitor Thermal State Plugin
 
 Capacitor plugin to read the device thermal state and react before the operating system throttles your app.
 

--- a/packages/torch/README.md
+++ b/packages/torch/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-torch
+# Capacitor Torch Plugin
 
 Capacitor plugin for switching the flashlight on and off.
 

--- a/packages/vault/README.md
+++ b/packages/vault/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-vault
+# Capacitor Vault Plugin
 
 Capacitor plugin to securely store key/value pairs in lockable, biometric-protected vaults.
 

--- a/packages/volume/README.md
+++ b/packages/volume/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-volume
+# Capacitor Volume Plugin
 
 Capacitor plugin to control the volume and observe hardware volume button presses.
 

--- a/packages/wallet/README.md
+++ b/packages/wallet/README.md
@@ -1,4 +1,4 @@
-# @capawesome/capacitor-wallet
+# Capacitor Wallet Plugin
 
 Capacitor plugin for adding passes to [Apple Wallet](https://developer.apple.com/documentation/passkit) and [Google Wallet](https://developers.google.com/wallet).
 

--- a/packages/wifi/README.md
+++ b/packages/wifi/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-wifi
+# Capacitor Wifi Plugin
 
 Capacitor plugin to manage Wi-Fi connectivity, including adding, connecting, and disconnecting networks. Supports both Android and iOS.[^1][^2]
 

--- a/packages/zip/README.md
+++ b/packages/zip/README.md
@@ -1,4 +1,4 @@
-# @capawesome-team/capacitor-zip
+# Capacitor Zip Plugin
 
 Capacitor plugin to zip and unzip files and directories with support for encryption.
 


### PR DESCRIPTION
## Summary

Renames each plugin README's h1 from the npm package name (e.g. `@capawesome/capacitor-live-update`) to the human-readable plugin name with a `Plugin` suffix (e.g. "Capacitor Live Update Plugin").

The names follow the navigation titles on capawesome.io (e.g. `NFC`, `OAuth`, `SQLite`, `libSQL`, `Node.js`, `PostHog`).