### PR TITLE
feat(in-app-browser): add `browserUrlChanged` event and align event names

### DIFF
--- a/packages/in-app-browser/README.md
+++ b/packages/in-app-browser/README.md
@@ -159,14 +159,17 @@ const addListeners = async () => {
   await InAppBrowser.addListener('browserClosed', () => {
     console.log('Browser closed');
   });
+  await InAppBrowser.addListener('browserMessageReceived', event => {
+    console.log('Message received', event.data);
+  });
+  await InAppBrowser.addListener('browserNavigationCompleted', event => {
+    console.log('Navigation completed', event.url);
+  });
   await InAppBrowser.addListener('browserPageLoaded', () => {
     console.log('Browser page loaded');
   });
-  await InAppBrowser.addListener('browserPageNavigationCompleted', event => {
-    console.log('Navigation completed', event.url);
-  });
-  await InAppBrowser.addListener('messageReceived', event => {
-    console.log('Message received', event.data);
+  await InAppBrowser.addListener('browserUrlChanged', event => {
+    console.log('URL changed', event.url);
   });
 };
 ```
@@ -718,7 +721,7 @@ The web page can post a message to the app using the injected `window.CapacitorI
 window.CapacitorInAppBrowser.postMessage({ name: 'Capawesome' });
 ```
 
-The app receives the message via the `messageReceived` event.
+The app receives the message via the `browserMessageReceived` event.
 
 ### From the app to the web page
 
@@ -734,7 +737,7 @@ window.addEventListener('capacitorInAppBrowserMessage', event => {
 
 The three browser modes behave differently on each platform. Keep the following differences in mind:
 
-- **System browser**: Tracking the visited URLs is not possible by design. If you need the `browserPageNavigationCompleted` event, use the `openInWebView(...)` method instead. On Android, the `browserPageLoaded` event is not emitted for the system browser and the `browserClosed` event is emitted when the user returns to the app.
+- **System browser**: Tracking the visited URLs is not possible by design. If you need the `browserNavigationCompleted` or `browserUrlChanged` event, use the `openInWebView(...)` method instead. On Android, the `browserPageLoaded` event is not emitted for the system browser and the `browserClosed` event is emitted when the user returns to the app.
 - **Embedded web view**: The web view always uses the app-global (`shared`) data store on Android. The `dataStore` option is only supported on iOS. On iOS, hiding the toolbar removes the close button, so the browser can then only be closed using the `close(...)` method.
 - **External browser**: The browser is opened in a separate app. For this reason, no events are emitted and the `close(...)` method has no effect.
 

--- a/packages/in-app-browser/README.md
+++ b/packages/in-app-browser/README.md
@@ -186,9 +186,10 @@ const addListeners = async () => {
 * [`postMessage(...)`](#postmessage)
 * [`show()`](#show)
 * [`addListener('browserClosed', ...)`](#addlistenerbrowserclosed-)
+* [`addListener('browserMessageReceived', ...)`](#addlistenerbrowsermessagereceived-)
+* [`addListener('browserNavigationCompleted', ...)`](#addlistenerbrowsernavigationcompleted-)
 * [`addListener('browserPageLoaded', ...)`](#addlistenerbrowserpageloaded-)
-* [`addListener('browserPageNavigationCompleted', ...)`](#addlistenerbrowserpagenavigationcompleted-)
-* [`addListener('messageReceived', ...)`](#addlistenermessagereceived-)
+* [`addListener('browserUrlChanged', ...)`](#addlistenerbrowserurlchanged-)
 * [`removeAllListeners()`](#removealllisteners)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
@@ -416,6 +417,55 @@ Only available on Android and iOS.
 --------------------
 
 
+### addListener('browserMessageReceived', ...)
+
+```typescript
+addListener(eventName: 'browserMessageReceived', listenerFunc: (event: BrowserMessageReceivedEvent) => void) => Promise<PluginListenerHandle>
+```
+
+Called when the web page posts a message to the app using the injected
+`window.CapacitorInAppBrowser.postMessage(...)` function.
+
+This event is only emitted for browsers opened with `openInWebView(...)`.
+
+Only available on Android and iOS.
+
+| Param              | Type                                                                                                    |
+| ------------------ | ------------------------------------------------------------------------------------------------------- |
+| **`eventName`**    | <code>'browserMessageReceived'</code>                                                                   |
+| **`listenerFunc`** | <code>(event: <a href="#browsermessagereceivedevent">BrowserMessageReceivedEvent</a>) =&gt; void</code> |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+**Since:** 0.1.0
+
+--------------------
+
+
+### addListener('browserNavigationCompleted', ...)
+
+```typescript
+addListener(eventName: 'browserNavigationCompleted', listenerFunc: (event: BrowserNavigationCompletedEvent) => void) => Promise<PluginListenerHandle>
+```
+
+Called when a page navigation has been completed in the web view.
+
+This event is only emitted for browsers opened with `openInWebView(...)`.
+
+Only available on Android and iOS.
+
+| Param              | Type                                                                                                            |
+| ------------------ | --------------------------------------------------------------------------------------------------------------- |
+| **`eventName`**    | <code>'browserNavigationCompleted'</code>                                                                       |
+| **`listenerFunc`** | <code>(event: <a href="#browsernavigationcompletedevent">BrowserNavigationCompletedEvent</a>) =&gt; void</code> |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+**Since:** 0.1.0
+
+--------------------
+
+
 ### addListener('browserPageLoaded', ...)
 
 ```typescript
@@ -441,47 +491,27 @@ Only available on Android and iOS.
 --------------------
 
 
-### addListener('browserPageNavigationCompleted', ...)
+### addListener('browserUrlChanged', ...)
 
 ```typescript
-addListener(eventName: 'browserPageNavigationCompleted', listenerFunc: (event: BrowserPageNavigationCompletedEvent) => void) => Promise<PluginListenerHandle>
+addListener(eventName: 'browserUrlChanged', listenerFunc: (event: BrowserUrlChangedEvent) => void) => Promise<PluginListenerHandle>
 ```
 
-Called when a page navigation has been completed in the web view.
+Called when the current URL of the web view changes, e.g. when the user
+navigates to a new page, a server redirect occurs, or a single-page
+application updates the browser history.
+
+This event is also emitted for the initial URL and fires earlier than
+`browserNavigationCompleted`.
 
 This event is only emitted for browsers opened with `openInWebView(...)`.
 
 Only available on Android and iOS.
 
-| Param              | Type                                                                                                                    |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| **`eventName`**    | <code>'browserPageNavigationCompleted'</code>                                                                           |
-| **`listenerFunc`** | <code>(event: <a href="#browserpagenavigationcompletedevent">BrowserPageNavigationCompletedEvent</a>) =&gt; void</code> |
-
-**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
-
-**Since:** 0.1.0
-
---------------------
-
-
-### addListener('messageReceived', ...)
-
-```typescript
-addListener(eventName: 'messageReceived', listenerFunc: (event: MessageReceivedEvent) => void) => Promise<PluginListenerHandle>
-```
-
-Called when the web page posts a message to the app using the injected
-`window.CapacitorInAppBrowser.postMessage(...)` function.
-
-This event is only emitted for browsers opened with `openInWebView(...)`.
-
-Only available on Android and iOS.
-
-| Param              | Type                                                                                      |
-| ------------------ | ----------------------------------------------------------------------------------------- |
-| **`eventName`**    | <code>'messageReceived'</code>                                                            |
-| **`listenerFunc`** | <code>(event: <a href="#messagereceivedevent">MessageReceivedEvent</a>) =&gt; void</code> |
+| Param              | Type                                                                                          |
+| ------------------ | --------------------------------------------------------------------------------------------- |
+| **`eventName`**    | <code>'browserUrlChanged'</code>                                                              |
+| **`listenerFunc`** | <code>(event: <a href="#browserurlchangedevent">BrowserUrlChangedEvent</a>) =&gt; void</code> |
 
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
 
@@ -628,18 +658,25 @@ Remove all listeners for this plugin.
 | **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
 
 
-#### BrowserPageNavigationCompletedEvent
+#### BrowserMessageReceivedEvent
+
+| Prop       | Type                 | Description                              | Since |
+| ---------- | -------------------- | ---------------------------------------- | ----- |
+| **`data`** | <code>unknown</code> | The message data posted by the web page. | 0.1.0 |
+
+
+#### BrowserNavigationCompletedEvent
 
 | Prop      | Type                | Description                                | Since |
 | --------- | ------------------- | ------------------------------------------ | ----- |
 | **`url`** | <code>string</code> | The URL of the page that was navigated to. | 0.1.0 |
 
 
-#### MessageReceivedEvent
+#### BrowserUrlChangedEvent
 
-| Prop       | Type                 | Description                              | Since |
-| ---------- | -------------------- | ---------------------------------------- | ----- |
-| **`data`** | <code>unknown</code> | The message data posted by the web page. | 0.1.0 |
+| Prop      | Type                | Description                  | Since |
+| --------- | ------------------- | ---------------------------- | ----- |
+| **`url`** | <code>string</code> | The new URL of the web view. | 0.1.0 |
 
 
 ### Type Aliases

--- a/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/InAppBrowser.java
+++ b/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/InAppBrowser.java
@@ -11,8 +11,9 @@ import androidx.browser.customtabs.CustomTabColorSchemeParams;
 import androidx.browser.customtabs.CustomTabsIntent;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.CustomExceptions;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.WebViewDialog;
-import io.capawesome.capacitorjs.plugins.inappbrowser.classes.events.BrowserPageNavigationCompletedEvent;
-import io.capawesome.capacitorjs.plugins.inappbrowser.classes.events.MessageReceivedEvent;
+import io.capawesome.capacitorjs.plugins.inappbrowser.classes.events.BrowserMessageReceivedEvent;
+import io.capawesome.capacitorjs.plugins.inappbrowser.classes.events.BrowserNavigationCompletedEvent;
+import io.capawesome.capacitorjs.plugins.inappbrowser.classes.events.BrowserUrlChangedEvent;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.options.ExecuteScriptOptions;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.options.GetCookiesOptions;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.options.OpenInExternalBrowserOptions;
@@ -200,13 +201,18 @@ public class InAppBrowser {
                         }
 
                         @Override
+                        public void onNavigationCompleted(@NonNull String url) {
+                            plugin.notifyBrowserNavigationCompletedListeners(new BrowserNavigationCompletedEvent(url));
+                        }
+
+                        @Override
                         public void onPageLoaded() {
                             plugin.notifyBrowserPageLoadedListeners();
                         }
 
                         @Override
-                        public void onPageNavigationCompleted(@NonNull String url) {
-                            plugin.notifyBrowserPageNavigationCompletedListeners(new BrowserPageNavigationCompletedEvent(url));
+                        public void onUrlChanged(@NonNull String url) {
+                            plugin.notifyBrowserUrlChangedListeners(new BrowserUrlChangedEvent(url));
                         }
                     }
                 );
@@ -251,6 +257,6 @@ public class InAppBrowser {
         } catch (JSONException exception) {
             value = data;
         }
-        plugin.notifyMessageReceivedListeners(new MessageReceivedEvent(value));
+        plugin.notifyBrowserMessageReceivedListeners(new BrowserMessageReceivedEvent(value));
     }
 }

