### PR TITLE
docs: add Ionic Enterprise migration FAQs and fix stale metadata

### DIFF
--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -3,8 +3,8 @@
 Capacitor plugin for communicating with OAuth 2.0 and OpenID Connect providers.[^1][^2]
 
 <div class="capawesome-z29o10a">
-  <a href="https://cloud.capawesome.io/" target="_blank">
-    <img alt="Deliver Live Updates to your Capacitor app with Capawesome Cloud" src="https://cloud.capawesome.io/assets/banners/cloud-build-and-deploy-capacitor-apps.png?t=1" />
+  <a href="https://capawesome.io/" target="_blank">
+    <img alt="Deliver Live Updates to your Capacitor app with Capawesome Cloud" src="https://capawesome.io/assets/banners/cloud-build-and-deploy-capacitor-apps.png?t=1" />
   </a>
 </div>
 
@@ -29,7 +29,7 @@ Missing a feature? Just [open an issue](https://github.com/capawesome-team/capac
 
 ## Newsletter
 
-Stay up to date with the latest news and updates about the Capawesome, Capacitor, and Ionic ecosystem by subscribing to our [Capawesome Newsletter](https://cloud.capawesome.io/newsletter/).
+Stay up to date with the latest news and updates about the Capawesome, Capacitor, and Ionic ecosystem by subscribing to our [Capawesome Newsletter](https://capawesome.io/newsletter/).
 
 ## Compatibility
 
@@ -51,6 +51,7 @@ Stay up to date with the latest news and updates about the Capawesome, Capacitor
 - [How to Sign in with Auth0 using Capacitor](https://capawesome.io/blog/how-to-sign-in-with-auth0-using-capacitor/)
 - [How to Sign in with Azure Entra ID using Capacitor](https://capawesome.io/blog/how-to-sign-in-with-azure-entra-id-using-capacitor/)
 - [Alternatives to Ionic Enterprise Plugins](https://capawesome.io/blog/alternatives-to-ionic-enterprise-plugins/)
+- [Alternative to the Ionic Auth Connect Plugin](https://capawesome.io/blog/alternative-to-ionic-auth-connect-plugin/)
 
 ## Installation
 
@@ -516,6 +517,42 @@ Refresh the access token using a refresh token.
 On iOS, `login(...)` may hang forever (while working on Android and Web) if the redirect URI returned by your provider does not exactly match the `redirectUrl` you passed. The plugin compares scheme, host and path and silently ignores any mismatch, so the promise never settles. The usual culprit is a **trailing slash** added by the provider or its infrastructure (`com.example.app://callback` vs `com.example.app://callback/`).
 
 Compare the returned redirect URI (e.g. via a network proxy such as [Proxyman](https://proxyman.io/)) byte-for-byte with your `redirectUrl` and make them match exactly.
+
+## FAQ
+
+### Is this plugin an alternative to Ionic Auth Connect?
+
+Yes. This plugin was built as an actively maintained alternative to [Ionic Auth Connect](https://ionic.io/products/auth-connect), which has been discontinued and reaches end of life on December 31, 2027. It offers a similar feature set:
+
+- OAuth 2.0 and OpenID Connect support for any provider, including Auth0, Azure AD, Amazon Cognito, Okta and OneLogin
+- Authorization Code flow with Proof Key for Code Exchange (PKCE)
+- Automatic endpoint discovery via OpenID Connect discovery
+- Access token refresh using a refresh token
+- Logout via the provider's end-session endpoint
+
+### How do I migrate from Ionic Auth Connect?
+
+For an AI-assisted migration of your code, add the [Capawesome Skills](https://github.com/capawesome-team/skills) to your AI tool:
+
+```bash
+npx skills add capawesome-team/skills --skill ionic-enterprise-sdk-migration
+```
+
+Then use the following prompt:
+
+```
+Use the `ionic-enterprise-sdk-migration` skill from `capawesome-team/skills` to migrate my project from Ionic Auth Connect to `@capawesome-team/capacitor-oauth`.
+```
+
+Alternatively, if you want to perform the migration manually, you can follow the instructions in this blog post: [Alternative to the Ionic Auth Connect plugin](https://capawesome.io/blog/alternative-to-ionic-auth-connect-plugin/).
+
+## Next steps
+
+Here are a few resources to help you continue:
+
+- Read [Alternative to the Ionic Auth Connect plugin](https://capawesome.io/blog/alternative-to-ionic-auth-connect-plugin/) if you are migrating from Ionic Auth Connect.
+- Store tokens and other sensitive data with the [Capacitor Secure Preferences plugin](https://capawesome.io/docs/sdks/capacitor/secure-preferences/).
+- Check out [Getting Started with Insiders](https://capawesome.io/docs/insiders/getting-started/) to learn how to install the plugin.
 
 ## Changelog
 

--- a/packages/secure-preferences/README.md
+++ b/packages/secure-preferences/README.md
@@ -3,8 +3,8 @@
 Capacitor plugin to securely store key/value pairs such as passwords, tokens or other sensitive information.
 
 <div class="capawesome-z29o10a">
-  <a href="https://cloud.capawesome.io/" target="_blank">
-    <img alt="Deliver Live Updates to your Capacitor app with Capawesome Cloud" src="https://cloud.capawesome.io/assets/banners/cloud-build-and-deploy-capacitor-apps.png?t=1" />
+  <a href="https://capawesome.io/" target="_blank">
+    <img alt="Deliver Live Updates to your Capacitor app with Capawesome Cloud" src="https://capawesome.io/assets/banners/cloud-build-and-deploy-capacitor-apps.png?t=1" />
   </a>
 </div>
 
@@ -25,13 +25,14 @@ Missing a feature? Just [open an issue](https://github.com/capawesome-team/capac
 
 ## Newsletter
 
-Stay up to date with the latest news and updates about the Capawesome, Capacitor, and Ionic ecosystem by subscribing to our [Capawesome Newsletter](https://cloud.capawesome.io/newsletter/).
+Stay up to date with the latest news and updates about the Capawesome, Capacitor, and Ionic ecosystem by subscribing to our [Capawesome Newsletter](https://capawesome.io/newsletter/).
 
 ## Compatibility
 
 | Plugin Version | Capacitor Version | Status         |
 | -------------- | ----------------- | -------------- |
-| 0.2.x          | >=8.x.x           | Active support |
+| 0.3.x          | >=8.x.x           | Active support |
+| 0.2.x          | >=8.x.x           | Deprecated     |
 
 ## Guides
 
@@ -150,7 +151,7 @@ clear() => Promise<void>
 
 Clear all stored keys and values.
 
-**Since:** 7.0.0
+**Since:** 0.1.0
 
 --------------------
 
@@ -169,7 +170,7 @@ Get the value associated with a key.
 
 **Returns:** <code>Promise&lt;<a href="#getresult">GetResult</a>&gt;</code>
 
-**Since:** 7.0.0
+**Since:** 0.1.0
 
 --------------------
 
@@ -184,7 +185,7 @@ Get a list of all stored keys.
 
 **Returns:** <code>Promise&lt;<a href="#keysresult">KeysResult</a>&gt;</code>
 
-**Since:** 7.0.0
+**Since:** 0.1.0
 
 --------------------
 
@@ -201,7 +202,7 @@ Remove a value given its key.
 | ------------- | ------------------------------------------------------- |
 | **`options`** | <code><a href="#removeoptions">RemoveOptions</a></code> |
 
-**Since:** 7.0.0
+**Since:** 0.1.0
 
 --------------------
 
@@ -221,7 +222,7 @@ This is for development purposes only and should NOT be used in production.
 | ------------- | ------------------------------------------------- |
 | **`options`** | <code><a href="#setoptions">SetOptions</a></code> |
 
-**Since:** 7.0.0
+**Since:** 0.1.0
 
 --------------------
 
@@ -233,36 +234,36 @@ This is for development purposes only and should NOT be used in production.
 
 | Prop        | Type                        | Description          | Since |
 | ----------- | --------------------------- | -------------------- | ----- |
-| **`value`** | <code>string \| null</code> | The retrieved value. | 7.0.0 |
+| **`value`** | <code>string \| null</code> | The retrieved value. | 0.1.0 |
 
 
 #### GetOptions
 
 | Prop      | Type                | Description                               | Since |
 | --------- | ------------------- | ----------------------------------------- | ----- |
-| **`key`** | <code>string</code> | The key associated with the stored value. | 7.0.0 |
+| **`key`** | <code>string</code> | The key associated with the stored value. | 0.1.0 |
 
 
 #### KeysResult
 
 | Prop       | Type                  | Description                | Since |
 | ---------- | --------------------- | -------------------------- | ----- |
-| **`keys`** | <code>string[]</code> | The available stored keys. | 7.0.0 |
+| **`keys`** | <code>string[]</code> | The available stored keys. | 0.1.0 |
 
 
 #### RemoveOptions
 
 | Prop      | Type                | Description        | Since |
 | --------- | ------------------- | ------------------ | ----- |
-| **`key`** | <code>string</code> | The key to remove. | 7.0.0 |
+| **`key`** | <code>string</code> | The key to remove. | 0.1.0 |
 
 
 #### SetOptions
 
 | Prop        | Type                | Description                               | Since |
 | ----------- | ------------------- | ----------------------------------------- | ----- |
-| **`key`**   | <code>string</code> | The key associated with the stored value. | 7.0.0 |
-| **`value`** | <code>string</code> | The value to store.                       | 7.0.0 |
+| **`key`**   | <code>string</code> | The key associated with the stored value. | 0.1.0 |
+| **`value`** | <code>string</code> | The value to store.                       | 0.1.0 |
 
 </docgen-api>
 
@@ -291,6 +292,34 @@ A quick decision tree:
 - Need queries, relations, or large datasets? → **SQLite**.
 
 The three plugins are designed to coexist. A real-world app might use Secure Preferences for app-managed tokens, SQLite for synced records, and Vault for the master password that protects everything else.
+
+### Is this plugin an alternative to Ionic Secure Storage?
+
+Yes, for key/value data. This plugin was built as an actively maintained alternative to [Ionic Secure Storage](https://ionic.io/products/secure-storage), which sunsets on December 31, 2027. Like Ionic Secure Storage's key/value API, it stores sensitive data encrypted at rest, backed by the Android Keystore and iOS Keychain. If you use Ionic Secure Storage's encrypted SQLite database, take a look at the [SQLite](https://capawesome.io/docs/sdks/capacitor/sqlite/) plugin instead, which provides SQLCipher-based encryption.
+
+### How do I migrate from Ionic Secure Storage?
+
+For an AI-assisted migration of your code, add the [Capawesome Skills](https://github.com/capawesome-team/skills) to your AI tool:
+
+```bash
+npx skills add capawesome-team/skills --skill ionic-enterprise-sdk-migration
+```
+
+Then use the following prompt:
+
+```
+Use the `ionic-enterprise-sdk-migration` skill from `capawesome-team/skills` to migrate my project from Ionic Secure Storage to `@capawesome-team/capacitor-secure-preferences`.
+```
+
+Alternatively, if you want to perform the migration manually, you can follow the instructions in this blog post: [Alternative to the Ionic Secure Storage plugin](https://capawesome.io/blog/alternative-to-ionic-secure-storage-plugin/).
+
+## Next steps
+
+Here are a few resources to help you continue:
+
+- Read [Alternative to the Ionic Secure Storage plugin](https://capawesome.io/blog/alternative-to-ionic-secure-storage-plugin/) if you are migrating from Ionic Secure Storage.
+- Need biometric-protected, lockable storage? Check out the [Capacitor Vault plugin](https://capawesome.io/docs/sdks/capacitor/vault/).
+- Need encrypted relational storage? Check out the [Capacitor SQLite plugin](https://capawesome.io/docs/sdks/capacitor/sqlite/).
 
 ## Changelog
 

--- a/packages/sqlite/README.md
+++ b/packages/sqlite/README.md
@@ -3,8 +3,8 @@
 Capacitor plugin to access SQLite databases with support for encryption, transactions, and schema migrations.[^1][^2][^3]
 
 <div class="capawesome-z29o10a">
-  <a href="https://cloud.capawesome.io/" target="_blank">
-    <img alt="Deliver Live Updates to your Capacitor app with Capawesome Cloud" src="https://cloud.capawesome.io/assets/banners/cloud-build-and-deploy-capacitor-apps.png?t=1" />
+  <a href="https://capawesome.io/" target="_blank">
+    <img alt="Deliver Live Updates to your Capacitor app with Capawesome Cloud" src="https://capawesome.io/assets/banners/cloud-build-and-deploy-capacitor-apps.png?t=1" />
   </a>
 </div>
 
@@ -39,7 +39,7 @@ Missing a feature? Just [open an issue](https://github.com/capawesome-team/capac
 
 ## Newsletter
 
-Stay up to date with the latest news and updates about the Capawesome, Capacitor, and Ionic ecosystem by subscribing to our [Capawesome Newsletter](https://cloud.capawesome.io/newsletter/).
+Stay up to date with the latest news and updates about the Capawesome, Capacitor, and Ionic ecosystem by subscribing to our [Capawesome Newsletter](https://capawesome.io/newsletter/).
 
 ## Compatibility
 
@@ -1035,6 +1035,22 @@ A quick decision tree:
 - Need encrypted key/value storage the user must actively unlock with biometrics or a passcode? → **Vault**.
 
 The three plugins are designed to coexist. A real-world app might use Secure Preferences for app-managed tokens, SQLite for synced records, and Vault for the master password that protects everything else.
+
+### Is this plugin an alternative to Ionic Secure Storage?
+
+Yes. [Ionic Secure Storage](https://ionic.io/products/secure-storage), which sunsets on December 31, 2027, provides an encrypted SQLite database based on SQLCipher — and so does this plugin: it offers 256 bit AES encryption via SQLCipher on Android and iOS (see the [Encryption](#encryption) section). Since both are built on SQLCipher and this plugin applies SQLCipher's default configuration, an existing database created by Ionic Secure Storage can generally be opened with the same encryption key — but verify this with your own database before migrating. For a step-by-step guide, check out the blog post [Alternative to the Ionic Secure Storage plugin](https://capawesome.io/blog/alternative-to-ionic-secure-storage-plugin/). If you only store key/value data, the [Secure Preferences](https://capawesome.io/docs/sdks/capacitor/secure-preferences/) plugin may be the better fit.
+
+### Is this plugin an alternative to the Capacitor Community SQLite plugin?
+
+Yes. Check out the blog post [Alternative to the Capacitor Community SQLite plugin](https://capawesome.io/blog/alternative-to-capacitor-community-sqlite-plugin/) for a detailed comparison of `@capacitor-community/sqlite` and this plugin, including a migration guide.
+
+## Next steps
+
+Here are a few resources to help you continue:
+
+- Read [Alternative to the Ionic Secure Storage plugin](https://capawesome.io/blog/alternative-to-ionic-secure-storage-plugin/) if you are migrating from Ionic Secure Storage.
+- Read [Alternative to the Capacitor Community SQLite plugin](https://capawesome.io/blog/alternative-to-capacitor-community-sqlite-plugin/) to see how this plugin compares.
+- Store small pieces of sensitive data like tokens with the [Capacitor Secure Preferences plugin](https://capawesome.io/docs/sdks/capacitor/secure-preferences/).
 
 ## Changelog
 

--- a/packages/vault/README.md
+++ b/packages/vault/README.md
@@ -3,8 +3,8 @@
 Capacitor plugin to securely store key/value pairs in lockable, biometric-protected vaults.
 
 <div class="capawesome-z29o10a">
-  <a href="https://cloud.capawesome.io/" target="_blank">
-    <img alt="Deliver Live Updates to your Capacitor app with Capawesome Cloud" src="https://cloud.capawesome.io/assets/banners/cloud-build-and-deploy-capacitor-apps.png?t=1" />
+  <a href="https://capawesome.io/" target="_blank">
+    <img alt="Deliver Live Updates to your Capacitor app with Capawesome Cloud" src="https://capawesome.io/assets/banners/cloud-build-and-deploy-capacitor-apps.png?t=1" />
   </a>
 </div>
 
@@ -31,7 +31,7 @@ Missing a feature? Just [open an issue](https://github.com/capawesome-team/capac
 
 ## Newsletter
 
-Stay up to date with the latest news and updates about the Capawesome, Capacitor, and Ionic ecosystem by subscribing to our [Capawesome Newsletter](https://cloud.capawesome.io/newsletter/).
+Stay up to date with the latest news and updates about the Capawesome, Capacitor, and Ionic ecosystem by subscribing to our [Capawesome Newsletter](https://capawesome.io/newsletter/).
 
 ## Compatibility
 
@@ -860,7 +860,7 @@ Then use the following prompt:
 Use the `ionic-enterprise-sdk-migration` skill from `capawesome-team/skills` to migrate my project from Ionic Identity Vault to `@capawesome-team/capacitor-vault`.
 ```
 
-Alternatively, if you want to perform the migration manually, you can follow the instructions in this blog post:[Alternative to the Ionic Identity Vault plugin](https://capawesome.io/blog/alternative-to-ionic-identity-vault-plugin/).
+Alternatively, if you want to perform the migration manually, you can follow the instructions in this blog post: [Alternative to the Ionic Identity Vault plugin](https://capawesome.io/blog/alternative-to-ionic-identity-vault-plugin/).
 
 The stored data needs to be migrated at runtime while **both** plugins are still installed. Identity Vault exposes `exportVault()`, which returns a plain key/value map after the user unlocks the vault. That map has the exact shape expected by this plugin's [`importData(...)`](#importdata) method, so the two can be bridged directly:
 
@@ -900,6 +900,14 @@ const migrateFromIdentityVault = async () => {
 Once all users have migrated (for example, after a release cycle in which everyone has opened the app at least once), you can remove the Identity Vault dependency in a follow-up release.
 
 **Note**: The user has to authenticate once during the migration to unlock the old vault. This is unavoidable, since the data is protected by the device's biometric or passcode authentication by design.
+
+## Next steps
+
+Here are a few resources to help you continue:
+
+- Read [Alternative to the Ionic Identity Vault plugin](https://capawesome.io/blog/alternative-to-ionic-identity-vault-plugin/) if you are migrating from Ionic Identity Vault.
+- Need simple secure key/value storage without vault locking? Check out the [Capacitor Secure Preferences plugin](https://capawesome.io/docs/sdks/capacitor/secure-preferences/).
+- Check out [Getting Started with Insiders](https://capawesome.io/docs/insiders/getting-started/) to learn how to install the plugin.
 
 ## Changelog
 


### PR DESCRIPTION
## Summary

Mirrors capawesome-team/capacitor-plugins-sponsorware#486 (the source of truth for these READMEs) so the public repo and the embedded capawesome.io docs pages pick up the changes immediately.

- FAQ entries naming the discontinued Ionic Enterprise plugins (Auth Connect, Identity Vault, Secure Storage) with the December 31, 2027 end-of-life date and migration pointers
- Next steps sections linking related guides and plugins
- secure-preferences: compatibility table updated (0.3.x active, 0.2.x deprecated), phantom `Since 7.0.0` markers corrected to `0.1.0`
- `cloud.capawesome.io` 301 links fixed, vault FAQ typo fixed

If the automated sync from the sponsorware repo already propagates READMEs, feel free to close this in favor of the sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)