### PR TITLE
feat(network): expose ultra-constrained network status on iOS

### DIFF
--- a/.changeset/silver-moons-orbit.md
+++ b/.changeset/silver-moons-orbit.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-network': patch
+---
+
+feat: add `ultraConstrained` property to `GetStatusResult`

--- a/packages/network/README.md
+++ b/packages/network/README.md
@@ -15,6 +15,7 @@ The Capacitor Network plugin is one of the most complete network information sol
 - 📶 **Network status**: Read whether the device is connected and how (Wi-Fi, cellular, ethernet, VPN).
 - 🌍 **Internet reachability**: Detect whether the connection has verified access to the internet (Android).
 - 💸 **Data saving & cost**: Detect whether the connection is constrained (Data Saver or Low Data Mode) or expensive (metered).
+- 🛰️ **Ultra-constrained networks**: Detect carrier-provided satellite connections on iOS 26+.
 - ✈️ **Airplane mode**: Read whether the airplane mode is enabled (Android).
 - 👂 **Change events**: Listen for changes to the network status.
 - 🌐 **Web support**: Read the network status on the web.
@@ -83,6 +84,21 @@ const getStatus = async () => {
   return status;
 };
 ```
+
+### Detect ultra-constrained networks
+
+Read whether the connection is ultra-constrained, such as a carrier-provided satellite network. Only available on iOS 26+:
+
+```typescript
+import { Network } from '@capawesome/capacitor-network';
+
+const isUltraConstrained = async () => {
+  const { ultraConstrained } = await Network.getStatus();
+  return ultraConstrained;
+};
+```
+
+Detecting this state requires no entitlement. However, if your app wants to transfer data over such a network, it must allow this per request (see [`allowsUltraConstrainedNetworkAccess`](https://developer.apple.com/documentation/foundation/urlrequest/allowsultraconstrainednetworkaccess)) and may need the [`com.apple.developer.networking.carrier-constrained.appcategory`](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.developer.networking.carrier-constrained.appcategory) entitlement to be allowed on all carriers. This plugin neither adds entitlements nor modifies your `URLSession` or `NWParameters` configuration. See [Configuring your app for ultra-constrained networks](https://developer.apple.com/documentation/bundleresources/configuring-your-app-for-ultra-constrained-networks) for more information.
 
 ### Check whether airplane mode is enabled
 
@@ -213,13 +229,14 @@ Remove all listeners for this plugin.
 
 #### GetStatusResult
 
-| Prop                    | Type                                                      | Description                                                                                                                                                                                                                                                  | Since |
-| ----------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
-| **`connected`**         | <code>boolean</code>                                      | Whether the device is currently connected to a network.                                                                                                                                                                                                      | 0.1.0 |
-| **`connectionType`**    | <code><a href="#connectiontype">ConnectionType</a></code> | The type of the currently active network connection.                                                                                                                                                                                                         | 0.1.0 |
-| **`internetReachable`** | <code>boolean \| null</code>                              | Whether the active network connection has verified access to the internet. This is `null` on platforms that cannot validate internet access (iOS and Web), where connectivity does not guarantee reachability. Only available on Android.                    | 0.1.0 |
-| **`constrained`**       | <code>boolean \| null</code>                              | Whether the active network connection is subject to data saving restrictions, such as Data Saver on Android or Low Data Mode on iOS. This is `false` if the device is not connected to a network and `null` on browsers that do not expose this information. | 0.1.2 |
-| **`expensive`**         | <code>boolean \| null</code>                              | Whether the active network connection is considered expensive, for example a metered Wi-Fi or cellular network. This is `false` if the device is not connected to a network and `null` on platforms that cannot determine the cost of the connection (Web).  | 0.1.2 |
+| Prop                    | Type                                                      | Description                                                                                                                                                                                                                                                                          | Since |
+| ----------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
+| **`connected`**         | <code>boolean</code>                                      | Whether the device is currently connected to a network.                                                                                                                                                                                                                              | 0.1.0 |
+| **`connectionType`**    | <code><a href="#connectiontype">ConnectionType</a></code> | The type of the currently active network connection.                                                                                                                                                                                                                                 | 0.1.0 |
+| **`internetReachable`** | <code>boolean \| null</code>                              | Whether the active network connection has verified access to the internet. This is `null` on platforms that cannot validate internet access (iOS and Web), where connectivity does not guarantee reachability. Only available on Android.                                            | 0.1.0 |
+| **`constrained`**       | <code>boolean \| null</code>                              | Whether the active network connection is subject to data saving restrictions, such as Data Saver on Android or Low Data Mode on iOS. This is `false` if the device is not connected to a network and `null` on browsers that do not expose this information.                         | 0.1.2 |
+| **`expensive`**         | <code>boolean \| null</code>                              | Whether the active network connection is considered expensive, for example a metered Wi-Fi or cellular network. This is `false` if the device is not connected to a network and `null` on platforms that cannot determine the cost of the connection (Web).                          | 0.1.2 |
+| **`ultraConstrained`**  | <code>boolean \| null</code>                              | Whether the active network connection is ultra-constrained, such as a carrier-provided satellite network. This is `false` if the device is not connected to a network and `null` on platforms that cannot determine this (Android, Web and iOS below 26). Only available on iOS 26+. | 0.1.2 |
 
 
 #### IsAirplaneModeEnabledResult

--- a/packages/network/android/src/main/java/io/capawesome/capacitorjs/plugins/network/Network.java
+++ b/packages/network/android/src/main/java/io/capawesome/capacitorjs/plugins/network/Network.java
@@ -147,7 +147,8 @@ public class Network {
             capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED);
         boolean constrained = computeConstrained(capabilities);
         boolean expensive = computeExpensive(capabilities);
-        return new GetStatusResult(connected, connectionType, internetReachable, constrained, expensive);
+        Boolean ultraConstrained = connected ? null : Boolean.FALSE;
+        return new GetStatusResult(connected, connectionType, internetReachable, constrained, expensive, ultraConstrained);
     }
 
     @NonNull

--- a/packages/network/android/src/main/java/io/capawesome/capacitorjs/plugins/network/classes/results/GetStatusResult.java
+++ b/packages/network/android/src/main/java/io/capawesome/capacitorjs/plugins/network/classes/results/GetStatusResult.java
@@ -1,8 +1,10 @@
 package io.capawesome.capacitorjs.plugins.network.classes.results;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.getcapacitor.JSObject;
 import io.capawesome.capacitorjs.plugins.network.interfaces.Result;
+import org.json.JSONObject;
 
 public class GetStatusResult implements Result {
 
@@ -17,18 +19,23 @@ public class GetStatusResult implements Result {
 
     private final boolean expensive;
 
+    @Nullable
+    private final Boolean ultraConstrained;
+
     public GetStatusResult(
         boolean connected,
         @NonNull String connectionType,
         boolean internetReachable,
         boolean constrained,
-        boolean expensive
+        boolean expensive,
+        @Nullable Boolean ultraConstrained
     ) {
         this.connected = connected;
         this.connectionType = connectionType;
         this.internetReachable = internetReachable;
         this.constrained = constrained;
         this.expensive = expensive;
+        this.ultraConstrained = ultraConstrained;
     }
 
     @Override
@@ -40,6 +47,7 @@ public class GetStatusResult implements Result {
         result.put("internetReachable", internetReachable);
         result.put("constrained", constrained);
         result.put("expensive", expensive);
+        result.put("ultraConstrained", ultraConstrained == null ? JSONObject.NULL : ultraConstrained);
         return result;
     }
 }

--- a/packages/network/ios/Plugin/Classes/Results/GetStatusResult.swift
+++ b/packages/network/ios/Plugin/Classes/Results/GetStatusResult.swift
@@ -7,13 +7,22 @@ import Capacitor
     private let internetReachable: NSNumber?
     private let constrained: Bool
     private let expensive: Bool
+    private let ultraConstrained: NSNumber?
 
-    init(connected: Bool, connectionType: String, internetReachable: NSNumber?, constrained: Bool, expensive: Bool) {
+    init(
+        connected: Bool,
+        connectionType: String,
+        internetReachable: NSNumber?,
+        constrained: Bool,
+        expensive: Bool,
+        ultraConstrained: NSNumber?
+    ) {
         self.connected = connected
         self.connectionType = connectionType
         self.internetReachable = internetReachable
         self.constrained = constrained
         self.expensive = expensive
+        self.ultraConstrained = ultraConstrained
     }
 
     @objc public func toJSObject() -> AnyObject {
@@ -23,6 +32,7 @@ import Capacitor
         result["internetReachable"] = internetReachable ?? NSNull()
         result["constrained"] = constrained
         result["expensive"] = expensive
+        result["ultraConstrained"] = ultraConstrained ?? NSNull()
         return result as AnyObject
     }
 }

--- a/packages/network/ios/Plugin/Network.swift
+++ b/packages/network/ios/Plugin/Network.swift
@@ -48,7 +48,8 @@ import Network
 
     private func createStatusKey(_ path: NWPath) -> String {
         let connected = path.status == .satisfied
-        return "\(connected)|\(mapConnectionType(path))|\(connected && path.isConstrained)|\(connected && path.isExpensive)"
+        let ultraConstrained = mapUltraConstrained(path)?.boolValue.description ?? "null"
+        return "\(connected)|\(mapConnectionType(path))|\(connected && path.isConstrained)|\(connected && path.isExpensive)|\(ultraConstrained)"
     }
 
     private func createStatusResult(_ path: NWPath) -> GetStatusResult {
@@ -58,7 +59,8 @@ import Network
             connectionType: mapConnectionType(path),
             internetReachable: nil,
             constrained: connected && path.isConstrained,
-            expensive: connected && path.isExpensive
+            expensive: connected && path.isExpensive,
+            ultraConstrained: mapUltraConstrained(path)
         )
     }
 
@@ -89,5 +91,15 @@ import Network
             return Network.connectionTypeEthernet
         }
         return Network.connectionTypeUnknown
+    }
+
+    private func mapUltraConstrained(_ path: NWPath) -> NSNumber? {
+        if path.status != .satisfied {
+            return NSNumber(value: false)
+        }
+        guard #available(iOS 26.0, *) else {
+            return nil
+        }
+        return NSNumber(value: path.isUltraConstrained)
     }
 }

--- a/packages/network/ios/PluginTests/NetworkTests.swift
+++ b/packages/network/ios/PluginTests/NetworkTests.swift
@@ -9,7 +9,8 @@ class NetworkTests: XCTestCase {
             connectionType: "WIFI",
             internetReachable: nil,
             constrained: false,
-            expensive: true
+            expensive: true,
+            ultraConstrained: nil
         )
 
         let jsObject = result.toJSObject() as? [String: Any]
@@ -19,5 +20,6 @@ class NetworkTests: XCTestCase {
         XCTAssertTrue(jsObject?["internetReachable"] is NSNull)
         XCTAssertEqual(false, jsObject?["constrained"] as? Bool)
         XCTAssertEqual(true, jsObject?["expensive"] as? Bool)
+        XCTAssertTrue(jsObject?["ultraConstrained"] is NSNull)
     }
 }

--- a/packages/network/src/definitions.ts
+++ b/packages/network/src/definitions.ts
@@ -90,6 +90,19 @@ export interface GetStatusResult {
    * @since 0.1.2
    */
   expensive: boolean | null;
+  /**
+   * Whether the active network connection is ultra-constrained, such as a
+   * carrier-provided satellite network.
+   *
+   * This is `false` if the device is not connected to a network and `null`
+   * on platforms that cannot determine this (Android, Web and iOS below 26).
+   *
+   * Only available on iOS 26+.
+   *
+   * @example false
+   * @since 0.1.2
+   */
+  ultraConstrained: boolean | null;
 }
 
 /**

--- a/packages/network/src/web.ts
+++ b/packages/network/src/web.ts
@@ -46,6 +46,7 @@ export class NetworkWeb extends WebPlugin implements NetworkPlugin {
       internetReachable: null,
       constrained: connected ? (connection?.saveData ?? null) : false,
       expensive: connected ? null : false,
+      ultraConstrained: connected ? null : false,
     };
   }
 


### PR DESCRIPTION
Adds the `ultraConstrained` property to `GetStatusResult`, so apps can detect carrier-provided ultra-constrained connectivity such as satellite networks and apply much stronger data reduction than for a generally constrained or expensive connection. The property is returned by `getStatus()` and the `networkStatusChange` event.

## Platform mappings

**iOS**

- `ultraConstrained` reflects `NWPath.isUltraConstrained` on iOS 26 and later.
- `null` on earlier iOS versions, because the platform API is unavailable.
- Part of the deduplication key, so changes emit `networkStatusChange` even if the connection type does not change.

**Android and Web**

- `null` while connected, because the platform cannot determine this.

Following the contract of `constrained` and `expensive`, the value is `false` whenever the device is not connected to a network, and `null` only when the platform cannot determine it for an active connection.

## Notes

- Reading this state requires no entitlement. The README documents that transferring data over such a network requires an app-level opt-in per request and possibly the `com.apple.developer.networking.carrier-constrained.appcategory` entitlement. The plugin neither adds entitlements nor modifies the app's `URLSession` or `NWParameters` configuration.
- No satellite connection type is introduced, because Apple exposes this condition as a path property rather than an `NWInterface` type.

Close #958