--- a/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/InAppBrowserPlugin.java
+++ b/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/InAppBrowserPlugin.java
@@ -9,8 +9,9 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.CustomException;
-import io.capawesome.capacitorjs.plugins.inappbrowser.classes.events.BrowserPageNavigationCompletedEvent;
-import io.capawesome.capacitorjs.plugins.inappbrowser.classes.events.MessageReceivedEvent;
+import io.capawesome.capacitorjs.plugins.inappbrowser.classes.events.BrowserMessageReceivedEvent;
+import io.capawesome.capacitorjs.plugins.inappbrowser.classes.events.BrowserNavigationCompletedEvent;
+import io.capawesome.capacitorjs.plugins.inappbrowser.classes.events.BrowserUrlChangedEvent;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.options.ExecuteScriptOptions;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.options.GetCookiesOptions;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.options.OpenInExternalBrowserOptions;
@@ -27,9 +28,10 @@ import io.capawesome.capacitorjs.plugins.inappbrowser.interfaces.Result;
 public class InAppBrowserPlugin extends Plugin {
 
     public static final String EVENT_BROWSER_CLOSED = "browserClosed";
+    public static final String EVENT_BROWSER_MESSAGE_RECEIVED = "browserMessageReceived";
+    public static final String EVENT_BROWSER_NAVIGATION_COMPLETED = "browserNavigationCompleted";
     public static final String EVENT_BROWSER_PAGE_LOADED = "browserPageLoaded";
-    public static final String EVENT_BROWSER_PAGE_NAVIGATION_COMPLETED = "browserPageNavigationCompleted";
-    public static final String EVENT_MESSAGE_RECEIVED = "messageReceived";
+    public static final String EVENT_BROWSER_URL_CHANGED = "browserUrlChanged";
     public static final String TAG = "InAppBrowserPlugin";
 
     private static final String ERROR_UNKNOWN_ERROR = "An unknown error occurred.";
@@ -152,16 +154,20 @@ public class InAppBrowserPlugin extends Plugin {
         notifyListeners(EVENT_BROWSER_CLOSED, new JSObject());
     }
 
+    public void notifyBrowserMessageReceivedListeners(@NonNull BrowserMessageReceivedEvent event) {
+        notifyListeners(EVENT_BROWSER_MESSAGE_RECEIVED, event.toJSObject());
+    }
+
+    public void notifyBrowserNavigationCompletedListeners(@NonNull BrowserNavigationCompletedEvent event) {
+        notifyListeners(EVENT_BROWSER_NAVIGATION_COMPLETED, event.toJSObject());
+    }
+
     public void notifyBrowserPageLoadedListeners() {
         notifyListeners(EVENT_BROWSER_PAGE_LOADED, new JSObject());
     }
 
-    public void notifyBrowserPageNavigationCompletedListeners(@NonNull BrowserPageNavigationCompletedEvent event) {
-        notifyListeners(EVENT_BROWSER_PAGE_NAVIGATION_COMPLETED, event.toJSObject());
-    }
-
-    public void notifyMessageReceivedListeners(@NonNull MessageReceivedEvent event) {
-        notifyListeners(EVENT_MESSAGE_RECEIVED, event.toJSObject());
+    public void notifyBrowserUrlChangedListeners(@NonNull BrowserUrlChangedEvent event) {
+        notifyListeners(EVENT_BROWSER_URL_CHANGED, event.toJSObject());
     }
 
     @PluginMethod

--- a/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/classes/WebViewDialog.java
+++ b/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/classes/WebViewDialog.java
@@ -38,8 +38,9 @@ public class WebViewDialog extends Dialog {
     public interface Listener {
         void onClosed(@NonNull WebViewDialog dialog);
         void onMessageReceived(@NonNull String data);
+        void onNavigationCompleted(@NonNull String url);
         void onPageLoaded();
-        void onPageNavigationCompleted(@NonNull String url);
+        void onUrlChanged(@NonNull String url);
     }
 
     private static final String BRIDGE_JAVASCRIPT =
@@ -54,6 +55,9 @@ public class WebViewDialog extends Dialog {
     private TextView forwardButton;
 
     private boolean initialLoadNotified = false;
+
+    @Nullable
+    private String lastNotifiedUrl;
 
     @NonNull
     private final Listener listener;
@@ -238,6 +242,7 @@ public class WebViewDialog extends Dialog {
                 @Override
                 public void onPageStarted(WebView view, String url, Bitmap favicon) {
                     injectBridgeJavaScript();
+                    handleUrlChanged(url);
                 }
 
                 @Override
@@ -250,7 +255,7 @@ public class WebViewDialog extends Dialog {
                         listener.onPageLoaded();
                     }
                     if (url != null) {
-                        listener.onPageNavigationCompleted(url);
+                        listener.onNavigationCompleted(url);
                     }
                 }
 
@@ -258,6 +263,7 @@ public class WebViewDialog extends Dialog {
                 public void doUpdateVisitedHistory(WebView view, String url, boolean isReload) {
                     updateNavigationButtons();
                     updateTitle();
+                    handleUrlChanged(url);
                 }
             }
         );
@@ -306,6 +312,14 @@ public class WebViewDialog extends Dialog {
         } else {
             request.grant(grantedResources.toArray(new String[0]));
         }
+    }
+
+    private void handleUrlChanged(@Nullable String url) {
+        if (url == null || url.equals(lastNotifiedUrl)) {
+            return;
+        }
+        lastNotifiedUrl = url;
+        listener.onUrlChanged(url);
     }
 
     private boolean hasPermission(@NonNull String permission) {

--- a/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/classes/events/BrowserMessageReceivedEvent.java
+++ b/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/classes/events/BrowserMessageReceivedEvent.java
@@ -1,0 +1,23 @@
+package io.capawesome.capacitorjs.plugins.inappbrowser.classes.events;
+
+import androidx.annotation.NonNull;
+import com.getcapacitor.JSObject;
+import io.capawesome.capacitorjs.plugins.inappbrowser.interfaces.Result;
+
+public class BrowserMessageReceivedEvent implements Result {
+
+    @NonNull
+    private final Object data;
+
+    public BrowserMessageReceivedEvent(@NonNull Object data) {
+        this.data = data;
+    }
+
+    @Override
+    @NonNull
+    public JSObject toJSObject() {
+        JSObject result = new JSObject();
+        result.put("data", data);
+        return result;
+    }
+}

--- a/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/classes/events/BrowserNavigationCompletedEvent.java
+++ b/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/classes/events/BrowserNavigationCompletedEvent.java
@@ -4,12 +4,12 @@ import androidx.annotation.NonNull;
 import com.getcapacitor.JSObject;
 import io.capawesome.capacitorjs.plugins.inappbrowser.interfaces.Result;
 
-public class BrowserPageNavigationCompletedEvent implements Result {
+public class BrowserNavigationCompletedEvent implements Result {
 
     @NonNull
     private final String url;
 
-    public BrowserPageNavigationCompletedEvent(@NonNull String url) {
+    public BrowserNavigationCompletedEvent(@NonNull String url) {
         this.url = url;
     }
 

--- a/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/classes/events/BrowserUrlChangedEvent.java
+++ b/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/classes/events/BrowserUrlChangedEvent.java
@@ -4,20 +4,20 @@ import androidx.annotation.NonNull;
 import com.getcapacitor.JSObject;
 import io.capawesome.capacitorjs.plugins.inappbrowser.interfaces.Result;
 
-public class MessageReceivedEvent implements Result {
+public class BrowserUrlChangedEvent implements Result {
 
     @NonNull
-    private final Object data;
+    private final String url;
 
-    public MessageReceivedEvent(@NonNull Object data) {
-        this.data = data;
+    public BrowserUrlChangedEvent(@NonNull String url) {
+        this.url = url;
     }
 
     @Override
     @NonNull
     public JSObject toJSObject() {
         JSObject result = new JSObject();
-        result.put("data", data);
+        result.put("url", url);
         return result;
     }
 }

--- a/packages/in-app-browser/ios/Plugin.xcodeproj/project.pbxproj
+++ b/packages/in-app-browser/ios/Plugin.xcodeproj/project.pbxproj
@@ -17,8 +17,8 @@
 		A71100000000000000000002 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71100000000000000000001 /* Result.swift */; };
 		A71100000000000000000004 /* CustomError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71100000000000000000003 /* CustomError.swift */; };
 		A71100000000000000000006 /* ExecuteScriptResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71100000000000000000005 /* ExecuteScriptResult.swift */; };
-		A71100000000000000000008 /* BrowserPageNavigationCompletedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71100000000000000000007 /* BrowserPageNavigationCompletedEvent.swift */; };
-		A7110000000000000000000A /* MessageReceivedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71100000000000000000009 /* MessageReceivedEvent.swift */; };
+		A71100000000000000000008 /* BrowserNavigationCompletedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71100000000000000000007 /* BrowserNavigationCompletedEvent.swift */; };
+		A7110000000000000000000A /* BrowserMessageReceivedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71100000000000000000009 /* BrowserMessageReceivedEvent.swift */; };
 		A7110000000000000000000C /* ExecuteScriptOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7110000000000000000000B /* ExecuteScriptOptions.swift */; };
 		A7110000000000000000000E /* OpenInExternalBrowserOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7110000000000000000000D /* OpenInExternalBrowserOptions.swift */; };
 		A71100000000000000000010 /* OpenInSystemBrowserOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7110000000000000000000F /* OpenInSystemBrowserOptions.swift */; };
