### PR TITLE
feat(network): support constrained satellite networks on Android

### DIFF
--- a/.changeset/brave-comets-signal.md
+++ b/.changeset/brave-comets-signal.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-network': patch
+---
+
+feat: add support for constrained satellite networks on Android

--- a/packages/network/README.md
+++ b/packages/network/README.md
@@ -15,7 +15,7 @@ The Capacitor Network plugin is one of the most complete network information sol
 - 📶 **Network status**: Read whether the device is connected and how (Wi-Fi, cellular, ethernet, VPN).
 - 🌍 **Internet reachability**: Detect whether the connection has verified access to the internet (Android).
 - 💸 **Data saving & cost**: Detect whether the connection is constrained (Data Saver or Low Data Mode) or expensive (metered).
-- 🛰️ **Satellite networks**: Detect carrier-provided satellite connections on Android 15+ and iOS 26+.
+- 🛰️ **Satellite networks**: Detect satellite transport on Android 15+ and ultra-constrained connections on iOS 26+.
 - ✈️ **Airplane mode**: Read whether the airplane mode is enabled (Android).
 - 👂 **Change events**: Listen for changes to the network status.
 - 🌐 **Web support**: Read the network status on the web.
@@ -107,7 +107,7 @@ Android only uses constrained satellite networks for apps that identify themselv
 />
 ```
 
-This plugin does not add this element automatically, because each app must decide whether it is suitable for constrained satellite access. Push notifications must additionally be sent with the `bandwidth_constrained_ok` flag to be delivered on such a network. See [Constrained satellite networks](https://developer.android.com/develop/connectivity/satellite/constrained-networks) for more information.
+Replace `PACKAGE_NAME` with your app's package name. This plugin does not add this element automatically, because each app must decide whether it is suitable for constrained satellite access. Push notifications must additionally be sent with the `bandwidth_constrained_ok` flag to be delivered on such a network. See [Constrained satellite networks](https://developer.android.com/develop/connectivity/satellite/constrained-networks) for more information.
 
 On **iOS**, carrier-provided satellite connections are reported as `CELLULAR` with `ultraConstrained` set to `true`, because Apple does not expose satellite as a connection type.
 

--- a/packages/network/README.md
+++ b/packages/network/README.md
@@ -15,7 +15,7 @@ The Capacitor Network plugin is one of the most complete network information sol
 - 📶 **Network status**: Read whether the device is connected and how (Wi-Fi, cellular, ethernet, VPN).
 - 🌍 **Internet reachability**: Detect whether the connection has verified access to the internet (Android).
 - 💸 **Data saving & cost**: Detect whether the connection is constrained (Data Saver or Low Data Mode) or expensive (metered).
-- 🛰️ **Ultra-constrained networks**: Detect carrier-provided satellite connections on iOS 26+.
+- 🛰️ **Satellite networks**: Detect carrier-provided satellite connections on Android 15+ and iOS 26+.
 - ✈️ **Airplane mode**: Read whether the airplane mode is enabled (Android).
 - 👂 **Change events**: Listen for changes to the network status.
 - 🌐 **Web support**: Read the network status on the web.
@@ -84,6 +84,30 @@ const getStatus = async () => {
   return status;
 };
 ```
