### PR TITLE
feat(volume): add `volumeButtonReleased` event

### DIFF
--- a/.changeset/volume-button-released-event.md
+++ b/.changeset/volume-button-released-event.md
@@ -1,0 +1,5 @@
+---
+"@capawesome/capacitor-volume": minor
+---
+
+feat(android): add `volumeButtonReleased` event

--- a/packages/volume/README.md
+++ b/packages/volume/README.md
@@ -169,6 +169,7 @@ const removeAllListeners = async () => {
 * [`startWatching(...)`](#startwatching)
 * [`stopWatching()`](#stopwatching)
 * [`addListener('volumeButtonPressed', ...)`](#addlistenervolumebuttonpressed-)
+* [`addListener('volumeButtonReleased', ...)`](#addlistenervolumebuttonreleased-)
 * [`addListener('volumeChange', ...)`](#addlistenervolumechange-)
 * [`removeAllListeners()`](#removealllisteners)
 * [Interfaces](#interfaces)
@@ -249,8 +250,8 @@ startWatching(options?: StartWatchingOptions | undefined) => Promise<void>
 
 Start watching the hardware volume buttons.
 
-The `volumeButtonPressed` and `volumeChange` events are only
-emitted while watching.
+The `volumeButtonPressed`, `volumeButtonReleased` and `volumeChange`
+events are only emitted while watching.
 
 If the volume buttons are already being watched, this call has
 no effect. Call `stopWatching()` first to change the options.
@@ -302,6 +303,28 @@ Only available on Android and iOS.
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
 
 **Since:** 0.1.0
+
+--------------------
+
+
+### addListener('volumeButtonReleased', ...)
+
+```typescript
+addListener(eventName: 'volumeButtonReleased', listenerFunc: (event: VolumeButtonReleasedEvent) => void) => Promise<PluginListenerHandle>
+```
+
+Called when a hardware volume button is released while watching.
+
+Only available on Android.
+
+| Param              | Type                                                                                                |
+| ------------------ | --------------------------------------------------------------------------------------------------- |
+| **`eventName`**    | <code>'volumeButtonReleased'</code>                                                                 |
+| **`listenerFunc`** | <code>(event: <a href="#volumebuttonreleasedevent">VolumeButtonReleasedEvent</a>) =&gt; void</code> |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+**Since:** 0.2.0
 
 --------------------
 
@@ -396,6 +419,13 @@ Remove all listeners for this plugin.
 | Prop            | Type                                            | Description                                          | Since |
 | --------------- | ----------------------------------------------- | ---------------------------------------------------- | ----- |
 | **`direction`** | <code><a href="#direction">Direction</a></code> | The direction of the pressed hardware volume button. | 0.1.0 |
+
+
+#### VolumeButtonReleasedEvent
+
+| Prop            | Type                                            | Description                                           | Since |
+| --------------- | ----------------------------------------------- | ----------------------------------------------------- | ----- |
+| **`direction`** | <code><a href="#direction">Direction</a></code> | The direction of the released hardware volume button. | 0.2.0 |
 
 
 #### VolumeChangeEvent

--- a/packages/volume/android/src/main/java/io/capawesome/capacitorjs/plugins/volume/Volume.java
+++ b/packages/volume/android/src/main/java/io/capawesome/capacitorjs/plugins/volume/Volume.java
@@ -12,6 +12,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import io.capawesome.capacitorjs.plugins.volume.classes.CustomExceptions;
 import io.capawesome.capacitorjs.plugins.volume.classes.events.VolumeButtonPressedEvent;
+import io.capawesome.capacitorjs.plugins.volume.classes.events.VolumeButtonReleasedEvent;
 import io.capawesome.capacitorjs.plugins.volume.classes.events.VolumeChangeEvent;
 import io.capawesome.capacitorjs.plugins.volume.classes.options.GetVolumeOptions;
 import io.capawesome.capacitorjs.plugins.volume.classes.options.SetVolumeOptions;
@@ -120,9 +121,11 @@ public class Volume {
         if (keyCode != KeyEvent.KEYCODE_VOLUME_UP && keyCode != KeyEvent.KEYCODE_VOLUME_DOWN) {
             return false;
         }
-        if (event.getAction() == KeyEvent.ACTION_DOWN) {
-            String direction = keyCode == KeyEvent.KEYCODE_VOLUME_UP ? DIRECTION_UP : DIRECTION_DOWN;
+        String direction = keyCode == KeyEvent.KEYCODE_VOLUME_UP ? DIRECTION_UP : DIRECTION_DOWN;
+        if (event.getAction() == KeyEvent.ACTION_DOWN && event.getRepeatCount() == 0) {
             plugin.notifyVolumeButtonPressedListeners(new VolumeButtonPressedEvent(direction));
+        } else if (event.getAction() == KeyEvent.ACTION_UP) {
+            plugin.notifyVolumeButtonReleasedListeners(new VolumeButtonReleasedEvent(direction));
         }
         return suppressVolumeChange;
     }

--- a/packages/volume/android/src/main/java/io/capawesome/capacitorjs/plugins/volume/VolumePlugin.java
+++ b/packages/volume/android/src/main/java/io/capawesome/capacitorjs/plugins/volume/VolumePlugin.java
@@ -8,6 +8,7 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import io.capawesome.capacitorjs.plugins.volume.classes.CustomException;
 import io.capawesome.capacitorjs.plugins.volume.classes.events.VolumeButtonPressedEvent;
+import io.capawesome.capacitorjs.plugins.volume.classes.events.VolumeButtonReleasedEvent;
 import io.capawesome.capacitorjs.plugins.volume.classes.events.VolumeChangeEvent;
 import io.capawesome.capacitorjs.plugins.volume.classes.options.GetVolumeOptions;
 import io.capawesome.capacitorjs.plugins.volume.classes.options.SetVolumeOptions;
@@ -22,6 +23,7 @@ import io.capawesome.capacitorjs.plugins.volume.interfaces.Result;
 public class VolumePlugin extends Plugin {
 
     public static final String EVENT_VOLUME_BUTTON_PRESSED = "volumeButtonPressed";
+    public static final String EVENT_VOLUME_BUTTON_RELEASED = "volumeButtonReleased";
     public static final String EVENT_VOLUME_CHANGE = "volumeChange";
     public static final String TAG = "VolumePlugin";
 
@@ -79,6 +81,10 @@ public class VolumePlugin extends Plugin {
 
     public void notifyVolumeButtonPressedListeners(@NonNull VolumeButtonPressedEvent event) {
         notifyListeners(EVENT_VOLUME_BUTTON_PRESSED, event.toJSObject());
+    }
+
+    public void notifyVolumeButtonReleasedListeners(@NonNull VolumeButtonReleasedEvent event) {
+        notifyListeners(EVENT_VOLUME_BUTTON_RELEASED, event.toJSObject());
     }
 
     public void notifyVolumeChangeListeners(@NonNull VolumeChangeEvent event) {

--- a/packages/volume/android/src/main/java/io/capawesome/capacitorjs/plugins/volume/classes/events/VolumeButtonReleasedEvent.java
+++ b/packages/volume/android/src/main/java/io/capawesome/capacitorjs/plugins/volume/classes/events/VolumeButtonReleasedEvent.java
@@ -1,0 +1,23 @@
+package io.capawesome.capacitorjs.plugins.volume.classes.events;
+
+import androidx.annotation.NonNull;
+import com.getcapacitor.JSObject;
+import io.capawesome.capacitorjs.plugins.volume.interfaces.Result;
+
+public class VolumeButtonReleasedEvent implements Result {
+
+    @NonNull
+    private final String direction;
+
+    public VolumeButtonReleasedEvent(@NonNull String direction) {
+        this.direction = direction;
+    }
+
+    @Override
+    @NonNull
+    public JSObject toJSObject() {
+        JSObject result = new JSObject();
+        result.put("direction", direction);
+        return result;
+    }
+}

--- a/packages/volume/src/definitions.ts
+++ b/packages/volume/src/definitions.ts
@@ -32,8 +32,8 @@ export interface VolumePlugin {
   /**
    * Start watching the hardware volume buttons.
    *
-   * The `volumeButtonPressed` and `volumeChange` events are only
-   * emitted while watching.
+   * The `volumeButtonPressed`, `volumeButtonReleased` and `volumeChange`
+   * events are only emitted while watching.
    *
    * If the volume buttons are already being watched, this call has
    * no effect. Call `stopWatching()` first to change the options.
@@ -64,6 +64,17 @@ export interface VolumePlugin {
   addListener(
     eventName: 'volumeButtonPressed',
     listenerFunc: (event: VolumeButtonPressedEvent) => void,
+  ): Promise<PluginListenerHandle>;
+  /**
+   * Called when a hardware volume button is released while watching.
+   *
+   * Only available on Android.
+   *
+   * @since 0.2.0
+   */
+  addListener(
+    eventName: 'volumeButtonReleased',
+    listenerFunc: (event: VolumeButtonReleasedEvent) => void,
   ): Promise<PluginListenerHandle>;
   /**
    * Called when the volume level changes while watching.
@@ -184,6 +195,19 @@ export interface VolumeButtonPressedEvent {
    * The direction of the pressed hardware volume button.
    *
    * @since 0.1.0
+   * @example 'up'
+   */
+  direction: Direction;
+}
+
+/**
+ * @since 0.2.0
+ */
+export interface VolumeButtonReleasedEvent {
+  /**
+   * The direction of the released hardware volume button.
+   *
+   * @since 0.2.0
    * @example 'up'
    */
   direction: Direction;


### PR DESCRIPTION
This PR adds a new `volumeButtonReleased` event to the Volume plugin, emitted while watching when a hardware volume button is released. This enables press-and-hold use cases such as push-to-talk.

On Android, the event is emitted on `ACTION_UP` of the volume keys. Additionally, auto-repeated `ACTION_DOWN` events are now ignored, so `volumeButtonPressed` fires only once per physical press instead of repeatedly while a button is held.

The event is only available on Android, since iOS provides no public API to detect volume button releases (volume button detection on iOS is based on observing volume level changes).

Close #930