### PR TITLE
fix(apple-sign-in): remove deprecated status bar color call

### DIFF
--- a/.changeset/bright-apples-sign.md
+++ b/.changeset/bright-apples-sign.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-apple-sign-in': patch
+---
+
+fix(android): remove deprecated status bar color call

--- a/packages/apple-sign-in/android/src/main/java/io/capawesome/capacitorjs/plugins/applesignin/AppleSignInActivity.java
+++ b/packages/apple-sign-in/android/src/main/java/io/capawesome/capacitorjs/plugins/applesignin/AppleSignInActivity.java
@@ -292,7 +292,6 @@ public class AppleSignInActivity extends Activity {
     @SuppressWarnings("deprecation")
     private void setupStatusBar() {
         Window window = getWindow();
-        window.setStatusBarColor(0xFFF8F8F8);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             android.view.WindowInsetsController controller = window.getInsetsController();
             if (controller != null) {


### PR DESCRIPTION
## Summary

- Remove the deprecated `Window.setStatusBarColor` call from `AppleSignInActivity`.

## Testing

- `npm run prettier --workspace @capawesome/capacitor-apple-sign-in -- --check`
- `npm run verify:android --workspace @capawesome/capacitor-apple-sign-in`