+
+### Detect satellite networks
+
+Read whether the device is connected via a satellite network. Only available on Android:
+
+```typescript
+import { ConnectionType, Network } from '@capawesome/capacitor-network';
+
+const isSatellite = async () => {
+  const { connectionType } = await Network.getStatus();
+  return connectionType === ConnectionType.Satellite;
+};
+```
+
+Android only uses constrained satellite networks for apps that identify themselves as optimized for them. If your app is optimized for extremely limited bandwidth and variable latency, add the following element to the `application` element in your `AndroidManifest.xml`:
+
+```xml
+<meta-data
+  android:name="android.telephony.PROPERTY_SATELLITE_DATA_OPTIMIZED"
+  android:value="PACKAGE_NAME"
+/>
+```
+
+This plugin does not add this element automatically, because each app must decide whether it is suitable for constrained satellite access. Push notifications must additionally be sent with the `bandwidth_constrained_ok` flag to be delivered on such a network. See [Constrained satellite networks](https://developer.android.com/develop/connectivity/satellite/constrained-networks) for more information.
 
 ### Detect ultra-constrained networks
 
@@ -229,14 +253,14 @@ Remove all listeners for this plugin.
 
 #### GetStatusResult
 
-| Prop                    | Type                                                      | Description                                                                                                                                                                                                                                                                          | Since |
-| ----------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
-| **`connected`**         | <code>boolean</code>                                      | Whether the device is currently connected to a network.                                                                                                                                                                                                                              | 0.1.0 |
-| **`connectionType`**    | <code><a href="#connectiontype">ConnectionType</a></code> | The type of the currently active network connection.                                                                                                                                                                                                                                 | 0.1.0 |
-| **`internetReachable`** | <code>boolean \| null</code>                              | Whether the active network connection has verified access to the internet. This is `null` on platforms that cannot validate internet access (iOS and Web), where connectivity does not guarantee reachability. Only available on Android.                                            | 0.1.0 |
-| **`constrained`**       | <code>boolean \| null</code>                              | Whether the active network connection is subject to data saving restrictions, such as Data Saver on Android or Low Data Mode on iOS. This is `false` if the device is not connected to a network and `null` on browsers that do not expose this information.                         | 0.1.2 |
-| **`expensive`**         | <code>boolean \| null</code>                              | Whether the active network connection is considered expensive, for example a metered Wi-Fi or cellular network. This is `false` if the device is not connected to a network and `null` on platforms that cannot determine the cost of the connection (Web).                          | 0.1.2 |
-| **`ultraConstrained`**  | <code>boolean \| null</code>                              | Whether the active network connection is ultra-constrained, such as a carrier-provided satellite network. This is `false` if the device is not connected to a network and `null` on platforms that cannot determine this (Android, Web and iOS below 26). Only available on iOS 26+. | 0.1.2 |
+| Prop                    | Type                                                      | Description                                                                                                                                                                                                                                                                                            | Since |
+| ----------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
+| **`connected`**         | <code>boolean</code>                                      | Whether the device is currently connected to a network.                                                                                                                                                                                                                                                | 0.1.0 |
+| **`connectionType`**    | <code><a href="#connectiontype">ConnectionType</a></code> | The type of the currently active network connection.                                                                                                                                                                                                                                                   | 0.1.0 |
+| **`internetReachable`** | <code>boolean \| null</code>                              | Whether the active network connection has verified access to the internet. This is `null` on platforms that cannot validate internet access (iOS and Web), where connectivity does not guarantee reachability. Only available on Android.                                                              | 0.1.0 |
+| **`constrained`**       | <code>boolean \| null</code>                              | Whether the active network connection is subject to data saving restrictions or limited bandwidth, such as Data Saver on Android, Low Data Mode on iOS or a satellite network. This is `false` if the device is not connected to a network and `null` on browsers that do not expose this information. | 0.1.2 |
+| **`expensive`**         | <code>boolean \| null</code>                              | Whether the active network connection is considered expensive, for example a metered Wi-Fi or cellular network. This is `false` if the device is not connected to a network and `null` on platforms that cannot determine the cost of the connection (Web).                                            | 0.1.2 |
+| **`ultraConstrained`**  | <code>boolean \| null</code>                              | Whether the active network connection is ultra-constrained, such as a carrier-provided satellite network. This is `false` if the device is not connected to a network and `null` on platforms that cannot determine this (Android, Web and iOS below 26). Only available on iOS 26+.                   | 0.1.2 |
 
 
 #### IsAirplaneModeEnabledResult
@@ -258,14 +282,15 @@ Remove all listeners for this plugin.
 
 #### ConnectionType
 
-| Members        | Value                   | Description                                                  | Since |
-| -------------- | ----------------------- | ------------------------------------------------------------ | ----- |
-| **`Cellular`** | <code>'CELLULAR'</code> | The device is connected via a cellular network.              | 0.1.0 |
-| **`Ethernet`** | <code>'ETHERNET'</code> | The device is connected via a wired ethernet network.        | 0.1.0 |
-| **`None`**     | <code>'NONE'</code>     | The device is not connected to any network.                  | 0.1.0 |
-| **`Unknown`**  | <code>'UNKNOWN'</code>  | The type of the network connection could not be determined.  | 0.1.0 |
-| **`Vpn`**      | <code>'VPN'</code>      | The device is connected via a virtual private network (VPN). | 0.1.0 |
-| **`Wifi`**     | <code>'WIFI'</code>     | The device is connected via a Wi-Fi network.                 | 0.1.0 |
+| Members         | Value                    | Description                                                                 | Since |
+| --------------- | ------------------------ | --------------------------------------------------------------------------- | ----- |
+| **`Cellular`**  | <code>'CELLULAR'</code>  | The device is connected via a cellular network.                             | 0.1.0 |
+| **`Ethernet`**  | <code>'ETHERNET'</code>  | The device is connected via a wired ethernet network.                       | 0.1.0 |
+| **`None`**      | <code>'NONE'</code>      | The device is not connected to any network.                                 | 0.1.0 |
+| **`Satellite`** | <code>'SATELLITE'</code> | The device is connected via a satellite network. Only available on Android. | 0.1.2 |
+| **`Unknown`**   | <code>'UNKNOWN'</code>   | The type of the network connection could not be determined.                 | 0.1.0 |
+| **`Vpn`**       | <code>'VPN'</code>       | The device is connected via a virtual private network (VPN).                | 0.1.0 |
+| **`Wifi`**      | <code>'WIFI'</code>      | The device is connected via a Wi-Fi network.                                | 0.1.0 |
 
 </docgen-api>
 

--- a/packages/network/README.md
+++ b/packages/network/README.md
@@ -109,9 +109,11 @@ Android only uses constrained satellite networks for apps that identify themselv
 
 This plugin does not add this element automatically, because each app must decide whether it is suitable for constrained satellite access. Push notifications must additionally be sent with the `bandwidth_constrained_ok` flag to be delivered on such a network. See [Constrained satellite networks](https://developer.android.com/develop/connectivity/satellite/constrained-networks) for more information.
 
+On **iOS**, carrier-provided satellite connections are reported as `CELLULAR` with `ultraConstrained` set to `true`, because Apple does not expose satellite as a connection type.
+
 ### Detect ultra-constrained networks
 
-Read whether the connection is ultra-constrained, such as a carrier-provided satellite network. Only available on iOS 26+:
+Read whether the connection is severely limited in bandwidth, such as a carrier-provided satellite network. Only available on Android and iOS 26+:
 
 ```typescript
 import { Network } from '@capawesome/capacitor-network';
@@ -122,7 +124,9 @@ const isUltraConstrained = async () => {
 };
 ```
 
-Detecting this state requires no entitlement. However, if your app wants to transfer data over such a network, it must allow this per request (see [`allowsUltraConstrainedNetworkAccess`](https://developer.apple.com/documentation/foundation/urlrequest/allowsultraconstrainednetworkaccess)) and may need the [`com.apple.developer.networking.carrier-constrained.appcategory`](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.developer.networking.carrier-constrained.appcategory) entitlement to be allowed on all carriers. This plugin neither adds entitlements nor modifies your `URLSession` or `NWParameters` configuration. See [Configuring your app for ultra-constrained networks](https://developer.apple.com/documentation/bundleresources/configuring-your-app-for-ultra-constrained-networks) for more information.
+On **Android**, this is `true` on satellite networks and on networks that the system reports as bandwidth-constrained.
+
+On **iOS**, detecting this state requires no entitlement. However, if your app wants to transfer data over such a network, it must allow this per request (see [`allowsUltraConstrainedNetworkAccess`](https://developer.apple.com/documentation/foundation/urlrequest/allowsultraconstrainednetworkaccess)) and may need the [`com.apple.developer.networking.carrier-constrained.appcategory`](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.developer.networking.carrier-constrained.appcategory) entitlement to be allowed on all carriers. This plugin neither adds entitlements nor modifies your `URLSession` or `NWParameters` configuration. See [Configuring your app for ultra-constrained networks](https://developer.apple.com/documentation/bundleresources/configuring-your-app-for-ultra-constrained-networks) for more information.
 
 ### Check whether airplane mode is enabled
 
@@ -253,14 +257,14 @@ Remove all listeners for this plugin.
 
 #### GetStatusResult
 
-| Prop                    | Type                                                      | Description                                                                                                                                                                                                                                                                                            | Since |
-| ----------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
-| **`connected`**         | <code>boolean</code>                                      | Whether the device is currently connected to a network.                                                                                                                                                                                                                                                | 0.1.0 |
-| **`connectionType`**    | <code><a href="#connectiontype">ConnectionType</a></code> | The type of the currently active network connection.                                                                                                                                                                                                                                                   | 0.1.0 |
-| **`internetReachable`** | <code>boolean \| null</code>                              | Whether the active network connection has verified access to the internet. This is `null` on platforms that cannot validate internet access (iOS and Web), where connectivity does not guarantee reachability. Only available on Android.                                                              | 0.1.0 |
-| **`constrained`**       | <code>boolean \| null</code>                              | Whether the active network connection is subject to data saving restrictions or limited bandwidth, such as Data Saver on Android, Low Data Mode on iOS or a satellite network. This is `false` if the device is not connected to a network and `null` on browsers that do not expose this information. | 0.1.2 |
-| **`expensive`**         | <code>boolean \| null</code>                              | Whether the active network connection is considered expensive, for example a metered Wi-Fi or cellular network. This is `false` if the device is not connected to a network and `null` on platforms that cannot determine the cost of the connection (Web).                                            | 0.1.2 |
-| **`ultraConstrained`**  | <code>boolean \| null</code>                              | Whether the active network connection is ultra-constrained, such as a carrier-provided satellite network. This is `false` if the device is not connected to a network and `null` on platforms that cannot determine this (Android, Web and iOS below 26). Only available on iOS 26+.                   | 0.1.2 |
+| Prop                    | Type                                                      | Description                                                                                                                                                                                                                                                                                         | Since |
+| ----------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| **`connected`**         | <code>boolean</code>                                      | Whether the device is currently connected to a network.                                                                                                                                                                                                                                             | 0.1.0 |
+| **`connectionType`**    | <code><a href="#connectiontype">ConnectionType</a></code> | The type of the currently active network connection.                                                                                                                                                                                                                                                | 0.1.0 |
+| **`internetReachable`** | <code>boolean \| null</code>                              | Whether the active network connection has verified access to the internet. This is `null` on platforms that cannot validate internet access (iOS and Web), where connectivity does not guarantee reachability. Only available on Android.                                                           | 0.1.0 |
+| **`constrained`**       | <code>boolean \| null</code>                              | Whether the active network connection is subject to data saving restrictions, such as Data Saver on Android or Low Data Mode on iOS. This is `false` if the device is not connected to a network and `null` on browsers that do not expose this information.                                        | 0.1.2 |
+| **`expensive`**         | <code>boolean \| null</code>                              | Whether the active network connection is considered expensive, for example a metered Wi-Fi or cellular network. This is `false` if the device is not connected to a network and `null` on platforms that cannot determine the cost of the connection (Web).                                         | 0.1.2 |
+| **`ultraConstrained`**  | <code>boolean \| null</code>                              | Whether the active network connection is severely limited in bandwidth, such as a carrier-provided satellite network. This is `false` if the device is not connected to a network and `null` on platforms that cannot determine this (Web and iOS below 26). Only available on Android and iOS 26+. | 0.1.2 |
 
 
 #### IsAirplaneModeEnabledResult
@@ -315,6 +319,10 @@ The `connected` property tells you whether the device is connected to any networ
 ### Why is `internetReachable` always `null` on iOS and Web?
 
 iOS and the Web platform cannot distinguish validated internet access from mere network connectivity, so the plugin returns `null` instead of a potentially misleading value. On these platforms, being connected to a network does not guarantee that the internet is reachable. See the [Network Information](#network-information) section for the platform-specific details.
+
+### What is the difference between the `SATELLITE` connection type and `ultraConstrained`?
+
+The `SATELLITE` connection type tells you what the connection is, while `ultraConstrained` tells you that it is severely limited in bandwidth. Satellite is only reported as a connection type on Android, because iOS exposes this condition as a property of the connection instead. The two do not always match: a satellite network is not necessarily reported as bandwidth-constrained, and a bandwidth-constrained network is not necessarily a satellite network.
 
 ### Can I check whether airplane mode is enabled on iOS or Web?
 

--- a/packages/network/android/src/main/java/io/capawesome/capacitorjs/plugins/network/Network.java
+++ b/packages/network/android/src/main/java/io/capawesome/capacitorjs/plugins/network/Network.java
@@ -123,18 +123,6 @@ public class Network {
     }
 
     private boolean computeConstrained(@Nullable NetworkCapabilities capabilities) {
-        if (capabilities == null) {
-            return false;
-        }
-        if (isSatellite(capabilities)) {
-            return true;
-        }
-        if (
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA &&
-            !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_BANDWIDTH_CONSTRAINED)
-        ) {
-            return true;
-        }
         return computeExpensive(capabilities) && isDataSaverEnabled();
     }
 
@@ -154,8 +142,21 @@ public class Network {
             capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED);
         boolean constrained = computeConstrained(capabilities);
         boolean expensive = computeExpensive(capabilities);
-        Boolean ultraConstrained = connected ? null : Boolean.FALSE;
+        boolean ultraConstrained = computeUltraConstrained(capabilities);
         return new GetStatusResult(connected, connectionType, internetReachable, constrained, expensive, ultraConstrained);
+    }
+
+    private boolean computeUltraConstrained(@Nullable NetworkCapabilities capabilities) {
+        if (capabilities == null) {
+            return false;
+        }
+        if (isSatellite(capabilities)) {
+            return true;
+        }
+        return (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA &&
+            !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_BANDWIDTH_CONSTRAINED)
+        );
     }
 
     @NonNull

--- a/packages/network/android/src/main/java/io/capawesome/capacitorjs/plugins/network/Network.java
+++ b/packages/network/android/src/main/java/io/capawesome/capacitorjs/plugins/network/Network.java
@@ -20,6 +20,7 @@ public class Network {
     private static final String CONNECTION_TYPE_CELLULAR = "CELLULAR";
     private static final String CONNECTION_TYPE_ETHERNET = "ETHERNET";
     private static final String CONNECTION_TYPE_NONE = "NONE";
+    private static final String CONNECTION_TYPE_SATELLITE = "SATELLITE";
     private static final String CONNECTION_TYPE_UNKNOWN = "UNKNOWN";
     private static final String CONNECTION_TYPE_VPN = "VPN";
     private static final String CONNECTION_TYPE_WIFI = "WIFI";
@@ -106,6 +107,9 @@ public class Network {
         if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
             return CONNECTION_TYPE_VPN;
         }
+        if (isSatellite(capabilities)) {
+            return CONNECTION_TYPE_SATELLITE;
+        }
         if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
             return CONNECTION_TYPE_WIFI;
         }
@@ -121,6 +125,9 @@ public class Network {
     private boolean computeConstrained(@Nullable NetworkCapabilities capabilities) {
         if (capabilities == null) {
             return false;
+        }
+        if (isSatellite(capabilities)) {
+            return true;
         }
         if (
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA &&
@@ -168,5 +175,12 @@ public class Network {
 
     private boolean isDataSaverEnabled() {
         return connectivityManager.getRestrictBackgroundStatus() == ConnectivityManager.RESTRICT_BACKGROUND_STATUS_ENABLED;
+    }
+
+    private boolean isSatellite(@NonNull NetworkCapabilities capabilities) {
+        return (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM &&
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_SATELLITE)
+        );
     }
 }

--- a/packages/network/android/src/main/java/io/capawesome/capacitorjs/plugins/network/classes/results/GetStatusResult.java
+++ b/packages/network/android/src/main/java/io/capawesome/capacitorjs/plugins/network/classes/results/GetStatusResult.java
@@ -1,10 +1,8 @@
 package io.capawesome.capacitorjs.plugins.network.classes.results;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import com.getcapacitor.JSObject;
 import io.capawesome.capacitorjs.plugins.network.interfaces.Result;
-import org.json.JSONObject;
 
 public class GetStatusResult implements Result {
 
@@ -19,8 +17,7 @@ public class GetStatusResult implements Result {
 
     private final boolean expensive;
 
-    @Nullable
-    private final Boolean ultraConstrained;
+    private final boolean ultraConstrained;
 
     public GetStatusResult(
         boolean connected,
@@ -28,7 +25,7 @@ public class GetStatusResult implements Result {
         boolean internetReachable,
         boolean constrained,
         boolean expensive,
-        @Nullable Boolean ultraConstrained
+        boolean ultraConstrained
     ) {
         this.connected = connected;
         this.connectionType = connectionType;
@@ -47,7 +44,7 @@ public class GetStatusResult implements Result {
         result.put("internetReachable", internetReachable);
         result.put("constrained", constrained);
         result.put("expensive", expensive);
-        result.put("ultraConstrained", ultraConstrained == null ? JSONObject.NULL : ultraConstrained);
+        result.put("ultraConstrained", ultraConstrained);
         return result;
     }
 }

--- a/packages/network/src/definitions.ts
+++ b/packages/network/src/definitions.ts
@@ -70,7 +70,8 @@ export interface GetStatusResult {
   internetReachable: boolean | null;
   /**
    * Whether the active network connection is subject to data saving
-   * restrictions, such as Data Saver on Android or Low Data Mode on iOS.
+   * restrictions or limited bandwidth, such as Data Saver on Android,
+   * Low Data Mode on iOS or a satellite network.
    *
    * This is `false` if the device is not connected to a network and `null`
    * on browsers that do not expose this information.
@@ -142,6 +143,14 @@ export enum ConnectionType {
    * @since 0.1.0
    */
   None = 'NONE',
+  /**
+   * The device is connected via a satellite network.
+   *
+   * Only available on Android.
+   *
+   * @since 0.1.2
+   */
+  Satellite = 'SATELLITE',
   /**
    * The type of the network connection could not be determined.
    *

--- a/packages/network/src/definitions.ts
+++ b/packages/network/src/definitions.ts
@@ -70,8 +70,7 @@ export interface GetStatusResult {
   internetReachable: boolean | null;
   /**
    * Whether the active network connection is subject to data saving
-   * restrictions or limited bandwidth, such as Data Saver on Android,
-   * Low Data Mode on iOS or a satellite network.
+   * restrictions, such as Data Saver on Android or Low Data Mode on iOS.
    *
    * This is `false` if the device is not connected to a network and `null`
    * on browsers that do not expose this information.
@@ -92,13 +91,13 @@ export interface GetStatusResult {
    */
   expensive: boolean | null;
   /**
-   * Whether the active network connection is ultra-constrained, such as a
-   * carrier-provided satellite network.
+   * Whether the active network connection is severely limited in bandwidth,
+   * such as a carrier-provided satellite network.
    *
    * This is `false` if the device is not connected to a network and `null`
-   * on platforms that cannot determine this (Android, Web and iOS below 26).
+   * on platforms that cannot determine this (Web and iOS below 26).
    *
-   * Only available on iOS 26+.
+   * Only available on Android and iOS 26+.
    *
    * @example false
    * @since 0.1.2


### PR DESCRIPTION
Adds support for constrained satellite networks on Android, so apps can detect satellite transport and adapt behavior such as reducing payload sizes, batching requests and disabling optional transfers.

## Changes

- Adds `ConnectionType.Satellite` with the value `SATELLITE`, detected via `NetworkCapabilities.TRANSPORT_SATELLITE` (Android 15+).
- Satellite is checked before Wi-Fi and cellular, because carrier satellite networks also report `TRANSPORT_CELLULAR` and would otherwise be masked.
- Entering or leaving satellite transport emits `networkStatusChange`, because the connection type is part of the deduplication key.
- Behavior on Android versions without satellite support is unchanged.

## Property semantics

This also aligns the meaning of `constrained` and `ultraConstrained` across platforms. Both properties were added in #960 and #962 and have not been released yet, so this is not a breaking change:

- `constrained` reflects a data saving preference only: Data Saver on a metered network (Android) or Low Data Mode (iOS).
- `ultraConstrained` reflects a severely limited connection: satellite transport (Android 15+) or a network without `NET_CAPABILITY_NOT_BANDWIDTH_CONSTRAINED` (Android 16+) on Android, and `NWPath.isUltraConstrained` (iOS 26+) on iOS.
- `connectionType` reflects the transport itself.

Previously, Android reported bandwidth-constrained networks via `constrained` while iOS reported the same condition via `ultraConstrained`.

## Notes

- Monitoring continues to use `registerDefaultNetworkCallback`. A `NetworkRequest` that removes `NET_CAPABILITY_NOT_BANDWIDTH_CONSTRAINED` would report networks that the app is not allowed to use, so the `networkStatusChange` event and `getStatus()` would disagree with each other.
- The consuming app must opt in by adding the `android.telephony.PROPERTY_SATELLITE_DATA_OPTIMIZED` meta-data element to its manifest. The plugin does not add it automatically, because each app must decide whether it is optimized for constrained satellite access. This is documented in the README.
- Apple does not expose satellite as a connection type, so `SATELLITE` is only reported on Android. On iOS, such connections are reported as `CELLULAR` with `ultraConstrained` set to `true`.

Close #957
