### PR TITLE
feat(superwall): add `dismiss()` method

### DIFF
--- a/.changeset/nervous-donuts-dismiss.md
+++ b/.changeset/nervous-donuts-dismiss.md
@@ -1,5 +1,5 @@
 ---
-'@capawesome/capacitor-superwall': minor
+'@capawesome/capacitor-superwall': patch
 ---
 
 feat: add `dismiss()` method

--- a/.changeset/nervous-donuts-dismiss.md
+++ b/.changeset/nervous-donuts-dismiss.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-superwall': minor
+---
+
+feat: add `dismiss()` method

--- a/packages/superwall/README.md
+++ b/packages/superwall/README.md
@@ -274,6 +274,7 @@ const logout = async () => {
 
 * [`configure(...)`](#configure)
 * [`register(...)`](#register)
+* [`dismiss()`](#dismiss)
 * [`getPresentationResult(...)`](#getpresentationresult)
 * [`identify(...)`](#identify)
 * [`reset()`](#reset)
@@ -340,6 +341,24 @@ Only available on Android and iOS.
 **Returns:** <code>Promise&lt;<a href="#registerresult">RegisterResult</a>&gt;</code>
 
 **Since:** 0.0.1
+
+--------------------
+
+
+### dismiss()
+
+```typescript
+dismiss() => Promise<void>
+```
+
+Dismiss the currently presented paywall, if one exists.
+
+Resolves once the paywall has been dismissed.
+If no paywall is presented, the method resolves immediately.
+
+Only available on Android and iOS.
+
+**Since:** 0.2.0
 
 --------------------
 

--- a/packages/superwall/README.md
+++ b/packages/superwall/README.md
@@ -358,7 +358,7 @@ If no paywall is presented, the method resolves immediately.
 
 Only available on Android and iOS.
 
-**Since:** 0.2.0
+**Since:** 0.1.3
 
 --------------------
 

--- a/packages/superwall/android/src/main/java/io/capawesome/capacitorjs/plugins/superwall/Superwall.kt
+++ b/packages/superwall/android/src/main/java/io/capawesome/capacitorjs/plugins/superwall/Superwall.kt
@@ -15,6 +15,7 @@ import com.superwall.sdk.delegate.SuperwallDelegate
 import com.superwall.sdk.analytics.superwall.SuperwallEventInfo
 import com.superwall.sdk.paywall.presentation.PaywallInfo
 import com.superwall.sdk.paywall.presentation.PaywallPresentationHandler
+import com.superwall.sdk.paywall.presentation.dismiss
 import com.superwall.sdk.paywall.presentation.internal.state.PaywallResult
 import com.superwall.sdk.paywall.presentation.result.PresentationResult
 import com.superwall.sdk.paywall.presentation.register
@@ -97,6 +98,18 @@ class Superwall(private val plugin: SuperwallPlugin) : SuperwallDelegate {
             params = params,
             handler = handler
         )
+    }
+
+    fun dismiss(callback: EmptyCallback) {
+        if (!isConfigured) {
+            callback.error(CustomExceptions.NOT_CONFIGURED)
+            return
+        }
+
+        coroutineScope.launch {
+            SuperwallSDK.instance.dismiss()
+            callback.success()
+        }
     }
 
     fun getPresentationResult(

--- a/packages/superwall/android/src/main/java/io/capawesome/capacitorjs/plugins/superwall/SuperwallPlugin.java
+++ b/packages/superwall/android/src/main/java/io/capawesome/capacitorjs/plugins/superwall/SuperwallPlugin.java
@@ -83,6 +83,28 @@ public class SuperwallPlugin extends Plugin {
     }
 
     @PluginMethod
+    public void dismiss(PluginCall call) {
+        try {
+            EmptyCallback callback = new EmptyCallback() {
+                @Override
+                public void success() {
+                    resolveCall(call);
+                }
+
+                @Override
+                public void error(@NonNull Exception exception) {
+                    rejectCall(call, exception);
+                }
+            };
+
+            assert implementation != null;
+            implementation.dismiss(callback);
+        } catch (Exception exception) {
+            rejectCall(call, exception);
+        }
+    }
+
+    @PluginMethod
     public void getPresentationResult(PluginCall call) {
         try {
             GetPresentationResultOptions options = new GetPresentationResultOptions(call);

--- a/packages/superwall/ios/Plugin/Superwall.swift
+++ b/packages/superwall/ios/Plugin/Superwall.swift
@@ -56,6 +56,17 @@ import SuperwallKit
         )
     }
 
+    @objc public func dismiss(completion: @escaping (_ error: Error?) -> Void) throws {
+        guard isConfigured else {
+            completion(CustomError.notConfigured)
+            return
+        }
+
+        SuperwallKit.Superwall.shared.dismiss {
+            completion(nil)
+        }
+    }
+
     @objc public func getPresentationResult(_ options: GetPresentationResultOptions, completion: @escaping (_ result: GetPresentationResultResult?, _ error: Error?) -> Void) throws {
         guard isConfigured else {
             completion(nil, CustomError.notConfigured)

--- a/packages/superwall/ios/Plugin/SuperwallPlugin.swift
+++ b/packages/superwall/ios/Plugin/SuperwallPlugin.swift
@@ -8,6 +8,7 @@ public class SuperwallPlugin: CAPPlugin, CAPBridgedPlugin {
     public let pluginMethods: [CAPPluginMethod] = [
         CAPPluginMethod(name: "configure", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "register", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "dismiss", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getPresentationResult", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "identify", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "reset", returnType: CAPPluginReturnPromise),
@@ -58,6 +59,20 @@ public class SuperwallPlugin: CAPPlugin, CAPBridgedPlugin {
                     self.rejectCall(call, error)
                 } else {
                     self.resolveCall(call, result)
+                }
+            }
+        } catch {
+            rejectCall(call, error)
+        }
+    }
+
+    @objc func dismiss(_ call: CAPPluginCall) {
+        do {
+            try implementation?.dismiss { error in
+                if let error = error {
+                    self.rejectCall(call, error)
+                } else {
+                    self.resolveCall(call)
                 }
             }
         } catch {

--- a/packages/superwall/src/definitions.ts
+++ b/packages/superwall/src/definitions.ts
@@ -25,6 +25,17 @@ export interface SuperwallPlugin {
    */
   register(options: RegisterOptions): Promise<RegisterResult>;
   /**
+   * Dismiss the currently presented paywall, if one exists.
+   *
+   * Resolves once the paywall has been dismissed.
+   * If no paywall is presented, the method resolves immediately.
+   *
+   * Only available on Android and iOS.
+   *
+   * @since 0.2.0
+   */
+  dismiss(): Promise<void>;
+  /**
    * Check if a paywall would be presented for a placement without actually presenting it.
    *
    * Useful for determining whether to show a feature or paywall before the user interacts.

--- a/packages/superwall/src/definitions.ts
+++ b/packages/superwall/src/definitions.ts
@@ -32,7 +32,7 @@ export interface SuperwallPlugin {
    *
    * Only available on Android and iOS.
    *
-   * @since 0.2.0
+   * @since 0.1.3
    */
   dismiss(): Promise<void>;
   /**

--- a/packages/superwall/src/web.ts
+++ b/packages/superwall/src/web.ts
@@ -24,6 +24,10 @@ export class SuperwallWeb extends WebPlugin implements SuperwallPlugin {
     throw this.unimplemented('Not implemented on web.');
   }
 
+  async dismiss(): Promise<void> {
+    throw this.unimplemented('Not implemented on web.');
+  }
+
   async getPresentationResult(
     _options: GetPresentationResultOptions,
   ): Promise<GetPresentationResultResult> {


### PR DESCRIPTION
## Motivation

The Superwall native SDKs expose a `dismiss()` method on both platforms, but the Capacitor plugin doesn't bridge it. Without it, an app cannot programmatically close a presented paywall — which is needed e.g. when the app is (re)opened through a deep link or home-screen quick action that should present a *different* paywall: Superwall refuses to present over an already-presented paywall, so the stale one has to be dismissed first.

## Changes

- Add `dismiss()` to `SuperwallPlugin` (TS definitions, web unimplemented stub, iOS, Android)
- iOS: `SuperwallKit.Superwall.shared.dismiss(completion:)` — resolves once dismissal completes; resolves immediately when no paywall is presented
- Android: suspending `Superwall.instance.dismiss()` launched on the plugin's main-dispatcher scope, same semantics
- Both guarded by the existing `NOT_CONFIGURED` error like the other methods
- README API section + changeset (`minor`) included

🤖 Generated with [Claude Code](https://claude.com/claude-code)