### PR TITLE
feat(file-picker): make pickDirectory results persistence-ready

### DIFF
--- a/packages/file-picker/README.md
+++ b/packages/file-picker/README.md
@@ -564,9 +564,10 @@ Remove all listeners for this plugin.
 
 #### PickDirectoryResult
 
-| Prop       | Type                | Description                         | Since |
-| ---------- | ------------------- | ----------------------------------- | ----- |
-| **`path`** | <code>string</code> | The path to the selected directory. | 6.2.0 |
+| Prop           | Type                | Description                                                                                                                                                         | Since |
+| -------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| **`bookmark`** | <code>string</code> | The base64-encoded security-scoped bookmark of the selected directory. It can be used to retain access to the directory across app launches. Only available on iOS. | 8.1.0 |
+| **`path`**     | <code>string</code> | The path to the selected directory.                                                                                                                                 | 6.2.0 |
 
 
 #### PickMediaOptions

--- a/packages/file-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePickerPlugin.java
+++ b/packages/file-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePickerPlugin.java
@@ -118,6 +118,11 @@ public class FilePickerPlugin extends Plugin {
     public void pickDirectory(PluginCall call) {
         try {
             Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+            intent.addFlags(
+                Intent.FLAG_GRANT_READ_URI_PERMISSION |
+                Intent.FLAG_GRANT_WRITE_URI_PERMISSION |
+                Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+            );
             startActivityForResult(call, intent, "pickDirectoryResult");
         } catch (Exception ex) {
             String message = ex.getMessage();

--- a/packages/file-picker/ios/Plugin/FilePicker.swift
+++ b/packages/file-picker/ios/Plugin/FilePicker.swift
@@ -309,7 +309,15 @@ extension FilePicker: UIDocumentPickerDelegate {
                 plugin?.handleDocumentPickerResult(urls: nil, error: self.plugin?.errorTemporaryCopyFailed)
             }
         } else if invokedMethod == "pickDirectory" {
-            plugin?.handleDirectoryPickerResult(path: urls.first?.absoluteString, error: nil)
+            var bookmark: String?
+            if let url = urls.first {
+                let isSecurityScoped = url.startAccessingSecurityScopedResource()
+                bookmark = (try? url.bookmarkData())?.base64EncodedString()
+                if isSecurityScoped {
+                    url.stopAccessingSecurityScopedResource()
+                }
+            }
+            plugin?.handleDirectoryPickerResult(path: urls.first?.absoluteString, bookmark: bookmark, error: nil)
         } else {
             return
         }
@@ -320,7 +328,7 @@ extension FilePicker: UIDocumentPickerDelegate {
         if invokedMethod == "pickFiles" {
             plugin?.handleDocumentPickerResult(urls: nil, error: nil)
         } else if invokedMethod == "pickDirectory" {
-            plugin?.handleDirectoryPickerResult(path: nil, error: nil)
+            plugin?.handleDirectoryPickerResult(path: nil, bookmark: nil, error: nil)
         } else {
             return
         }

--- a/packages/file-picker/ios/Plugin/FilePickerPlugin.swift
+++ b/packages/file-picker/ios/Plugin/FilePickerPlugin.swift
@@ -172,7 +172,7 @@ public class FilePickerPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
-    @objc func handleDirectoryPickerResult(path: String?, error: String?) {
+    @objc func handleDirectoryPickerResult(path: String?, bookmark: String?, error: String?) {
         guard let savedCall = savedCall else {
             return
         }
@@ -185,6 +185,9 @@ public class FilePickerPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
         var result = JSObject()
+        if let bookmark = bookmark {
+            result["bookmark"] = bookmark
+        }
         result["path"] = path
         savedCall.resolve(result)
     }

--- a/packages/file-picker/src/definitions.ts
+++ b/packages/file-picker/src/definitions.ts
@@ -318,6 +318,16 @@ export interface PickMediaOptions {
 
 export interface PickDirectoryResult {
   /**
+   * The base64-encoded security-scoped bookmark of the selected directory.
+   *
+   * It can be used to retain access to the directory across app launches.
+   *
+   * Only available on iOS.
+   *
+   * @since 8.1.0
+   */
+  bookmark?: string;
+  /**
    * The path to the selected directory.
    *
    * @since 6.2.0


### PR DESCRIPTION
## Changes

- **Android**: Set `FLAG_GRANT_READ_URI_PERMISSION`, `FLAG_GRANT_WRITE_URI_PERMISSION` and `FLAG_GRANT_PERSISTABLE_URI_PERMISSION` on the `pickDirectory` intent so consumers can call `takePersistableUriPermission()` on the returned tree URI.
- **iOS**: Create bookmark data for the picked folder inside the picker delegate callback (while the security scope is active) and return it base64-encoded as a new optional `bookmark` field in `PickDirectoryResult`.

Both changes are backward-compatible.

Close #918