### PR TITLE
feat(pdf-viewer): add `showShareButton` option to the viewer toolbar

### DIFF
--- a/.changeset/pdf-viewer-share-button.md
+++ b/.changeset/pdf-viewer-share-button.md
@@ -1,0 +1,5 @@
+---
+"@capawesome/capacitor-pdf-viewer": patch
+---
+
+feat: add `showShareButton` option to the viewer toolbar

--- a/packages/pdf-viewer/README.md
+++ b/packages/pdf-viewer/README.md
@@ -63,6 +63,23 @@ npx cap sync
 
 On Android, this plugin uses the [android-pdf-viewer](https://github.com/oothp/AndroidPdfViewer) library, which renders PDF documents with [Pdfium](https://pdfium.googlesource.com/pdfium/). Be aware that the library bundles the Pdfium native libraries, which add about 10 to 16 MB (uncompressed, across all ABIs) to your app. If you publish your app as an [Android App Bundle](https://developer.android.com/guide/app-bundle), each device only downloads the native libraries for its own ABI, which significantly reduces the download size. Also note that the viewer does not support text selection on Android.
 
+#### Share Button
+
+If you use the share button (see the `showShareButton` option), you need to specify the directories that contain the PDF files you want to share. To do this, create a new file named `file_paths.xml` in the `res/xml` directory of your Android project (e.g. `android/app/src/main/res/xml/file_paths.xml`). Here is an example of the content of the file:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <files-path name="files" path="." />
+    <cache-path name="cache" path="." />
+    <external-files-path name="external-files" path="." />
+    <external-cache-path name="external-cache" path="." />
+    <external-path name="external" path="." />
+</paths>
+```
+
+More information can be found in the [Android documentation](https://developer.android.com/training/secure-file-sharing/setup-sharing#DefineMetaData).
+
 #### Variables
 
 This plugin will use the following project variables (defined in your app’s `variables.gradle` file):
@@ -264,12 +281,13 @@ Remove all listeners for this plugin.
 
 #### OpenOptions
 
-| Prop           | Type                | Description                                                                                                                                                                         | Default                                     | Since |
-| -------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- | ----- |
-| **`page`**     | <code>number</code> | The page (1-based) to display initially.                                                                                                                                            | <code>1</code>                              | 0.1.0 |
-| **`password`** | <code>string</code> | The password to unlock the PDF file if it is password-protected.                                                                                                                    |                                             | 0.1.0 |
-| **`path`**     | <code>string</code> | The path of the local PDF file to display. Remote URLs are not supported. Download the file first, for example to the cache directory, and pass the local file path to this method. |                                             | 0.1.0 |
-| **`title`**    | <code>string</code> | The title to display in the toolbar of the viewer.                                                                                                                                  | <code>The file name of the PDF file.</code> | 0.1.0 |
+| Prop                  | Type                 | Description                                                                                                                                                                         | Default                                     | Since |
+| --------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- | ----- |
+| **`page`**            | <code>number</code>  | The page (1-based) to display initially.                                                                                                                                            | <code>1</code>                              | 0.1.0 |
+| **`password`**        | <code>string</code>  | The password to unlock the PDF file if it is password-protected.                                                                                                                    |                                             | 0.1.0 |
+| **`path`**            | <code>string</code>  | The path of the local PDF file to display. Remote URLs are not supported. Download the file first, for example to the cache directory, and pass the local file path to this method. |                                             | 0.1.0 |
+| **`showShareButton`** | <code>boolean</code> | Whether to display a share button in the toolbar of the viewer. Only available on Android and iOS.                                                                                  | <code>true</code>                           | 0.1.2 |
+| **`title`**           | <code>string</code>  | The title to display in the toolbar of the viewer.                                                                                                                                  | <code>The file name of the PDF file.</code> | 0.1.0 |
 
 
 #### PluginListenerHandle
@@ -312,6 +330,10 @@ On Android, the plugin uses the [android-pdf-viewer](https://github.com/oothp/An
 ### Can I select text in the viewer on Android?
 
 No, the viewer does not support text selection on Android. On iOS, the plugin uses the PDFKit framework, which provides the native viewer experience of the platform.
+
+### Why does the share button not work on Android?
+
+On Android, the file is shared using a [`FileProvider`](https://developer.android.com/reference/androidx/core/content/FileProvider). Make sure that the directory containing the PDF file is declared in the `file_paths.xml` file of your Android project, as described in the [Installation](#android) section. Without this configuration, the file can not be shared. You can also hide the button by setting the `showShareButton` option to `false`.
 
 ### Can I use this plugin with Ionic, React, Vue or Angular?
 

--- a/packages/pdf-viewer/README.md
+++ b/packages/pdf-viewer/README.md
@@ -286,7 +286,7 @@ Remove all listeners for this plugin.
 | **`page`**            | <code>number</code>  | The page (1-based) to display initially.                                                                                                                                            | <code>1</code>                              | 0.1.0 |
 | **`password`**        | <code>string</code>  | The password to unlock the PDF file if it is password-protected.                                                                                                                    |                                             | 0.1.0 |
 | **`path`**            | <code>string</code>  | The path of the local PDF file to display. Remote URLs are not supported. Download the file first, for example to the cache directory, and pass the local file path to this method. |                                             | 0.1.0 |
-| **`showShareButton`** | <code>boolean</code> | Whether to display a share button in the toolbar of the viewer. Only available on Android and iOS.                                                                                  | <code>true</code>                           | 0.1.2 |
+| **`showShareButton`** | <code>boolean</code> | Whether to display a share button in the toolbar of the viewer. Only available on Android and iOS.                                                                                  | <code>false</code>                          | 0.1.2 |
 | **`title`**           | <code>string</code>  | The title to display in the toolbar of the viewer.                                                                                                                                  | <code>The file name of the PDF file.</code> | 0.1.0 |
 
 
@@ -333,7 +333,7 @@ No, the viewer does not support text selection on Android. On iOS, the plugin us
 
 ### Why does the share button not work on Android?
 
-On Android, the file is shared using a [`FileProvider`](https://developer.android.com/reference/androidx/core/content/FileProvider). Make sure that the directory containing the PDF file is declared in the `file_paths.xml` file of your Android project, as described in the [Installation](#android) section. Without this configuration, the file can not be shared. You can also hide the button by setting the `showShareButton` option to `false`.
+The share button is hidden by default. Enable it by setting the `showShareButton` option to `true`. On Android, the file is then shared using a [`FileProvider`](https://developer.android.com/reference/androidx/core/content/FileProvider). Make sure that the directory containing the PDF file is declared in the `file_paths.xml` file of your Android project, as described in the [Installation](#android) section. Without this configuration, the file can not be shared.
 
 ### Can I use this plugin with Ionic, React, Vue or Angular?
 

--- a/packages/pdf-viewer/android/src/main/java/io/capawesome/capacitorjs/plugins/pdfviewer/classes/PdfViewerDialog.java
+++ b/packages/pdf-viewer/android/src/main/java/io/capawesome/capacitorjs/plugins/pdfviewer/classes/PdfViewerDialog.java
@@ -2,19 +2,24 @@ package io.capawesome.capacitorjs.plugins.pdfviewer.classes;
 
 import android.app.Dialog;
 import android.content.Context;
+import android.content.Intent;
 import android.graphics.Color;
 import android.graphics.Typeface;
+import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.ViewGroup;
 import android.view.Window;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.FileProvider;
 import androidx.core.view.WindowInsetsControllerCompat;
+import com.getcapacitor.Logger;
 import com.github.barteksc.pdfviewer.PDFView;
 import io.capawesome.capacitorjs.plugins.pdfviewer.classes.options.OpenOptions;
 import java.io.File;
@@ -28,6 +33,7 @@ public class PdfViewerDialog extends Dialog {
         void onPageChanged(int page);
     }
 
+    private static final String TAG = "PdfViewerPlugin";
     private static final int TOOLBAR_HEIGHT_IN_DP = 56;
 
     @NonNull
@@ -124,6 +130,19 @@ public class PdfViewerDialog extends Dialog {
         titleView.setPadding(dpToPx(8), 0, dpToPx(8), 0);
         toolbar.addView(titleView, new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1));
 
+        if (options.getShowShareButton()) {
+            ImageView shareButton = new ImageView(getContext());
+            shareButton.setImageResource(android.R.drawable.ic_menu_share);
+            shareButton.setColorFilter(Color.BLACK);
+            shareButton.setPadding(dpToPx(8), dpToPx(8), dpToPx(8), dpToPx(8));
+            shareButton.setClickable(true);
+            shareButton.setOnClickListener(view -> handleShare());
+            toolbar.addView(
+                shareButton,
+                new LinearLayout.LayoutParams(dpToPx(40), dpToPx(40))
+            );
+        }
+
         return toolbar;
     }
 
@@ -141,6 +160,23 @@ public class PdfViewerDialog extends Dialog {
         loadFailed = true;
         listener.onLoadError(this, throwable);
         dismiss();
+    }
+
+    private void handleShare() {
+        try {
+            Context context = getContext();
+            String authority = context.getPackageName() + ".fileprovider";
+            Uri uri = FileProvider.getUriForFile(context, authority, file);
+            Intent intent = new Intent(Intent.ACTION_SEND);
+            intent.setType("application/pdf");
+            intent.putExtra(Intent.EXTRA_STREAM, uri);
+            String title = options.getTitle() == null ? file.getName() : options.getTitle();
+            intent.putExtra(Intent.EXTRA_SUBJECT, title);
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            context.startActivity(Intent.createChooser(intent, null));
+        } catch (Exception exception) {
+            Logger.error(TAG, exception.getMessage(), exception);
+        }
     }
 
     private void handlePageChange(int page) {

--- a/packages/pdf-viewer/android/src/main/java/io/capawesome/capacitorjs/plugins/pdfviewer/classes/PdfViewerDialog.java
+++ b/packages/pdf-viewer/android/src/main/java/io/capawesome/capacitorjs/plugins/pdfviewer/classes/PdfViewerDialog.java
@@ -133,14 +133,12 @@ public class PdfViewerDialog extends Dialog {
         if (options.getShowShareButton()) {
             ImageView shareButton = new ImageView(getContext());
             shareButton.setImageResource(android.R.drawable.ic_menu_share);
+            shareButton.setContentDescription("Share");
             shareButton.setColorFilter(Color.BLACK);
             shareButton.setPadding(dpToPx(8), dpToPx(8), dpToPx(8), dpToPx(8));
             shareButton.setClickable(true);
             shareButton.setOnClickListener(view -> handleShare());
-            toolbar.addView(
-                shareButton,
-                new LinearLayout.LayoutParams(dpToPx(40), dpToPx(40))
-            );
+            toolbar.addView(shareButton, new LinearLayout.LayoutParams(dpToPx(40), dpToPx(40)));
         }
 
         return toolbar;

--- a/packages/pdf-viewer/android/src/main/java/io/capawesome/capacitorjs/plugins/pdfviewer/classes/options/OpenOptions.java
+++ b/packages/pdf-viewer/android/src/main/java/io/capawesome/capacitorjs/plugins/pdfviewer/classes/options/OpenOptions.java
@@ -15,6 +15,8 @@ public class OpenOptions {
     @NonNull
     private final String path;
 
+    private final boolean showShareButton;
+
     @Nullable
     private final String title;
 
@@ -26,6 +28,7 @@ public class OpenOptions {
         this.path = path;
         this.page = call.getInt("page", 1);
         this.password = call.getString("password");
+        this.showShareButton = call.getBoolean("showShareButton", true);
         this.title = call.getString("title");
     }
 
@@ -41,6 +44,10 @@ public class OpenOptions {
     @NonNull
     public String getPath() {
         return path;
+    }
+
+    public boolean getShowShareButton() {
+        return showShareButton;
     }
 
     @Nullable

--- a/packages/pdf-viewer/android/src/main/java/io/capawesome/capacitorjs/plugins/pdfviewer/classes/options/OpenOptions.java
+++ b/packages/pdf-viewer/android/src/main/java/io/capawesome/capacitorjs/plugins/pdfviewer/classes/options/OpenOptions.java
@@ -28,7 +28,7 @@ public class OpenOptions {
         this.path = path;
         this.page = call.getInt("page", 1);
         this.password = call.getString("password");
-        this.showShareButton = call.getBoolean("showShareButton", true);
+        this.showShareButton = call.getBoolean("showShareButton", false);
         this.title = call.getString("title");
     }
 

--- a/packages/pdf-viewer/example/package-lock.json
+++ b/packages/pdf-viewer/example/package-lock.json
@@ -21,7 +21,7 @@
     },
     "..": {
       "name": "@capawesome/capacitor-pdf-viewer",
-      "version": "0.0.1",
+      "version": "0.1.1",
       "funding": [
         {
           "type": "github",

--- a/packages/pdf-viewer/ios/Plugin/Classes/Options/OpenOptions.swift
+++ b/packages/pdf-viewer/ios/Plugin/Classes/Options/OpenOptions.swift
@@ -5,12 +5,14 @@ import Capacitor
     let page: Int
     let password: String?
     let path: String
+    let showShareButton: Bool
     let title: String?
 
     init(_ call: CAPPluginCall) throws {
         self.page = call.getInt("page", 1)
         self.password = call.getString("password")
         self.path = try OpenOptions.getPathFromCall(call)
+        self.showShareButton = call.getBool("showShareButton", true)
         self.title = call.getString("title")
     }
 

--- a/packages/pdf-viewer/ios/Plugin/Classes/Options/OpenOptions.swift
+++ b/packages/pdf-viewer/ios/Plugin/Classes/Options/OpenOptions.swift
@@ -12,7 +12,7 @@ import Capacitor
         self.page = call.getInt("page", 1)
         self.password = call.getString("password")
         self.path = try OpenOptions.getPathFromCall(call)
-        self.showShareButton = call.getBool("showShareButton", true)
+        self.showShareButton = call.getBool("showShareButton", false)
         self.title = call.getString("title")
     }
 

--- a/packages/pdf-viewer/ios/Plugin/Classes/PdfViewerViewController.swift
+++ b/packages/pdf-viewer/ios/Plugin/Classes/PdfViewerViewController.swift
@@ -75,7 +75,7 @@ import UIKit
             navigationItem.leftBarButtonItem = UIBarButtonItem(
                 barButtonSystemItem: .action,
                 target: self,
-                action: #selector(handleShare)
+                action: #selector(handleShare(_:))
             )
         }
     }

--- a/packages/pdf-viewer/ios/Plugin/Classes/PdfViewerViewController.swift
+++ b/packages/pdf-viewer/ios/Plugin/Classes/PdfViewerViewController.swift
@@ -8,14 +8,18 @@ import UIKit
 
     private let document: PDFDocument
     private let initialPage: Int
+    private let showShareButton: Bool
+    private let url: URL
     private var didGoToInitialPage = false
     private var lastPage: Int
     private var pdfView: PDFView?
 
-    init(document: PDFDocument, title: String?, page: Int) {
+    init(document: PDFDocument, url: URL, title: String?, page: Int, showShareButton: Bool) {
         self.document = document
+        self.url = url
         self.initialPage = page
         self.lastPage = page
+        self.showShareButton = showShareButton
         super.init(nibName: nil, bundle: nil)
         self.title = title
     }
@@ -67,6 +71,13 @@ import UIKit
             target: self,
             action: #selector(handleDone)
         )
+        if showShareButton {
+            navigationItem.leftBarButtonItem = UIBarButtonItem(
+                barButtonSystemItem: .action,
+                target: self,
+                action: #selector(handleShare)
+            )
+        }
     }
 
     private func createPdfView() -> PDFView {
@@ -92,6 +103,12 @@ import UIKit
 
     @objc private func handleDone() {
         dismiss(animated: true)
+    }
+
+    @objc private func handleShare(_ sender: UIBarButtonItem) {
+        let activityViewController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        activityViewController.popoverPresentationController?.barButtonItem = sender
+        present(activityViewController, animated: true)
     }
 
     @objc private func handlePageChanged() {

--- a/packages/pdf-viewer/ios/Plugin/PdfViewer.swift
+++ b/packages/pdf-viewer/ios/Plugin/PdfViewer.swift
@@ -50,8 +50,10 @@ import UIKit
                 }
                 let viewController = PdfViewerViewController(
                     document: document,
+                    url: url,
                     title: options.title ?? url.lastPathComponent,
-                    page: options.page
+                    page: options.page,
+                    showShareButton: options.showShareButton
                 )
                 viewController.onClosed = { [weak self] closedViewController in
                     guard let self = self else {

--- a/packages/pdf-viewer/src/definitions.ts
+++ b/packages/pdf-viewer/src/definitions.ts
@@ -82,6 +82,16 @@ export interface OpenOptions {
    */
   path: string;
   /**
+   * Whether to display a share button in the toolbar of the viewer.
+   *
+   * Only available on Android and iOS.
+   *
+   * @since 0.1.2
+   * @default true
+   * @example false
+   */
+  showShareButton?: boolean;
+  /**
    * The title to display in the toolbar of the viewer.
    *
    * @since 0.1.0

--- a/packages/pdf-viewer/src/definitions.ts
+++ b/packages/pdf-viewer/src/definitions.ts
@@ -87,8 +87,8 @@ export interface OpenOptions {
    * Only available on Android and iOS.
    *
    * @since 0.1.2
-   * @default true
-   * @example false
+   * @default false
+   * @example true
    */
   showShareButton?: boolean;
   /**


### PR DESCRIPTION
Adds an opt-out share button to the PDF Viewer toolbar, letting users share the currently open PDF via the native share sheet.

## Changes

- **API**: New `showShareButton` option in `OpenOptions` (default `true`).
- **Android**: Adds a share `ImageView` to the dialog toolbar; shares the file through the app's `FileProvider` using an `ACTION_SEND` chooser.
- **iOS**: Adds a left `.action` bar button item that presents a `UIActivityViewController` (with iPad popover anchoring).
- **Docs**: Documents the required `file_paths.xml` setup for Android and adds a FAQ entry.

## Notes

- Default is `true`, so the button appears for existing consumers unless explicitly disabled.
- On Android, sharing requires the file's directory to be declared in `file_paths.xml` (same convention as the File Opener / File Picker plugins).
