### PR TITLE
fix(superwall): pass activity provider to Superwall SDK on Android

### DIFF
--- a/.changeset/soft-donkeys-shake.md
+++ b/.changeset/soft-donkeys-shake.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-superwall': patch
+---
+
+fix(android): pass activity provider to Superwall SDK

--- a/packages/superwall/android/src/main/java/io/capawesome/capacitorjs/plugins/superwall/Superwall.kt
+++ b/packages/superwall/android/src/main/java/io/capawesome/capacitorjs/plugins/superwall/Superwall.kt
@@ -1,5 +1,6 @@
 package io.capawesome.capacitorjs.plugins.superwall
 
+import android.app.Activity
 import android.app.Application
 import android.net.Uri
 import com.getcapacitor.JSObject
@@ -18,6 +19,7 @@ import com.superwall.sdk.paywall.presentation.internal.state.PaywallResult
 import com.superwall.sdk.paywall.presentation.result.PresentationResult
 import com.superwall.sdk.paywall.presentation.register
 import com.superwall.sdk.paywall.presentation.get_presentation_result.getPresentationResultSync
+import com.superwall.sdk.misc.ActivityProvider
 import com.superwall.sdk.models.entitlements.SubscriptionStatus
 import com.superwall.sdk.logger.LogLevel
 import com.superwall.sdk.logger.LogScope
@@ -50,7 +52,9 @@ class Superwall(private val plugin: SuperwallPlugin) : SuperwallDelegate {
             apiKey = options.getApiKey(),
             purchaseController = null,
             options = options.getSuperwallOptions(),
-            activityProvider = null
+            activityProvider = object : ActivityProvider {
+                override fun getCurrentActivity(): Activity? = plugin.activity
+            }
         )
 
         isConfigured = true


### PR DESCRIPTION
The Superwall Android SDK was configured with `activityProvider = null`, so it fell back to tracking the current activity via `ActivityLifecycleCallbacks` registered at configure time. In a Capacitor app, `configure()` is called from JavaScript after the main activity has already been created and resumed, so the SDK never observed an activity and every paywall presentation failed with `SWPresentationError 103`.

The Capacitor bridge activity is now passed as the `ActivityProvider`.

Close #948