### PR TITLE
fix(file-picker): handle missing `COLUMN_LAST_MODIFIED` column on Android

### DIFF
--- a/.changeset/tidy-cameras-play.md
+++ b/.changeset/tidy-cameras-play.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-file-picker': patch
+---
+
+fix(android): handle missing `COLUMN_LAST_MODIFIED` column

--- a/packages/file-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePicker.java
+++ b/packages/file-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePicker.java
@@ -105,16 +105,16 @@ public class FilePicker {
 
     @Nullable
     public Long getModifiedAtFromUri(@NonNull Uri uri) {
-        try {
-            long modifiedAt = 0;
-            Cursor cursor = plugin.getBridge().getContext().getContentResolver().query(uri, null, null, null, null);
-            if (cursor != null) {
-                cursor.moveToFirst();
-                int columnIdx = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_LAST_MODIFIED);
-                modifiedAt = cursor.getLong(columnIdx);
-                cursor.close();
+        try (Cursor cursor = plugin.getBridge().getContext().getContentResolver().query(uri, null, null, null, null)) {
+            if (cursor == null || !cursor.moveToFirst()) {
+                return null;
             }
-            return modifiedAt;
+            int columnIdx = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_LAST_MODIFIED);
+            if (columnIdx < 0) {
+                Logger.warn(TAG, "The column " + DocumentsContract.Document.COLUMN_LAST_MODIFIED + " is not available.");
+                return null;
+            }
+            return cursor.getLong(columnIdx);
         } catch (Exception e) {
             Logger.error(TAG, "getModifiedAtFromUri failed.", e);
             return null;


### PR DESCRIPTION
Some Android `ContentProvider`s (e.g. Google Photos) do not expose the `DocumentsContract.Document.COLUMN_LAST_MODIFIED` column. In that case `Cursor.getColumnIndex(...)` returns `-1` and the subsequent `Cursor.getLong(-1)` call throws an `IllegalStateException`, which was caught and logged as an error on every file selection.

`FilePicker.getModifiedAtFromUri(...)` now checks that the cursor has a row and that the column exists before reading it, and returns `null` (so `modifiedAt` is simply omitted from the result) with a warning if the column is unavailable. The cursor is also closed reliably via try-with-resources.

Close #951