### PR TITLE
fix(file-picker): prevent crash when COLUMN_LAST_MODIFIED is unavailable

### DIFF
--- a/packages/file-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePicker.java
+++ b/packages/file-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePicker.java
@@ -108,12 +108,20 @@ public class FilePicker {
         try {
             long modifiedAt = 0;
             Cursor cursor = plugin.getBridge().getContext().getContentResolver().query(uri, null, null, null, null);
-            if (cursor != null) {
-                cursor.moveToFirst();
-                int columnIdx = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_LAST_MODIFIED);
-                modifiedAt = cursor.getLong(columnIdx);
-                cursor.close();
-            }
+                if (cursor != null) {
+                    try {
+                        if (cursor.moveToFirst()) {
+                            int columnIdx = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_LAST_MODIFIED);
+                            if (columnIdx >= 0) {
+                                modifiedAt = cursor.getLong(columnIdx);
+                            } else {
+                                Logger.warn(TAG, "COLUMN_LAST_MODIFIED not found for uri: " + uri);
+                            }
+                        }
+                    } finally {
+                        cursor.close();
+                    }
+                }
             return modifiedAt;
         } catch (Exception e) {
             Logger.error(TAG, "getModifiedAtFromUri failed.", e);


### PR DESCRIPTION
## Summary

This PR fixes a crash that occurs when `getModifiedAtFromUri()` tries to read
`DocumentsContract.Document.COLUMN_LAST_MODIFIED` from a `ContentProvider`
that does not expose this column.

Instead of throwing an exception, the method now safely checks whether the
column exists before trying to read it.

---

## Problem

Some Android `ContentProvider`s (for example **Google Photos**) do not expose
`DocumentsContract.Document.COLUMN_LAST_MODIFIED`.

In this situation:

```java
int columnIdx = cursor.getColumnIndex(
    DocumentsContract.Document.COLUMN_LAST_MODIFIED
);
```

returns:

```text
-1
```

The current implementation immediately calls:

```java
modifiedAt = cursor.getLong(columnIdx);
```

which results in the following exception:

```text
java.lang.IllegalStateException:
Couldn't read row 0, col -1 from CursorWindow.
```

Although the exception is caught afterwards, it still produces unnecessary
error logs and prevents the plugin from correctly retrieving the metadata for
the selected media.

---

## Root Cause

Some `ContentProvider`s don't implement the
`COLUMN_LAST_MODIFIED` field.

The plugin assumes the column is always available and directly reads it without
checking whether it exists.

When `getColumnIndex()` returns `-1`, calling `cursor.getLong(-1)` throws an
`IllegalStateException`.

---

## Solution

The method now:

- Checks that the cursor contains at least one row using `moveToFirst()`.
- Verifies that `COLUMN_LAST_MODIFIED` exists before reading it.
- Logs a warning when the column is unavailable instead of throwing an exception.
- Ensures the cursor is always closed using a `finally` block.

This keeps the existing behavior for providers exposing the metadata while
making the plugin compatible with providers that don't.

---

## Before

```java
cursor.moveToFirst();

int columnIdx = cursor.getColumnIndex(
    DocumentsContract.Document.COLUMN_LAST_MODIFIED
);

modifiedAt = cursor.getLong(columnIdx);
```

---

## After

```java
if (cursor != null) {
    try {
        if (cursor.moveToFirst()) {
            int columnIdx = cursor.getColumnIndex(
                DocumentsContract.Document.COLUMN_LAST_MODIFIED
            );

            if (columnIdx >= 0) {
                modifiedAt = cursor.getLong(columnIdx);
            } else {
                Logger.warn(TAG, "COLUMN_LAST_MODIFIED not found for uri: " + uri);
            }
        }
    } finally {
        cursor.close();
    }
}
```

---

## Testing

Tested successfully on:

- Android Emulator API 33
- Android Emulator API 36

The issue was reproduced by selecting videos from **Google Photos**, where
`COLUMN_LAST_MODIFIED` is not exposed.

### Before

- `IllegalStateException` thrown
- Error logged:
  ```
  Couldn't read row 0, col -1 from CursorWindow
  ```
- Plugin failed while reading the metadata.

### After

- No exception is thrown.
- The warning is logged only when the column is unavailable.
- The selected media is returned correctly.
- The upload process continues successfully.

---

## Why this change is safe

This modification is fully backward compatible.

If the `COLUMN_LAST_MODIFIED` field is available, the behavior remains exactly
the same.

If the field is unavailable, the plugin now safely skips reading it instead of
throwing an exception.