@@ -29,6 +29,7 @@
 		A7110000000000000000001A /* InAppBrowserHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71100000000000000000019 /* InAppBrowserHelper.swift */; };
 		A7110000000000000000001C /* GetCookiesResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7110000000000000000001B /* GetCookiesResult.swift */; };
 		A7110000000000000000001E /* GetCookiesOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7110000000000000000001D /* GetCookiesOptions.swift */; };
+		A71100000000000000000027 /* BrowserUrlChangedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71100000000000000000026 /* BrowserUrlChangedEvent.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,8 +55,8 @@
 		A71100000000000000000001 /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		A71100000000000000000003 /* CustomError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomError.swift; sourceTree = "<group>"; };
 		A71100000000000000000005 /* ExecuteScriptResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExecuteScriptResult.swift; sourceTree = "<group>"; };
-		A71100000000000000000007 /* BrowserPageNavigationCompletedEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPageNavigationCompletedEvent.swift; sourceTree = "<group>"; };
-		A71100000000000000000009 /* MessageReceivedEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReceivedEvent.swift; sourceTree = "<group>"; };
+		A71100000000000000000007 /* BrowserNavigationCompletedEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserNavigationCompletedEvent.swift; sourceTree = "<group>"; };
+		A71100000000000000000009 /* BrowserMessageReceivedEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserMessageReceivedEvent.swift; sourceTree = "<group>"; };
 		A7110000000000000000000B /* ExecuteScriptOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExecuteScriptOptions.swift; sourceTree = "<group>"; };
 		A7110000000000000000000D /* OpenInExternalBrowserOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenInExternalBrowserOptions.swift; sourceTree = "<group>"; };
 		A7110000000000000000000F /* OpenInSystemBrowserOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenInSystemBrowserOptions.swift; sourceTree = "<group>"; };
@@ -66,6 +67,7 @@
 		A71100000000000000000019 /* InAppBrowserHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppBrowserHelper.swift; sourceTree = "<group>"; };
 		A7110000000000000000001B /* GetCookiesResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCookiesResult.swift; sourceTree = "<group>"; };
 		A7110000000000000000001D /* GetCookiesOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCookiesOptions.swift; sourceTree = "<group>"; };
+		A71100000000000000000026 /* BrowserUrlChangedEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserUrlChangedEvent.swift; sourceTree = "<group>"; };
 		5E23F77F099397094342571A /* Pods-Plugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Plugin.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Plugin/Pods-Plugin.debug.xcconfig"; sourceTree = "<group>"; };
 		91781294A431A2A7CC6EB714 /* Pods-Plugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Plugin.release.xcconfig"; path = "Pods/Target Support Files/Pods-Plugin/Pods-Plugin.release.xcconfig"; sourceTree = "<group>"; };
 		96ED1B6440D6672E406C8D19 /* Pods-PluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PluginTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PluginTests/Pods-PluginTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -168,8 +170,9 @@
 		A71100000000000000000024 /* Events */ = {
 			isa = PBXGroup;
 			children = (
-				A71100000000000000000007 /* BrowserPageNavigationCompletedEvent.swift */,
-				A71100000000000000000009 /* MessageReceivedEvent.swift */,
+				A71100000000000000000009 /* BrowserMessageReceivedEvent.swift */,
+				A71100000000000000000007 /* BrowserNavigationCompletedEvent.swift */,
+				A71100000000000000000026 /* BrowserUrlChangedEvent.swift */,
 			);
 			path = Events;
 			sourceTree = "<group>";
@@ -397,8 +400,9 @@
 				A71100000000000000000002 /* Result.swift in Sources */,
 				A71100000000000000000004 /* CustomError.swift in Sources */,
 				A71100000000000000000006 /* ExecuteScriptResult.swift in Sources */,
-				A71100000000000000000008 /* BrowserPageNavigationCompletedEvent.swift in Sources */,
-				A7110000000000000000000A /* MessageReceivedEvent.swift in Sources */,
+				A71100000000000000000008 /* BrowserNavigationCompletedEvent.swift in Sources */,
+				A7110000000000000000000A /* BrowserMessageReceivedEvent.swift in Sources */,
+				A71100000000000000000027 /* BrowserUrlChangedEvent.swift in Sources */,
 				A7110000000000000000000C /* ExecuteScriptOptions.swift in Sources */,
 				A7110000000000000000000E /* OpenInExternalBrowserOptions.swift in Sources */,
 				A71100000000000000000010 /* OpenInSystemBrowserOptions.swift in Sources */,

--- a/packages/in-app-browser/ios/Plugin/Classes/Events/BrowserMessageReceivedEvent.swift
+++ b/packages/in-app-browser/ios/Plugin/Classes/Events/BrowserMessageReceivedEvent.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Capacitor
 
-@objc public class MessageReceivedEvent: NSObject, Result {
+@objc public class BrowserMessageReceivedEvent: NSObject, Result {
     let data: Any
 
     init(data: Any) {

--- a/packages/in-app-browser/ios/Plugin/Classes/Events/BrowserNavigationCompletedEvent.swift
+++ b/packages/in-app-browser/ios/Plugin/Classes/Events/BrowserNavigationCompletedEvent.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Capacitor
 
-@objc public class BrowserPageNavigationCompletedEvent: NSObject, Result {
+@objc public class BrowserNavigationCompletedEvent: NSObject, Result {
     let url: String
 
     init(url: String) {

--- a/packages/in-app-browser/ios/Plugin/Classes/Events/BrowserUrlChangedEvent.swift
+++ b/packages/in-app-browser/ios/Plugin/Classes/Events/BrowserUrlChangedEvent.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Capacitor
+
+@objc public class BrowserUrlChangedEvent: NSObject, Result {
+    let url: String
+
+    init(url: String) {
+        self.url = url
+    }
+
+    @objc public func toJSObject() -> AnyObject {
+        var result = JSObject()
+        result["url"] = url
+        return result as AnyObject
+    }
+}

--- a/packages/in-app-browser/ios/Plugin/Classes/WebViewController.swift
+++ b/packages/in-app-browser/ios/Plugin/Classes/WebViewController.swift
@@ -5,8 +5,9 @@ import WebKit
 @objc public class WebViewController: UIViewController, WKNavigationDelegate, WKScriptMessageHandler, WKUIDelegate {
     var onClosed: ((WebViewController) -> Void)?
     var onMessageReceived: ((String) -> Void)?
+    var onNavigationCompleted: ((String) -> Void)?
     var onPageLoaded: (() -> Void)?
-    var onPageNavigationCompleted: ((String) -> Void)?
+    var onUrlChanged: ((String) -> Void)?
 
     private static let bridgeJavaScript =
         "window.CapacitorInAppBrowser = window.CapacitorInAppBrowser || { postMessage: function (data) "
@@ -20,6 +21,7 @@ import WebKit
     private var canGoForwardObservation: NSKeyValueObservation?
     private var forwardButtonItem: UIBarButtonItem?
     private var initialLoadNotified = false
+    private var lastNotifiedUrl: String?
     private var titleObservation: NSKeyValueObservation?
     private var urlObservation: NSKeyValueObservation?
     private var webView: WKWebView?
@@ -100,7 +102,7 @@ import WebKit
             onPageLoaded?()
         }
         if let url = webView.url?.absoluteString {
-            onPageNavigationCompleted?(url)
+            onNavigationCompleted?(url)
         }
     }
 
@@ -183,6 +185,7 @@ import WebKit
             self?.updateTitle()
         }
         urlObservation = webView.observe(\.url, options: [.new]) { [weak self] _, _ in
+            self?.handleUrlChanged()
             self?.updateTitle()
         }
         return webView
@@ -202,6 +205,14 @@ import WebKit
         if webView?.canGoForward == true {
             webView?.goForward()
         }
+    }
+
+    private func handleUrlChanged() {
+        guard let url = webView?.url?.absoluteString, url != lastNotifiedUrl else {
+            return
+        }
+        lastNotifiedUrl = url
+        onUrlChanged?(url)
     }
 
     private func loadUrl() {

--- a/packages/in-app-browser/ios/Plugin/InAppBrowser.swift
+++ b/packages/in-app-browser/ios/Plugin/InAppBrowser.swift
@@ -135,11 +135,14 @@ import WebKit
                 webViewController.onMessageReceived = { [weak self] data in
                     self?.handleMessageReceived(data)
                 }
+                webViewController.onNavigationCompleted = { [weak self] url in
+                    self?.plugin.notifyBrowserNavigationCompletedListeners(BrowserNavigationCompletedEvent(url: url))
+                }
                 webViewController.onPageLoaded = { [weak self] in
                     self?.plugin.notifyBrowserPageLoadedListeners()
                 }
-                webViewController.onPageNavigationCompleted = { [weak self] url in
-                    self?.plugin.notifyBrowserPageNavigationCompletedListeners(BrowserPageNavigationCompletedEvent(url: url))
+                webViewController.onUrlChanged = { [weak self] url in
+                    self?.plugin.notifyBrowserUrlChangedListeners(BrowserUrlChangedEvent(url: url))
                 }
                 let navigationController = UINavigationController(rootViewController: webViewController)
                 navigationController.modalPresentationStyle = .fullScreen
@@ -227,6 +230,6 @@ import WebKit
         if let jsonData = data.data(using: .utf8), let parsedValue = try? JSONSerialization.jsonObject(with: jsonData, options: [.fragmentsAllowed]) {
             value = parsedValue
         }
-        plugin.notifyMessageReceivedListeners(MessageReceivedEvent(data: value))
+        plugin.notifyBrowserMessageReceivedListeners(BrowserMessageReceivedEvent(data: value))
     }
 }

--- a/packages/in-app-browser/ios/Plugin/InAppBrowserPlugin.swift
+++ b/packages/in-app-browser/ios/Plugin/InAppBrowserPlugin.swift
@@ -19,9 +19,10 @@ public class InAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
     ]
 
     public static let eventBrowserClosed = "browserClosed"
+    public static let eventBrowserMessageReceived = "browserMessageReceived"
+    public static let eventBrowserNavigationCompleted = "browserNavigationCompleted"
     public static let eventBrowserPageLoaded = "browserPageLoaded"
-    public static let eventBrowserPageNavigationCompleted = "browserPageNavigationCompleted"
-    public static let eventMessageReceived = "messageReceived"
+    public static let eventBrowserUrlChanged = "browserUrlChanged"
     public static let tag = "InAppBrowserPlugin"
 
     private var implementation: InAppBrowser?
@@ -96,16 +97,20 @@ public class InAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
         self.notifyListeners(Self.eventBrowserClosed, data: [:])
     }
 
+    @objc public func notifyBrowserMessageReceivedListeners(_ event: BrowserMessageReceivedEvent) {
+        self.notifyListeners(Self.eventBrowserMessageReceived, data: event.toJSObject() as? [String: Any])
+    }
+
+    @objc public func notifyBrowserNavigationCompletedListeners(_ event: BrowserNavigationCompletedEvent) {
+        self.notifyListeners(Self.eventBrowserNavigationCompleted, data: event.toJSObject() as? [String: Any])
+    }
+
     @objc public func notifyBrowserPageLoadedListeners() {
         self.notifyListeners(Self.eventBrowserPageLoaded, data: [:])
     }
 
-    @objc public func notifyBrowserPageNavigationCompletedListeners(_ event: BrowserPageNavigationCompletedEvent) {
-        self.notifyListeners(Self.eventBrowserPageNavigationCompleted, data: event.toJSObject() as? [String: Any])
-    }
-
-    @objc public func notifyMessageReceivedListeners(_ event: MessageReceivedEvent) {
-        self.notifyListeners(Self.eventMessageReceived, data: event.toJSObject() as? [String: Any])
+    @objc public func notifyBrowserUrlChangedListeners(_ event: BrowserUrlChangedEvent) {
+        self.notifyListeners(Self.eventBrowserUrlChanged, data: event.toJSObject() as? [String: Any])
     }
 
     @objc func openInExternalBrowser(_ call: CAPPluginCall) {

--- a/packages/in-app-browser/src/definitions.ts
+++ b/packages/in-app-browser/src/definitions.ts
@@ -111,6 +111,33 @@ export interface InAppBrowserPlugin {
     listenerFunc: () => void,
   ): Promise<PluginListenerHandle>;
   /**
+   * Called when the web page posts a message to the app using the injected
+   * `window.CapacitorInAppBrowser.postMessage(...)` function.
+   *
+   * This event is only emitted for browsers opened with `openInWebView(...)`.
+   *
+   * Only available on Android and iOS.
+   *
+   * @since 0.1.0
+   */
+  addListener(
+    eventName: 'browserMessageReceived',
+    listenerFunc: (event: BrowserMessageReceivedEvent) => void,
+  ): Promise<PluginListenerHandle>;
+  /**
+   * Called when a page navigation has been completed in the web view.
+   *
+   * This event is only emitted for browsers opened with `openInWebView(...)`.
+   *
+   * Only available on Android and iOS.
+   *
+   * @since 0.1.0
+   */
+  addListener(
+    eventName: 'browserNavigationCompleted',
+    listenerFunc: (event: BrowserNavigationCompletedEvent) => void,
+  ): Promise<PluginListenerHandle>;
+  /**
    * Called when the initial page of the browser has finished loading.
    *
    * On Android, this event is only emitted for browsers opened with
@@ -125,7 +152,12 @@ export interface InAppBrowserPlugin {
     listenerFunc: () => void,
   ): Promise<PluginListenerHandle>;
   /**
-   * Called when a page navigation has been completed in the web view.
+   * Called when the current URL of the web view changes, e.g. when the user
+   * navigates to a new page, a server redirect occurs, or a single-page
+   * application updates the browser history.
+   *
+   * This event is also emitted for the initial URL and fires earlier than
+   * `browserNavigationCompleted`.
    *
    * This event is only emitted for browsers opened with `openInWebView(...)`.
    *
@@ -134,22 +166,8 @@ export interface InAppBrowserPlugin {
    * @since 0.1.0
    */
   addListener(
-    eventName: 'browserPageNavigationCompleted',
-    listenerFunc: (event: BrowserPageNavigationCompletedEvent) => void,
-  ): Promise<PluginListenerHandle>;
-  /**
-   * Called when the web page posts a message to the app using the injected
-   * `window.CapacitorInAppBrowser.postMessage(...)` function.
-   *
-   * This event is only emitted for browsers opened with `openInWebView(...)`.
-   *
-   * Only available on Android and iOS.
-   *
-   * @since 0.1.0
-   */
-  addListener(
-    eventName: 'messageReceived',
-    listenerFunc: (event: MessageReceivedEvent) => void,
+    eventName: 'browserUrlChanged',
+    listenerFunc: (event: BrowserUrlChangedEvent) => void,
   ): Promise<PluginListenerHandle>;
   /**
    * Remove all listeners for this plugin.
@@ -524,7 +542,19 @@ export interface GetCookiesResult {
 /**
  * @since 0.1.0
  */
-export interface BrowserPageNavigationCompletedEvent {
+export interface BrowserMessageReceivedEvent {
+  /**
+   * The message data posted by the web page.
+   *
+   * @since 0.1.0
+   */
+  data: unknown;
+}
+
+/**
+ * @since 0.1.0
+ */
+export interface BrowserNavigationCompletedEvent {
   /**
    * The URL of the page that was navigated to.
    *
@@ -537,13 +567,14 @@ export interface BrowserPageNavigationCompletedEvent {
 /**
  * @since 0.1.0
  */
-export interface MessageReceivedEvent {
+export interface BrowserUrlChangedEvent {
   /**
-   * The message data posted by the web page.
+   * The new URL of the web view.
    *
+   * @example 'https://capawesome.io'
    * @since 0.1.0
    */
-  data: unknown;
+  url: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR adds a new fine-grained `browserUrlChanged` event to the In-App Browser plugin and aligns the naming of the existing events. Since the plugin has not been officially released yet, the renames are not breaking.

### New `browserUrlChanged` event

Emitted for browsers opened with `openInWebView(...)` whenever the current URL of the web view changes, including the initial URL, server-side redirects, link navigations, and single-page application history updates. This enables use cases that need to observe every redirect (e.g. detecting the success URL of an SSO/OAuth login flow before reading cookies), which the coarser `browserNavigationCompleted` event cannot reliably cover.

- **Android**: emitted from `WebViewClient.onPageStarted` (navigation starts and redirect hops) and `doUpdateVisitedHistory` (SPA history updates), deduplicated so the same URL is not reported twice in a row.
- **iOS**: emitted from the existing KVO observation on `WKWebView.url`, which covers navigation starts, server redirect hops, and SPA history updates.

### Event renames

| Before | After |
| --- | --- |
| `browserPageNavigationCompleted` | `browserNavigationCompleted` |
| `messageReceived` | `browserMessageReceived` |

All events now share a consistent `browser` prefix: `browserClosed`, `browserMessageReceived`, `browserNavigationCompleted`, `browserPageLoaded`, `browserUrlChanged`. The native event classes, constants, and notify methods were renamed accordingly on both platforms.

No changeset was added since the plugin is unreleased and these changes ship with the pending initial release.

## Testing

- `npm run verify` (Android, iOS, and web builds) passes.
- `npm run lint` and `npm run fmt` pass.
- On-device verification that the event fires on every redirect of real-world login flows is still pending.