### PR TITLE
feat(in-app-browser): add `visible` option and `show()` method

### DIFF
--- a/packages/in-app-browser/README.md
+++ b/packages/in-app-browser/README.md
@@ -184,6 +184,7 @@ const addListeners = async () => {
 * [`openInSystemBrowser(...)`](#openinsystembrowser)
 * [`openInWebView(...)`](#openinwebview)
 * [`postMessage(...)`](#postmessage)
+* [`show()`](#show)
 * [`addListener('browserClosed', ...)`](#addlistenerbrowserclosed-)
 * [`addListener('browserPageLoaded', ...)`](#addlistenerbrowserpageloaded-)
 * [`addListener('browserPageNavigationCompleted', ...)`](#addlistenerbrowserpagenavigationcompleted-)
@@ -375,6 +376,24 @@ Only available on Android and iOS.
 --------------------
 
 
+### show()
+
+```typescript
+show() => Promise<void>
+```
+
+Show the web view if it was opened with `visible: false`.
+
+This method is only available for browsers opened with
+`openInWebView(...)`.
+
+Only available on Android and iOS.
+
+**Since:** 0.1.0
+
+--------------------
+
+
 ### addListener('browserClosed', ...)
 
 ```typescript
@@ -552,16 +571,17 @@ Remove all listeners for this plugin.
 
 #### OpenInWebViewOptions
 
-| Prop                                  | Type                                                                                | Description                                                                                                                                                       | Default               | Since |
-| ------------------------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | ----- |
-| **`android`**                         | <code><a href="#openinwebviewandroidoptions">OpenInWebViewAndroidOptions</a></code> | Options that are only applied on Android. Only available on Android.                                                                                              |                       | 0.1.0 |
-| **`dataStore`**                       | <code><a href="#webviewdatastore">WebViewDataStore</a></code>                       | The data store to use for the web view. On Android, this option is ignored. The web view always uses the app-global (`shared`) data store. Only available on iOS. | <code>'shared'</code> | 0.1.0 |
-| **`headers`**                         | <code>{ [key: string]: string; }</code>                                             | Additional HTTP headers to send with the initial request.                                                                                                         |                       | 0.1.0 |
-| **`ios`**                             | <code><a href="#openinwebviewiosoptions">OpenInWebViewIosOptions</a></code>         | Options that are only applied on iOS. Only available on iOS.                                                                                                      |                       | 0.1.0 |
-| **`mediaPlaybackRequiresUserAction`** | <code>boolean</code>                                                                | Whether or not media playback requires user action.                                                                                                               | <code>false</code>    | 0.1.0 |
-| **`toolbar`**                         | <code><a href="#webviewtoolbaroptions">WebViewToolbarOptions</a></code>             | Options for the toolbar of the web view.                                                                                                                          |                       | 0.1.0 |
-| **`url`**                             | <code>string</code>                                                                 | The URL to open in the web view.                                                                                                                                  |                       | 0.1.0 |
-| **`userAgent`**                       | <code>string</code>                                                                 | The custom user agent to use for the web view.                                                                                                                    |                       | 0.1.0 |
+| Prop                                  | Type                                                                                | Description                                                                                                                                                                                                                                                        | Default               | Since |
+| ------------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------- | ----- |
+| **`android`**                         | <code><a href="#openinwebviewandroidoptions">OpenInWebViewAndroidOptions</a></code> | Options that are only applied on Android. Only available on Android.                                                                                                                                                                                               |                       | 0.1.0 |
+| **`dataStore`**                       | <code><a href="#webviewdatastore">WebViewDataStore</a></code>                       | The data store to use for the web view. On Android, this option is ignored. The web view always uses the app-global (`shared`) data store. Only available on iOS.                                                                                                  | <code>'shared'</code> | 0.1.0 |
+| **`headers`**                         | <code>{ [key: string]: string; }</code>                                             | Additional HTTP headers to send with the initial request.                                                                                                                                                                                                          |                       | 0.1.0 |
+| **`ios`**                             | <code><a href="#openinwebviewiosoptions">OpenInWebViewIosOptions</a></code>         | Options that are only applied on iOS. Only available on iOS.                                                                                                                                                                                                       |                       | 0.1.0 |
+| **`mediaPlaybackRequiresUserAction`** | <code>boolean</code>                                                                | Whether or not media playback requires user action.                                                                                                                                                                                                                | <code>false</code>    | 0.1.0 |
+| **`toolbar`**                         | <code><a href="#webviewtoolbaroptions">WebViewToolbarOptions</a></code>             | Options for the toolbar of the web view.                                                                                                                                                                                                                           |                       | 0.1.0 |
+| **`url`**                             | <code>string</code>                                                                 | The URL to open in the web view.                                                                                                                                                                                                                                   |                       | 0.1.0 |
+| **`userAgent`**                       | <code>string</code>                                                                 | The custom user agent to use for the web view.                                                                                                                                                                                                                     |                       | 0.1.0 |
+| **`visible`**                         | <code>boolean</code>                                                                | Whether or not the web view is presented when opened. If `false`, the web view loads the URL in the background and stays hidden until `show()` is called. The `browserPageLoaded` event is still emitted and `close()` can be called while the web view is hidden. | <code>true</code>     | 0.1.0 |
 
 
 #### OpenInWebViewAndroidOptions

--- a/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/InAppBrowser.java
+++ b/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/InAppBrowser.java
@@ -230,6 +230,20 @@ public class InAppBrowser {
             });
     }
 
+    public void show(@NonNull EmptyCallback callback) {
+        plugin
+            .getActivity()
+            .runOnUiThread(() -> {
+                WebViewDialog webViewDialog = this.webViewDialog;
+                if (webViewDialog == null) {
+                    callback.error(CustomExceptions.NO_BROWSER_OPEN);
+                    return;
+                }
+                webViewDialog.showWebView();
+                callback.success();
+            });
+    }
+
     private void handleMessageReceived(@NonNull String data) {
         Object value;
         try {

--- a/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/InAppBrowserPlugin.java
+++ b/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/InAppBrowserPlugin.java
@@ -252,6 +252,27 @@ public class InAppBrowserPlugin extends Plugin {
         }
     }
 
+    @PluginMethod
+    public void show(PluginCall call) {
+        try {
+            EmptyCallback callback = new EmptyCallback() {
+                @Override
+                public void success() {
+                    resolveCall(call);
+                }
+
+                @Override
+                public void error(@NonNull Exception exception) {
+                    rejectCall(call, exception);
+                }
+            };
+
+            implementation.show(callback);
+        } catch (Exception exception) {
+            rejectCall(call, exception);
+        }
+    }
+
     @Override
     protected void handleOnPause() {
         implementation.handleOnPause();

--- a/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/classes/WebViewDialog.java
+++ b/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/classes/WebViewDialog.java
@@ -12,7 +12,10 @@ import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.TypedValue;
 import android.view.Gravity;
+import android.view.View;
 import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager;
 import android.webkit.JavascriptInterface;
 import android.webkit.PermissionRequest;
 import android.webkit.ValueCallback;
@@ -111,6 +114,15 @@ public class WebViewDialog extends Dialog {
         }
     }
 
+    public void showWebView() {
+        Window window = getWindow();
+        if (window == null) {
+            return;
+        }
+        window.clearFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE | WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
+        window.getDecorView().setVisibility(View.VISIBLE);
+    }
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -118,6 +130,9 @@ public class WebViewDialog extends Dialog {
         this.webView = webView;
         setContentView(createContentView(webView));
         setOnDismissListener(dialog -> handleDismiss());
+        if (!options.getVisible()) {
+            hideWebView();
+        }
         webView.loadUrl(options.getUri().toString(), options.getHeaders());
     }
 
@@ -295,6 +310,15 @@ public class WebViewDialog extends Dialog {
 
     private boolean hasPermission(@NonNull String permission) {
         return ContextCompat.checkSelfPermission(getContext(), permission) == PackageManager.PERMISSION_GRANTED;
+    }
+
+    private void hideWebView() {
+        Window window = getWindow();
+        if (window == null) {
+            return;
+        }
+        window.addFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE | WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
+        window.getDecorView().setVisibility(View.INVISIBLE);
     }
 
     private void injectBridgeJavaScript() {

--- a/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/classes/options/OpenInWebViewOptions.java
+++ b/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/classes/options/OpenInWebViewOptions.java
@@ -30,6 +30,8 @@ public class OpenInWebViewOptions {
     @Nullable
     private final String userAgent;
 
+    private final boolean visible;
+
     public OpenInWebViewOptions(@NonNull PluginCall call) throws Exception {
         JSObject androidOptions = call.getObject("android");
         this.allowZoom = androidOptions != null && androidOptions.optBoolean("allowZoom", false);
@@ -40,6 +42,7 @@ public class OpenInWebViewOptions {
         this.toolbar = new WebViewToolbarOptions(call.getObject("toolbar"));
         this.uri = OpenInWebViewOptions.getUriFromCall(call);
         this.userAgent = call.getString("userAgent");
+        this.visible = call.getBoolean("visible", true);
     }
 
     public boolean getAllowZoom() {
@@ -76,6 +79,10 @@ public class OpenInWebViewOptions {
     @Nullable
     public String getUserAgent() {
         return userAgent;
+    }
+
+    public boolean getVisible() {
+        return visible;
     }
 
     @NonNull

--- a/packages/in-app-browser/example/src/index.html
+++ b/packages/in-app-browser/example/src/index.html
@@ -42,6 +42,10 @@
         <ion-button id="openInWebView" expand="block"
           >Open In Web View</ion-button
         >
+        <ion-button id="openInWebViewHidden" expand="block"
+          >Open In Web View (Hidden)</ion-button
+        >
+        <ion-button id="show" expand="block">Show</ion-button>
         <ion-button id="close" expand="block">Close</ion-button>
         <ion-button id="executeScript" expand="block"
           >Execute Script</ion-button

--- a/packages/in-app-browser/example/src/js/script.js
+++ b/packages/in-app-browser/example/src/js/script.js
@@ -35,6 +35,22 @@ document.addEventListener('DOMContentLoaded', () => {
         },
       });
     });
+  document
+    .querySelector('#openInWebViewHidden')
+    .addEventListener('click', async () => {
+      await InAppBrowser.openInWebView({
+        url,
+        toolbar: {
+          backgroundColor: '#008080',
+          color: '#FFFFFF',
+          showNavigationButtons: true,
+        },
+        visible: false,
+      });
+    });
+  document.querySelector('#show').addEventListener('click', async () => {
+    await InAppBrowser.show();
+  });
   document.querySelector('#close').addEventListener('click', async () => {
     await InAppBrowser.close();
   });

--- a/packages/in-app-browser/ios/Plugin/Classes/Options/OpenInWebViewOptions.swift
+++ b/packages/in-app-browser/ios/Plugin/Classes/Options/OpenInWebViewOptions.swift
@@ -10,6 +10,7 @@ import Capacitor
     let toolbar: WebViewToolbarOptions
     let url: URL
     let userAgent: String?
+    let visible: Bool
 
     init(_ call: CAPPluginCall) throws {
         let iosOptions = call.getObject("ios")
@@ -21,6 +22,7 @@ import Capacitor
         self.toolbar = try WebViewToolbarOptions(call.getObject("toolbar"))
         self.url = try OpenInWebViewOptions.getUrlFromCall(call)
         self.userAgent = call.getString("userAgent")
+        self.visible = call.getBool("visible", true)
     }
 
     private static func getHeadersFromCall(_ call: CAPPluginCall) -> [String: String] {

--- a/packages/in-app-browser/ios/Plugin/Classes/WebViewController.swift
+++ b/packages/in-app-browser/ios/Plugin/Classes/WebViewController.swift
@@ -43,6 +43,11 @@ import WebKit
         }
     }
 
+    public func handleCloseWithoutPresentation() {
+        cleanup()
+        onClosed?(self)
+    }
+
     public func postMessage(_ data: String) {
         webView?.evaluateJavaScript(
             "window.dispatchEvent(new CustomEvent('capacitorInAppBrowserMessage', { detail: \(data) }));",

--- a/packages/in-app-browser/ios/Plugin/InAppBrowser.swift
+++ b/packages/in-app-browser/ios/Plugin/InAppBrowser.swift
@@ -9,6 +9,7 @@ import WebKit
 
     private var safariViewController: SFSafariViewController?
     private var webViewController: WebViewController?
+    private var webViewNavigationController: UINavigationController?
 
     init(plugin: InAppBrowserPlugin) {
         self.plugin = plugin
@@ -35,6 +36,11 @@ import WebKit
     @objc public func close(completion: @escaping (_ error: Error?) -> Void) {
         DispatchQueue.main.async {
             if let webViewController = self.webViewController {
+                if self.webViewNavigationController?.presentingViewController == nil {
+                    webViewController.handleCloseWithoutPresentation()
+                    completion(nil)
+                    return
+                }
                 webViewController.dismiss(animated: true) {
                     completion(nil)
                 }
@@ -122,6 +128,7 @@ import WebKit
                     }
                     if self.webViewController === viewController {
                         self.webViewController = nil
+                        self.webViewNavigationController = nil
                     }
                     self.plugin.notifyBrowserClosedListeners()
                 }
@@ -138,7 +145,13 @@ import WebKit
                 navigationController.modalPresentationStyle = .fullScreen
                 navigationController.setNavigationBarHidden(!options.toolbar.visible, animated: false)
                 self.webViewController = webViewController
-                bridgeViewController.present(navigationController, animated: true) {
+                self.webViewNavigationController = navigationController
+                if options.visible {
+                    bridgeViewController.present(navigationController, animated: true) {
+                        completion(nil)
+                    }
+                } else {
+                    webViewController.loadViewIfNeeded()
                     completion(nil)
                 }
             }
@@ -168,8 +181,33 @@ import WebKit
         plugin.notifyBrowserClosedListeners()
     }
 
+    @objc public func show(completion: @escaping (_ error: Error?) -> Void) {
+        DispatchQueue.main.async {
+            guard let navigationController = self.webViewNavigationController else {
+                completion(CustomError.noBrowserOpen)
+                return
+            }
+            if navigationController.presentingViewController != nil {
+                completion(nil)
+                return
+            }
+            guard let bridgeViewController = self.plugin.bridge?.viewController else {
+                completion(CustomError.noBrowserOpen)
+                return
+            }
+            bridgeViewController.present(navigationController, animated: true) {
+                completion(nil)
+            }
+        }
+    }
+
     private func dismissActiveBrowser(_ completion: @escaping () -> Void) {
         if let webViewController = self.webViewController {
+            if self.webViewNavigationController?.presentingViewController == nil {
+                webViewController.handleCloseWithoutPresentation()
+                completion()
+                return
+            }
             webViewController.dismiss(animated: false) {
                 completion()
             }

--- a/packages/in-app-browser/ios/Plugin/InAppBrowserPlugin.swift
+++ b/packages/in-app-browser/ios/Plugin/InAppBrowserPlugin.swift
@@ -14,7 +14,8 @@ public class InAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "openInExternalBrowser", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "openInSystemBrowser", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "openInWebView", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "postMessage", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "postMessage", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "show", returnType: CAPPluginReturnPromise)
     ]
 
     public static let eventBrowserClosed = "browserClosed"
@@ -169,6 +170,16 @@ public class InAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
         } catch {
             rejectCall(call, error)
         }
+    }
+
+    @objc func show(_ call: CAPPluginCall) {
+        implementation?.show(completion: { error in
+            if let error = error {
+                self.rejectCall(call, error)
+                return
+            }
+            self.resolveCall(call)
+        })
     }
 
     private func rejectCall(_ call: CAPPluginCall, _ error: Error) {

--- a/packages/in-app-browser/package.json
+++ b/packages/in-app-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capawesome/capacitor-in-app-browser",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Capacitor plugin to open URLs in the external browser, the system browser or an embedded web view.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/packages/in-app-browser/src/definitions.ts
+++ b/packages/in-app-browser/src/definitions.ts
@@ -89,6 +89,17 @@ export interface InAppBrowserPlugin {
    */
   postMessage(options: PostMessageOptions): Promise<void>;
   /**
+   * Show the web view if it was opened with `visible: false`.
+   *
+   * This method is only available for browsers opened with
+   * `openInWebView(...)`.
+   *
+   * Only available on Android and iOS.
+   *
+   * @since 0.1.0
+   */
+  show(): Promise<void>;
+  /**
    * Called when the browser is closed.
    *
    * Only available on Android and iOS.
@@ -317,6 +328,18 @@ export interface OpenInWebViewOptions {
    * @since 0.1.0
    */
   userAgent?: string;
+  /**
+   * Whether or not the web view is presented when opened.
+   *
+   * If `false`, the web view loads the URL in the background and stays
+   * hidden until `show()` is called. The `browserPageLoaded` event is
+   * still emitted and `close()` can be called while the web view is
+   * hidden.
+   *
+   * @default true
+   * @since 0.1.0
+   */
+  visible?: boolean;
 }
 
 /**

--- a/packages/in-app-browser/src/web.ts
+++ b/packages/in-app-browser/src/web.ts
@@ -50,4 +50,8 @@ export class InAppBrowserWeb extends WebPlugin implements InAppBrowserPlugin {
   async postMessage(): Promise<void> {
     throw this.unimplemented('Not implemented on web.');
   }
+
+  async show(): Promise<void> {
+    throw this.unimplemented('Not implemented on web.');
+  }
 }


### PR DESCRIPTION
## Description

This PR adds support for opening a web view in the background:

- New `visible` option for `openInWebView(...)` (default: `true`). When set to `false`, the web view is created and loads the URL without being presented. The `browserPageLoaded` event is still emitted and `close()` can be called while the web view is hidden.
- New `show()` method to present a web view that was opened with `visible: false`. Resolves without effect if the web view is already visible and rejects with `NO_BROWSER_OPEN` if no web view is open.

This enables use cases such as running silent flows (e.g. session logout) in a web view without any UI flashing up, pre-loading a page in the background before presenting it, or presenting the web view only after the page has finished loading.

### Implementation notes

- **Android**: The dialog is still shown so that the page starts loading, but its decor view is kept invisible and the window is flagged as not touchable/not focusable so it neither renders nor intercepts touches or back presses. `show()` reverts this.
- **iOS**: The view controller is created and its view is loaded without being presented. `show()` presents it. `close()` handles the never-presented case explicitly so cleanup and the `browserClosed` event still occur.
- The example app has new buttons to open a hidden web view and to show it.

## Testing

- `npm run verify` passes for all platforms (Android, iOS, Web).