### PR TITLE
feat(in-app-browser)!: replace `clearSessionData()` with `clearCookies()`

### DIFF
--- a/.changeset/eight-pants-hang.md
+++ b/.changeset/eight-pants-hang.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-in-app-browser': minor
+---
+
+feat!: replace `clearSessionData()` with `clearCookies()`, which supports clearing the cookies of a specific URL and no longer deletes the web storage of the app's own origin

--- a/packages/in-app-browser/BREAKING.md
+++ b/packages/in-app-browser/BREAKING.md
@@ -1,6 +1,6 @@
 # Breaking Changes
 
-This is a comprehensive list of the breaking changes introduced in the major version releases.
+This is a comprehensive list of the breaking changes introduced in the different releases.
 
 ## Versions
 

--- a/packages/in-app-browser/BREAKING.md
+++ b/packages/in-app-browser/BREAKING.md
@@ -1,0 +1,23 @@
+# Breaking Changes
+
+This is a comprehensive list of the breaking changes introduced in the major version releases.
+
+## Versions
+
+- [Version 0.2.x](#version-02x)
+
+## Version 0.2.x
+
+### `clearSessionData()` method
+
+The `clearSessionData()` method has been replaced by the `clearCookies()` method. The previous implementation also deleted the web storage of the app's own origin, which could corrupt the state of the app. The new method only clears cookies and accepts an optional `url` parameter to clear only the cookies of a specific URL:
+
+```typescript
+// Before
+await InAppBrowser.clearSessionData();
+
+// After
+await InAppBrowser.clearCookies();
+// or
+await InAppBrowser.clearCookies({ url: 'https://capawesome.io' });
+```

--- a/packages/in-app-browser/README.md
+++ b/packages/in-app-browser/README.md
@@ -17,7 +17,7 @@ The Capacitor In-App Browser plugin is one of the most complete in-app browsing 
 - 💉 **JavaScript execution**: Execute any JavaScript code in the embedded web view.
 - 💬 **Messaging**: Exchange messages between your app and the web page in both directions.
 - 🎨 **Toolbar theming**: Customize the toolbar color, title, close button and navigation buttons.
-- 🍪 **Session control**: Clear the cache and session data, or use an isolated data store on iOS.
+- 🍪 **Session control**: Clear the cache and cookies, or use an isolated data store on iOS.
 - 🎥 **Media permissions**: Camera and microphone permission requests from web pages are forwarded to the app.
 - 🤝 **Compatibility**: Works alongside the [App Launcher](https://capawesome.io/docs/sdks/capacitor/app-launcher/), [OAuth](https://capawesome.io/docs/sdks/capacitor/oauth/) and [System WebView](https://capawesome.io/docs/sdks/capacitor/system-webview/) plugins.
 - 📦 **CocoaPods & SPM**: Supports CocoaPods and Swift Package Manager for iOS.
@@ -33,7 +33,7 @@ The In-App Browser plugin is typically used whenever an app needs to display web
 - **Login and checkout flows**: Open a web-based flow in the embedded web view and watch for a redirect using the `browserUrlChanged` event.
 - **Hybrid web content**: Embed a web page with a themed native toolbar and exchange messages between the app and the page.
 - **Background loading**: Load a URL in a hidden web view with the `visible` option and present it once the page has loaded.
-- **Session control**: Clear the cache and session data of the web view, or use an isolated data store on iOS.
+- **Session control**: Clear the cache and cookies of the web view, or use an isolated data store on iOS.
 
 ## Compatibility
 
@@ -201,9 +201,9 @@ const postMessage = async () => {
 };
 ```
 
-### Clear the cache and session data
+### Clear the cache and cookies
 
-Clear the cache or the session data (cookies and web storage) of the web view. Only available on Android and iOS:
+Clear the cache or the cookies of the web view, either for all URLs or only for a specific URL. Only available on Android and iOS:
 
 ```typescript
 import { InAppBrowser } from '@capawesome/capacitor-in-app-browser';
@@ -212,8 +212,12 @@ const clearCache = async () => {
   await InAppBrowser.clearCache();
 };
 
-const clearSessionData = async () => {
-  await InAppBrowser.clearSessionData();
+const clearAllCookies = async () => {
+  await InAppBrowser.clearCookies();
+};
+
+const clearCookiesForUrl = async () => {
+  await InAppBrowser.clearCookies({ url: 'https://capawesome.io' });
 };
 ```
 
@@ -248,7 +252,7 @@ const addListeners = async () => {
 <docgen-index>
 
 * [`clearCache()`](#clearcache)
-* [`clearSessionData()`](#clearsessiondata)
+* [`clearCookies(...)`](#clearcookies)
 * [`close()`](#close)
 * [`executeScript(...)`](#executescript)
 * [`getCookies(...)`](#getcookies)
@@ -286,17 +290,21 @@ Only available on Android and iOS.
 --------------------
 
 
-### clearSessionData()
+### clearCookies(...)
 
 ```typescript
-clearSessionData() => Promise<void>
+clearCookies(options?: ClearCookiesOptions | undefined) => Promise<void>
 ```
 
-Clear the session data (cookies and web storage) of the web view.
+Clear the cookies of the web view.
 
 Only available on Android and iOS.
 
-**Since:** 0.1.0
+| Param         | Type                                                                |
+| ------------- | ------------------------------------------------------------------- |
+| **`options`** | <code><a href="#clearcookiesoptions">ClearCookiesOptions</a></code> |
+
+**Since:** 0.2.0
 
 --------------------
 
@@ -608,6 +616,13 @@ Remove all listeners for this plugin.
 ### Interfaces
 
 
+#### ClearCookiesOptions
+
+| Prop      | Type                | Description                                                                 | Since |
+| --------- | ------------------- | --------------------------------------------------------------------------- | ----- |
+| **`url`** | <code>string</code> | The URL to clear the cookies for. If not provided, all cookies are cleared. | 0.2.0 |
+
+
 #### ExecuteScriptResult
 
 | Prop         | Type                        | Description                                                                                                                                  | Since |
@@ -853,6 +868,10 @@ Stay up to date with the latest news and updates about the Capawesome, Capacitor
 ## Changelog
 
 See [CHANGELOG.md](https://github.com/capawesome-team/capacitor-plugins/blob/main/packages/in-app-browser/CHANGELOG.md).
+
+## Breaking Changes
+
+See [BREAKING.md](https://github.com/capawesome-team/capacitor-plugins/blob/main/packages/in-app-browser/BREAKING.md).
 
 ## License
 

--- a/packages/in-app-browser/README.md
+++ b/packages/in-app-browser/README.md
@@ -298,6 +298,9 @@ clearCookies(options?: ClearCookiesOptions | undefined) => Promise<void>
 
 Clear the cookies of the web view.
 
+Provide the `url` option to clear only the cookies of a specific URL.
+Otherwise, all cookies are cleared.
+
 Only available on Android and iOS.
 
 | Param         | Type                                                                |

--- a/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/InAppBrowser.java
+++ b/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/InAppBrowser.java
@@ -2,8 +2,8 @@ package io.capawesome.capacitorjs.plugins.inappbrowser;
 
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
+import android.net.Uri;
 import android.webkit.CookieManager;
-import android.webkit.WebStorage;
 import android.webkit.WebView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -14,6 +14,7 @@ import io.capawesome.capacitorjs.plugins.inappbrowser.classes.WebViewDialog;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.events.BrowserMessageReceivedEvent;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.events.BrowserNavigationCompletedEvent;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.events.BrowserUrlChangedEvent;
+import io.capawesome.capacitorjs.plugins.inappbrowser.classes.options.ClearCookiesOptions;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.options.ExecuteScriptOptions;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.options.GetCookiesOptions;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.options.OpenInExternalBrowserOptions;
@@ -44,75 +45,101 @@ public class InAppBrowser {
     }
 
     public void clearCache(@NonNull EmptyCallback callback) {
-        plugin.getActivity().runOnUiThread(() -> {
-            WebView webView = new WebView(plugin.getContext());
-            webView.clearCache(true);
-            webView.destroy();
-            callback.success();
-        });
-    }
-
-    public void clearSessionData(@NonNull EmptyCallback callback) {
-        plugin.getActivity().runOnUiThread(() -> {
-            CookieManager cookieManager = CookieManager.getInstance();
-            cookieManager.removeAllCookies(value -> {
-                cookieManager.flush();
-                WebStorage.getInstance().deleteAllData();
+        plugin
+            .getActivity()
+            .runOnUiThread(() -> {
+                WebView webView = new WebView(plugin.getContext());
+                webView.clearCache(true);
+                webView.destroy();
                 callback.success();
             });
-        });
+    }
+
+    public void clearCookies(@NonNull ClearCookiesOptions options, @NonNull EmptyCallback callback) {
+        plugin
+            .getActivity()
+            .runOnUiThread(() -> {
+                CookieManager cookieManager = CookieManager.getInstance();
+                String url = options.getUrl();
+                if (url == null) {
+                    cookieManager.removeAllCookies(value -> {
+                        cookieManager.flush();
+                        callback.success();
+                    });
+                } else {
+                    String cookieString = cookieManager.getCookie(url);
+                    if (cookieString != null) {
+                        String host = Uri.parse(url).getHost();
+                        for (String cookie : cookieString.split("; ")) {
+                            int separatorIndex = cookie.indexOf('=');
+                            if (separatorIndex < 0) {
+                                continue;
+                            }
+                            expireCookie(cookieManager, url, host, cookie.substring(0, separatorIndex));
+                        }
+                    }
+                    cookieManager.flush();
+                    callback.success();
+                }
+            });
     }
 
     public void close(@NonNull EmptyCallback callback) {
-        plugin.getActivity().runOnUiThread(() -> {
-            WebViewDialog webViewDialog = this.webViewDialog;
-            if (webViewDialog != null) {
-                webViewDialog.dismiss();
-                callback.success();
-                return;
-            }
-            if (customTabOpened) {
-                Intent intent = new Intent(plugin.getContext(), plugin.getActivity().getClass());
-                intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-                plugin.getActivity().startActivity(intent);
-                callback.success();
-                return;
-            }
-            callback.error(CustomExceptions.NO_BROWSER_OPEN);
-        });
+        plugin
+            .getActivity()
+            .runOnUiThread(() -> {
+                WebViewDialog webViewDialog = this.webViewDialog;
+                if (webViewDialog != null) {
+                    webViewDialog.dismiss();
+                    callback.success();
+                    return;
+                }
+                if (customTabOpened) {
+                    Intent intent = new Intent(plugin.getContext(), plugin.getActivity().getClass());
+                    intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+                    plugin.getActivity().startActivity(intent);
+                    callback.success();
+                    return;
+                }
+                callback.error(CustomExceptions.NO_BROWSER_OPEN);
+            });
     }
 
     public void executeScript(@NonNull ExecuteScriptOptions options, @NonNull NonEmptyResultCallback<ExecuteScriptResult> callback) {
-        plugin.getActivity().runOnUiThread(() -> {
-            WebViewDialog webViewDialog = this.webViewDialog;
-            if (webViewDialog == null) {
-                callback.error(CustomExceptions.NO_BROWSER_OPEN);
-                return;
-            }
-            webViewDialog.executeScript(options.getScript(), value -> {
-                String result = value == null || value.equals("null") ? null : value;
-                callback.success(new ExecuteScriptResult(result));
+        plugin
+            .getActivity()
+            .runOnUiThread(() -> {
+                WebViewDialog webViewDialog = this.webViewDialog;
+                if (webViewDialog == null) {
+                    callback.error(CustomExceptions.NO_BROWSER_OPEN);
+                    return;
+                }
+                webViewDialog.executeScript(options.getScript(), value -> {
+                    String result = value == null || value.equals("null") ? null : value;
+                    callback.success(new ExecuteScriptResult(result));
+                });
             });
-        });
     }
 
     public void getCookies(@NonNull GetCookiesOptions options, @NonNull NonEmptyResultCallback<GetCookiesResult> callback) {
-        plugin.getActivity().runOnUiThread(() -> {
-            Map<String, String> cookies = new HashMap<>();
-            String cookieString = CookieManager.getInstance().getCookie(options.getUrl());
-            if (cookieString != null) {
-                for (String cookie : cookieString.split("; ")) {
-                    int separatorIndex = cookie.indexOf('=');
-                    if (separatorIndex < 0) {
-                        continue;
+        plugin
+            .getActivity()
+            .runOnUiThread(() -> {
+                Map<String, String> cookies = new HashMap<>();
+                String cookieString = CookieManager.getInstance().getCookie(options.getUrl());
+                if (cookieString != null) {
+                    for (String cookie : cookieString.split("; ")) {
+                        int separatorIndex = cookie.indexOf('=');
+                        if (separatorIndex < 0) {
+                            continue;
+                        }
+                        String name = cookie.substring(0, separatorIndex);
+                        String value = cookie.substring(separatorIndex + 1);
+                        cookies.put(name, value);
                     }
-                    String name = cookie.substring(0, separatorIndex);
-                    String value = cookie.substring(separatorIndex + 1);
-                    cookies.put(name, value);
                 }
-            }
-            callback.success(new GetCookiesResult(cookies));
-        });
+                callback.success(new GetCookiesResult(cookies));
+            });
     }
 
     public void handleOnPause() {
@@ -144,92 +171,100 @@ public class InAppBrowser {
     }
 
     public void openInSystemBrowser(@NonNull OpenInSystemBrowserOptions options, @NonNull EmptyCallback callback) {
-        plugin.getActivity().runOnUiThread(() -> {
-            CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
-            Integer toolbarColor = options.getToolbarColor();
-            if (toolbarColor != null) {
-                builder.setDefaultColorSchemeParams(new CustomTabColorSchemeParams.Builder().setToolbarColor(toolbarColor).build());
-            }
-            builder.setShowTitle(options.getShowTitle());
-            builder.setUrlBarHidingEnabled(options.getHideToolbarOnScroll());
-            CustomTabsIntent customTabsIntent = builder.build();
-            try {
-                customTabsIntent.launchUrl(plugin.getActivity(), options.getUri());
-                customTabOpened = true;
-                callback.success();
-            } catch (ActivityNotFoundException exception) {
-                callback.error(CustomExceptions.BROWSER_NOT_FOUND);
-            }
-        });
+        plugin
+            .getActivity()
+            .runOnUiThread(() -> {
+                CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
+                Integer toolbarColor = options.getToolbarColor();
+                if (toolbarColor != null) {
+                    builder.setDefaultColorSchemeParams(new CustomTabColorSchemeParams.Builder().setToolbarColor(toolbarColor).build());
+                }
+                builder.setShowTitle(options.getShowTitle());
+                builder.setUrlBarHidingEnabled(options.getHideToolbarOnScroll());
+                CustomTabsIntent customTabsIntent = builder.build();
+                try {
+                    customTabsIntent.launchUrl(plugin.getActivity(), options.getUri());
+                    customTabOpened = true;
+                    callback.success();
+                } catch (ActivityNotFoundException exception) {
+                    callback.error(CustomExceptions.BROWSER_NOT_FOUND);
+                }
+            });
     }
 
     public void openInWebView(@NonNull OpenInWebViewOptions options, @NonNull EmptyCallback callback) {
-        plugin.getActivity().runOnUiThread(() -> {
-            WebViewDialog existingWebViewDialog = this.webViewDialog;
-            if (existingWebViewDialog != null) {
-                existingWebViewDialog.dismiss();
-            }
-            WebViewDialog webViewDialog = new WebViewDialog(
-                plugin.getActivity(),
-                options,
-                new WebViewDialog.Listener() {
-                    @Override
-                    public void onClosed(@NonNull WebViewDialog dialog) {
-                        if (InAppBrowser.this.webViewDialog == dialog) {
-                            InAppBrowser.this.webViewDialog = null;
-                        }
-                        plugin.notifyBrowserClosedListeners();
-                    }
-
-                    @Override
-                    public void onMessageReceived(@NonNull String data) {
-                        handleMessageReceived(data);
-                    }
-
-                    @Override
-                    public void onNavigationCompleted(@NonNull String url) {
-                        plugin.notifyBrowserNavigationCompletedListeners(new BrowserNavigationCompletedEvent(url));
-                    }
-
-                    @Override
-                    public void onPageLoaded() {
-                        plugin.notifyBrowserPageLoadedListeners();
-                    }
-
-                    @Override
-                    public void onUrlChanged(@NonNull String url) {
-                        plugin.notifyBrowserUrlChangedListeners(new BrowserUrlChangedEvent(url));
-                    }
+        plugin
+            .getActivity()
+            .runOnUiThread(() -> {
+                WebViewDialog existingWebViewDialog = this.webViewDialog;
+                if (existingWebViewDialog != null) {
+                    existingWebViewDialog.dismiss();
                 }
-            );
-            this.webViewDialog = webViewDialog;
-            webViewDialog.show();
-            callback.success();
-        });
+                WebViewDialog webViewDialog = new WebViewDialog(
+                    plugin.getActivity(),
+                    options,
+                    new WebViewDialog.Listener() {
+                        @Override
+                        public void onClosed(@NonNull WebViewDialog dialog) {
+                            if (InAppBrowser.this.webViewDialog == dialog) {
+                                InAppBrowser.this.webViewDialog = null;
+                            }
+                            plugin.notifyBrowserClosedListeners();
+                        }
+
+                        @Override
+                        public void onMessageReceived(@NonNull String data) {
+                            handleMessageReceived(data);
+                        }
+
+                        @Override
+                        public void onNavigationCompleted(@NonNull String url) {
+                            plugin.notifyBrowserNavigationCompletedListeners(new BrowserNavigationCompletedEvent(url));
+                        }
+
+                        @Override
+                        public void onPageLoaded() {
+                            plugin.notifyBrowserPageLoadedListeners();
+                        }
+
+                        @Override
+                        public void onUrlChanged(@NonNull String url) {
+                            plugin.notifyBrowserUrlChangedListeners(new BrowserUrlChangedEvent(url));
+                        }
+                    }
+                );
+                this.webViewDialog = webViewDialog;
+                webViewDialog.show();
+                callback.success();
+            });
     }
 
     public void postMessage(@NonNull PostMessageOptions options, @NonNull EmptyCallback callback) {
-        plugin.getActivity().runOnUiThread(() -> {
-            WebViewDialog webViewDialog = this.webViewDialog;
-            if (webViewDialog == null) {
-                callback.error(CustomExceptions.NO_BROWSER_OPEN);
-                return;
-            }
-            webViewDialog.postMessage(options.getData().toString());
-            callback.success();
-        });
+        plugin
+            .getActivity()
+            .runOnUiThread(() -> {
+                WebViewDialog webViewDialog = this.webViewDialog;
+                if (webViewDialog == null) {
+                    callback.error(CustomExceptions.NO_BROWSER_OPEN);
+                    return;
+                }
+                webViewDialog.postMessage(options.getData().toString());
+                callback.success();
+            });
     }
 
     public void show(@NonNull EmptyCallback callback) {
-        plugin.getActivity().runOnUiThread(() -> {
-            WebViewDialog webViewDialog = this.webViewDialog;
-            if (webViewDialog == null) {
-                callback.error(CustomExceptions.NO_BROWSER_OPEN);
-                return;
-            }
-            webViewDialog.showWebView();
-            callback.success();
-        });
+        plugin
+            .getActivity()
+            .runOnUiThread(() -> {
+                WebViewDialog webViewDialog = this.webViewDialog;
+                if (webViewDialog == null) {
+                    callback.error(CustomExceptions.NO_BROWSER_OPEN);
+                    return;
+                }
+                webViewDialog.showWebView();
+                callback.success();
+            });
     }
 
     private void handleMessageReceived(@NonNull String data) {
@@ -240,5 +275,17 @@ public class InAppBrowser {
             value = data;
         }
         plugin.notifyBrowserMessageReceivedListeners(new BrowserMessageReceivedEvent(value));
+    }
+
+    private void expireCookie(@NonNull CookieManager cookieManager, @NonNull String url, @Nullable String host, @NonNull String name) {
+        String expiredCookie = name + "=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/";
+        cookieManager.setCookie(url, expiredCookie);
+        // Also expire the domain cookie variants of all parent domains
+        // because the cookie string does not reveal the cookie domain.
+        String domain = host;
+        while (domain != null && domain.indexOf('.') != -1) {
+            cookieManager.setCookie(url, expiredCookie + "; Domain=" + domain);
+            domain = domain.substring(domain.indexOf('.') + 1);
+        }
     }
 }

--- a/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/InAppBrowser.java
+++ b/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/InAppBrowser.java
@@ -45,101 +45,91 @@ public class InAppBrowser {
     }
 
     public void clearCache(@NonNull EmptyCallback callback) {
-        plugin
-            .getActivity()
-            .runOnUiThread(() -> {
-                WebView webView = new WebView(plugin.getContext());
-                webView.clearCache(true);
-                webView.destroy();
-                callback.success();
-            });
+        plugin.getActivity().runOnUiThread(() -> {
+            WebView webView = new WebView(plugin.getContext());
+            webView.clearCache(true);
+            webView.destroy();
+            callback.success();
+        });
     }
 
     public void clearCookies(@NonNull ClearCookiesOptions options, @NonNull EmptyCallback callback) {
-        plugin
-            .getActivity()
-            .runOnUiThread(() -> {
-                CookieManager cookieManager = CookieManager.getInstance();
-                String url = options.getUrl();
-                if (url == null) {
-                    cookieManager.removeAllCookies(value -> {
-                        cookieManager.flush();
-                        callback.success();
-                    });
-                } else {
-                    String cookieString = cookieManager.getCookie(url);
-                    if (cookieString != null) {
-                        String host = Uri.parse(url).getHost();
-                        for (String cookie : cookieString.split("; ")) {
-                            int separatorIndex = cookie.indexOf('=');
-                            if (separatorIndex < 0) {
-                                continue;
-                            }
-                            expireCookie(cookieManager, url, host, cookie.substring(0, separatorIndex));
-                        }
-                    }
+        plugin.getActivity().runOnUiThread(() -> {
+            CookieManager cookieManager = CookieManager.getInstance();
+            String url = options.getUrl();
+            if (url == null) {
+                cookieManager.removeAllCookies(value -> {
                     cookieManager.flush();
                     callback.success();
-                }
-            });
-    }
-
-    public void close(@NonNull EmptyCallback callback) {
-        plugin
-            .getActivity()
-            .runOnUiThread(() -> {
-                WebViewDialog webViewDialog = this.webViewDialog;
-                if (webViewDialog != null) {
-                    webViewDialog.dismiss();
-                    callback.success();
-                    return;
-                }
-                if (customTabOpened) {
-                    Intent intent = new Intent(plugin.getContext(), plugin.getActivity().getClass());
-                    intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-                    plugin.getActivity().startActivity(intent);
-                    callback.success();
-                    return;
-                }
-                callback.error(CustomExceptions.NO_BROWSER_OPEN);
-            });
-    }
-
-    public void executeScript(@NonNull ExecuteScriptOptions options, @NonNull NonEmptyResultCallback<ExecuteScriptResult> callback) {
-        plugin
-            .getActivity()
-            .runOnUiThread(() -> {
-                WebViewDialog webViewDialog = this.webViewDialog;
-                if (webViewDialog == null) {
-                    callback.error(CustomExceptions.NO_BROWSER_OPEN);
-                    return;
-                }
-                webViewDialog.executeScript(options.getScript(), value -> {
-                    String result = value == null || value.equals("null") ? null : value;
-                    callback.success(new ExecuteScriptResult(result));
                 });
-            });
-    }
-
-    public void getCookies(@NonNull GetCookiesOptions options, @NonNull NonEmptyResultCallback<GetCookiesResult> callback) {
-        plugin
-            .getActivity()
-            .runOnUiThread(() -> {
-                Map<String, String> cookies = new HashMap<>();
-                String cookieString = CookieManager.getInstance().getCookie(options.getUrl());
+            } else {
+                String cookieString = cookieManager.getCookie(url);
                 if (cookieString != null) {
+                    String host = Uri.parse(url).getHost();
                     for (String cookie : cookieString.split("; ")) {
                         int separatorIndex = cookie.indexOf('=');
                         if (separatorIndex < 0) {
                             continue;
                         }
-                        String name = cookie.substring(0, separatorIndex);
-                        String value = cookie.substring(separatorIndex + 1);
-                        cookies.put(name, value);
+                        expireCookie(cookieManager, url, host, cookie.substring(0, separatorIndex));
                     }
                 }
-                callback.success(new GetCookiesResult(cookies));
+                cookieManager.flush();
+                callback.success();
+            }
+        });
+    }
+
+    public void close(@NonNull EmptyCallback callback) {
+        plugin.getActivity().runOnUiThread(() -> {
+            WebViewDialog webViewDialog = this.webViewDialog;
+            if (webViewDialog != null) {
+                webViewDialog.dismiss();
+                callback.success();
+                return;
+            }
+            if (customTabOpened) {
+                Intent intent = new Intent(plugin.getContext(), plugin.getActivity().getClass());
+                intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+                plugin.getActivity().startActivity(intent);
+                callback.success();
+                return;
+            }
+            callback.error(CustomExceptions.NO_BROWSER_OPEN);
+        });
+    }
+
+    public void executeScript(@NonNull ExecuteScriptOptions options, @NonNull NonEmptyResultCallback<ExecuteScriptResult> callback) {
+        plugin.getActivity().runOnUiThread(() -> {
+            WebViewDialog webViewDialog = this.webViewDialog;
+            if (webViewDialog == null) {
+                callback.error(CustomExceptions.NO_BROWSER_OPEN);
+                return;
+            }
+            webViewDialog.executeScript(options.getScript(), value -> {
+                String result = value == null || value.equals("null") ? null : value;
+                callback.success(new ExecuteScriptResult(result));
             });
+        });
+    }
+
+    public void getCookies(@NonNull GetCookiesOptions options, @NonNull NonEmptyResultCallback<GetCookiesResult> callback) {
+        plugin.getActivity().runOnUiThread(() -> {
+            Map<String, String> cookies = new HashMap<>();
+            String cookieString = CookieManager.getInstance().getCookie(options.getUrl());
+            if (cookieString != null) {
+                for (String cookie : cookieString.split("; ")) {
+                    int separatorIndex = cookie.indexOf('=');
+                    if (separatorIndex < 0) {
+                        continue;
+                    }
+                    String name = cookie.substring(0, separatorIndex);
+                    String value = cookie.substring(separatorIndex + 1);
+                    cookies.put(name, value);
+                }
+            }
+            callback.success(new GetCookiesResult(cookies));
+        });
     }
 
     public void handleOnPause() {
@@ -171,100 +161,92 @@ public class InAppBrowser {
     }
 
     public void openInSystemBrowser(@NonNull OpenInSystemBrowserOptions options, @NonNull EmptyCallback callback) {
-        plugin
-            .getActivity()
-            .runOnUiThread(() -> {
-                CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
-                Integer toolbarColor = options.getToolbarColor();
-                if (toolbarColor != null) {
-                    builder.setDefaultColorSchemeParams(new CustomTabColorSchemeParams.Builder().setToolbarColor(toolbarColor).build());
-                }
-                builder.setShowTitle(options.getShowTitle());
-                builder.setUrlBarHidingEnabled(options.getHideToolbarOnScroll());
-                CustomTabsIntent customTabsIntent = builder.build();
-                try {
-                    customTabsIntent.launchUrl(plugin.getActivity(), options.getUri());
-                    customTabOpened = true;
-                    callback.success();
-                } catch (ActivityNotFoundException exception) {
-                    callback.error(CustomExceptions.BROWSER_NOT_FOUND);
-                }
-            });
+        plugin.getActivity().runOnUiThread(() -> {
+            CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
+            Integer toolbarColor = options.getToolbarColor();
+            if (toolbarColor != null) {
+                builder.setDefaultColorSchemeParams(new CustomTabColorSchemeParams.Builder().setToolbarColor(toolbarColor).build());
+            }
+            builder.setShowTitle(options.getShowTitle());
+            builder.setUrlBarHidingEnabled(options.getHideToolbarOnScroll());
+            CustomTabsIntent customTabsIntent = builder.build();
+            try {
+                customTabsIntent.launchUrl(plugin.getActivity(), options.getUri());
+                customTabOpened = true;
+                callback.success();
+            } catch (ActivityNotFoundException exception) {
+                callback.error(CustomExceptions.BROWSER_NOT_FOUND);
+            }
+        });
     }
 
     public void openInWebView(@NonNull OpenInWebViewOptions options, @NonNull EmptyCallback callback) {
-        plugin
-            .getActivity()
-            .runOnUiThread(() -> {
-                WebViewDialog existingWebViewDialog = this.webViewDialog;
-                if (existingWebViewDialog != null) {
-                    existingWebViewDialog.dismiss();
-                }
-                WebViewDialog webViewDialog = new WebViewDialog(
-                    plugin.getActivity(),
-                    options,
-                    new WebViewDialog.Listener() {
-                        @Override
-                        public void onClosed(@NonNull WebViewDialog dialog) {
-                            if (InAppBrowser.this.webViewDialog == dialog) {
-                                InAppBrowser.this.webViewDialog = null;
-                            }
-                            plugin.notifyBrowserClosedListeners();
+        plugin.getActivity().runOnUiThread(() -> {
+            WebViewDialog existingWebViewDialog = this.webViewDialog;
+            if (existingWebViewDialog != null) {
+                existingWebViewDialog.dismiss();
+            }
+            WebViewDialog webViewDialog = new WebViewDialog(
+                plugin.getActivity(),
+                options,
+                new WebViewDialog.Listener() {
+                    @Override
+                    public void onClosed(@NonNull WebViewDialog dialog) {
+                        if (InAppBrowser.this.webViewDialog == dialog) {
+                            InAppBrowser.this.webViewDialog = null;
                         }
-
-                        @Override
-                        public void onMessageReceived(@NonNull String data) {
-                            handleMessageReceived(data);
-                        }
-
-                        @Override
-                        public void onNavigationCompleted(@NonNull String url) {
-                            plugin.notifyBrowserNavigationCompletedListeners(new BrowserNavigationCompletedEvent(url));
-                        }
-
-                        @Override
-                        public void onPageLoaded() {
-                            plugin.notifyBrowserPageLoadedListeners();
-                        }
-
-                        @Override
-                        public void onUrlChanged(@NonNull String url) {
-                            plugin.notifyBrowserUrlChangedListeners(new BrowserUrlChangedEvent(url));
-                        }
+                        plugin.notifyBrowserClosedListeners();
                     }
-                );
-                this.webViewDialog = webViewDialog;
-                webViewDialog.show();
-                callback.success();
-            });
+
+                    @Override
+                    public void onMessageReceived(@NonNull String data) {
+                        handleMessageReceived(data);
+                    }
+
+                    @Override
+                    public void onNavigationCompleted(@NonNull String url) {
+                        plugin.notifyBrowserNavigationCompletedListeners(new BrowserNavigationCompletedEvent(url));
+                    }
+
+                    @Override
+                    public void onPageLoaded() {
+                        plugin.notifyBrowserPageLoadedListeners();
+                    }
+
+                    @Override
+                    public void onUrlChanged(@NonNull String url) {
+                        plugin.notifyBrowserUrlChangedListeners(new BrowserUrlChangedEvent(url));
+                    }
+                }
+            );
+            this.webViewDialog = webViewDialog;
+            webViewDialog.show();
+            callback.success();
+        });
     }
 
     public void postMessage(@NonNull PostMessageOptions options, @NonNull EmptyCallback callback) {
-        plugin
-            .getActivity()
-            .runOnUiThread(() -> {
-                WebViewDialog webViewDialog = this.webViewDialog;
-                if (webViewDialog == null) {
-                    callback.error(CustomExceptions.NO_BROWSER_OPEN);
-                    return;
-                }
-                webViewDialog.postMessage(options.getData().toString());
-                callback.success();
-            });
+        plugin.getActivity().runOnUiThread(() -> {
+            WebViewDialog webViewDialog = this.webViewDialog;
+            if (webViewDialog == null) {
+                callback.error(CustomExceptions.NO_BROWSER_OPEN);
+                return;
+            }
+            webViewDialog.postMessage(options.getData().toString());
+            callback.success();
+        });
     }
 
     public void show(@NonNull EmptyCallback callback) {
-        plugin
-            .getActivity()
-            .runOnUiThread(() -> {
-                WebViewDialog webViewDialog = this.webViewDialog;
-                if (webViewDialog == null) {
-                    callback.error(CustomExceptions.NO_BROWSER_OPEN);
-                    return;
-                }
-                webViewDialog.showWebView();
-                callback.success();
-            });
+        plugin.getActivity().runOnUiThread(() -> {
+            WebViewDialog webViewDialog = this.webViewDialog;
+            if (webViewDialog == null) {
+                callback.error(CustomExceptions.NO_BROWSER_OPEN);
+                return;
+            }
+            webViewDialog.showWebView();
+            callback.success();
+        });
     }
 
     private void handleMessageReceived(@NonNull String data) {

--- a/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/InAppBrowserPlugin.java
+++ b/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/InAppBrowserPlugin.java
@@ -12,6 +12,7 @@ import io.capawesome.capacitorjs.plugins.inappbrowser.classes.CustomException;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.events.BrowserMessageReceivedEvent;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.events.BrowserNavigationCompletedEvent;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.events.BrowserUrlChangedEvent;
+import io.capawesome.capacitorjs.plugins.inappbrowser.classes.options.ClearCookiesOptions;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.options.ExecuteScriptOptions;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.options.GetCookiesOptions;
 import io.capawesome.capacitorjs.plugins.inappbrowser.classes.options.OpenInExternalBrowserOptions;
@@ -60,8 +61,9 @@ public class InAppBrowserPlugin extends Plugin {
     }
 
     @PluginMethod
-    public void clearSessionData(PluginCall call) {
+    public void clearCookies(PluginCall call) {
         try {
+            ClearCookiesOptions options = new ClearCookiesOptions(call);
             EmptyCallback callback = new EmptyCallback() {
                 @Override
                 public void success() {
@@ -74,7 +76,7 @@ public class InAppBrowserPlugin extends Plugin {
                 }
             };
 
-            implementation.clearSessionData(callback);
+            implementation.clearCookies(options, callback);
         } catch (Exception exception) {
             rejectCall(call, exception);
         }

--- a/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/classes/options/ClearCookiesOptions.java
+++ b/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/classes/options/ClearCookiesOptions.java
@@ -1,0 +1,20 @@
+package io.capawesome.capacitorjs.plugins.inappbrowser.classes.options;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.getcapacitor.PluginCall;
+
+public class ClearCookiesOptions {
+
+    @Nullable
+    private final String url;
+
+    public ClearCookiesOptions(@NonNull PluginCall call) {
+        this.url = call.getString("url");
+    }
+
+    @Nullable
+    public String getUrl() {
+        return url;
+    }
+}

--- a/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/classes/options/ClearCookiesOptions.java
+++ b/packages/in-app-browser/android/src/main/java/io/capawesome/capacitorjs/plugins/inappbrowser/classes/options/ClearCookiesOptions.java
@@ -10,7 +10,8 @@ public class ClearCookiesOptions {
     private final String url;
 
     public ClearCookiesOptions(@NonNull PluginCall call) {
-        this.url = call.getString("url");
+        String url = call.getString("url");
+        this.url = url == null || url.isEmpty() ? null : url;
     }
 
     @Nullable

--- a/packages/in-app-browser/example/src/index.html
+++ b/packages/in-app-browser/example/src/index.html
@@ -53,9 +53,7 @@
         <ion-button id="getCookies" expand="block">Get Cookies</ion-button>
         <ion-button id="postMessage" expand="block">Post Message</ion-button>
         <ion-button id="clearCache" expand="block">Clear Cache</ion-button>
-        <ion-button id="clearSessionData" expand="block"
-          >Clear Session Data</ion-button
-        >
+        <ion-button id="clearCookies" expand="block">Clear Cookies</ion-button>
       </ion-content>
     </ion-app>
   </body>

--- a/packages/in-app-browser/example/src/js/script.js
+++ b/packages/in-app-browser/example/src/js/script.js
@@ -75,9 +75,9 @@ document.addEventListener('DOMContentLoaded', () => {
     await InAppBrowser.clearCache();
   });
   document
-    .querySelector('#clearSessionData')
+    .querySelector('#clearCookies')
     .addEventListener('click', async () => {
-      await InAppBrowser.clearSessionData();
+      await InAppBrowser.clearCookies({ url });
     });
 
   void InAppBrowser.addListener('browserClosed', () => {

--- a/packages/in-app-browser/ios/Plugin.xcodeproj/project.pbxproj
+++ b/packages/in-app-browser/ios/Plugin.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		A7110000000000000000001A /* InAppBrowserHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71100000000000000000019 /* InAppBrowserHelper.swift */; };
 		A7110000000000000000001C /* GetCookiesResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7110000000000000000001B /* GetCookiesResult.swift */; };
 		A7110000000000000000001E /* GetCookiesOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7110000000000000000001D /* GetCookiesOptions.swift */; };
+		A71100000000000000000029 /* ClearCookiesOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71100000000000000000028 /* ClearCookiesOptions.swift */; };
 		A71100000000000000000027 /* BrowserUrlChangedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71100000000000000000026 /* BrowserUrlChangedEvent.swift */; };
 /* End PBXBuildFile section */
 
@@ -67,6 +68,7 @@
 		A71100000000000000000019 /* InAppBrowserHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppBrowserHelper.swift; sourceTree = "<group>"; };
 		A7110000000000000000001B /* GetCookiesResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCookiesResult.swift; sourceTree = "<group>"; };
 		A7110000000000000000001D /* GetCookiesOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCookiesOptions.swift; sourceTree = "<group>"; };
+		A71100000000000000000028 /* ClearCookiesOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearCookiesOptions.swift; sourceTree = "<group>"; };
 		A71100000000000000000026 /* BrowserUrlChangedEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserUrlChangedEvent.swift; sourceTree = "<group>"; };
 		5E23F77F099397094342571A /* Pods-Plugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Plugin.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Plugin/Pods-Plugin.debug.xcconfig"; sourceTree = "<group>"; };
 		91781294A431A2A7CC6EB714 /* Pods-Plugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Plugin.release.xcconfig"; path = "Pods/Target Support Files/Pods-Plugin/Pods-Plugin.release.xcconfig"; sourceTree = "<group>"; };
@@ -180,6 +182,7 @@
 		A71100000000000000000025 /* Options */ = {
 			isa = PBXGroup;
 			children = (
+				A71100000000000000000028 /* ClearCookiesOptions.swift */,
 				A7110000000000000000000B /* ExecuteScriptOptions.swift */,
 				A7110000000000000000001D /* GetCookiesOptions.swift */,
 				A7110000000000000000000D /* OpenInExternalBrowserOptions.swift */,
@@ -413,6 +416,7 @@
 				A7110000000000000000001A /* InAppBrowserHelper.swift in Sources */,
 				A7110000000000000000001C /* GetCookiesResult.swift in Sources */,
 				A7110000000000000000001E /* GetCookiesOptions.swift in Sources */,
+				A71100000000000000000029 /* ClearCookiesOptions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/in-app-browser/ios/Plugin/Classes/Options/ClearCookiesOptions.swift
+++ b/packages/in-app-browser/ios/Plugin/Classes/Options/ClearCookiesOptions.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Capacitor
+
+@objc public class ClearCookiesOptions: NSObject {
+    let url: URL?
+
+    init(_ call: CAPPluginCall) throws {
+        self.url = try ClearCookiesOptions.getUrlFromCall(call)
+    }
+
+    private static func getUrlFromCall(_ call: CAPPluginCall) throws -> URL? {
+        guard let urlString = call.getString("url"), !urlString.isEmpty else {
+            return nil
+        }
+        guard let url = URL(string: urlString) else {
+            throw CustomError.urlInvalid
+        }
+        return url
+    }
+}

--- a/packages/in-app-browser/ios/Plugin/InAppBrowser.swift
+++ b/packages/in-app-browser/ios/Plugin/InAppBrowser.swift
@@ -26,13 +26,17 @@ import WebKit
 
     @objc public func clearCookies(_ options: ClearCookiesOptions, completion: @escaping (_ error: Error?) -> Void) {
         DispatchQueue.main.async {
-            let cookieStore = WKWebsiteDataStore.default().httpCookieStore
+            let dataStore = WKWebsiteDataStore.default()
+            guard let url = options.url else {
+                dataStore.removeData(ofTypes: [WKWebsiteDataTypeCookies], modifiedSince: .distantPast) {
+                    completion(nil)
+                }
+                return
+            }
+            let cookieStore = dataStore.httpCookieStore
             cookieStore.getAllCookies { cookies in
                 let cookiesToDelete = cookies.filter { cookie in
-                    guard let url = options.url else {
-                        return true
-                    }
-                    return InAppBrowserHelper.isCookie(cookie, matchingURL: url)
+                    InAppBrowserHelper.isCookie(cookie, matchingURL: url)
                 }
                 let dispatchGroup = DispatchGroup()
                 for cookie in cookiesToDelete {

--- a/packages/in-app-browser/ios/Plugin/InAppBrowser.swift
+++ b/packages/in-app-browser/ios/Plugin/InAppBrowser.swift
@@ -24,11 +24,26 @@ import WebKit
         }
     }
 
-    @objc public func clearSessionData(completion: @escaping (_ error: Error?) -> Void) {
+    @objc public func clearCookies(_ options: ClearCookiesOptions, completion: @escaping (_ error: Error?) -> Void) {
         DispatchQueue.main.async {
-            let types: Set<String> = [WKWebsiteDataTypeCookies, WKWebsiteDataTypeLocalStorage, WKWebsiteDataTypeSessionStorage]
-            WKWebsiteDataStore.default().removeData(ofTypes: types, modifiedSince: .distantPast) {
-                completion(nil)
+            let cookieStore = WKWebsiteDataStore.default().httpCookieStore
+            cookieStore.getAllCookies { cookies in
+                let cookiesToDelete = cookies.filter { cookie in
+                    guard let url = options.url else {
+                        return true
+                    }
+                    return InAppBrowserHelper.isCookie(cookie, matchingURL: url)
+                }
+                let dispatchGroup = DispatchGroup()
+                for cookie in cookiesToDelete {
+                    dispatchGroup.enter()
+                    cookieStore.delete(cookie) {
+                        dispatchGroup.leave()
+                    }
+                }
+                dispatchGroup.notify(queue: .main) {
+                    completion(nil)
+                }
             }
         }
     }

--- a/packages/in-app-browser/ios/Plugin/InAppBrowserPlugin.swift
+++ b/packages/in-app-browser/ios/Plugin/InAppBrowserPlugin.swift
@@ -7,7 +7,7 @@ public class InAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
     public let jsName = "InAppBrowser"
     public let pluginMethods: [CAPPluginMethod] = [
         CAPPluginMethod(name: "clearCache", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "clearSessionData", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "clearCookies", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "close", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "executeScript", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getCookies", returnType: CAPPluginReturnPromise),
@@ -37,14 +37,20 @@ public class InAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
         })
     }
 
-    @objc func clearSessionData(_ call: CAPPluginCall) {
-        implementation?.clearSessionData(completion: { error in
-            if let error = error {
-                self.rejectCall(call, error)
-                return
-            }
-            self.resolveCall(call)
-        })
+    @objc func clearCookies(_ call: CAPPluginCall) {
+        do {
+            let options = try ClearCookiesOptions(call)
+
+            implementation?.clearCookies(options, completion: { error in
+                if let error = error {
+                    self.rejectCall(call, error)
+                    return
+                }
+                self.resolveCall(call)
+            })
+        } catch {
+            rejectCall(call, error)
+        }
     }
 
     @objc func close(_ call: CAPPluginCall) {

--- a/packages/in-app-browser/src/definitions.ts
+++ b/packages/in-app-browser/src/definitions.ts
@@ -10,13 +10,13 @@ export interface InAppBrowserPlugin {
    */
   clearCache(): Promise<void>;
   /**
-   * Clear the session data (cookies and web storage) of the web view.
+   * Clear the cookies of the web view.
    *
    * Only available on Android and iOS.
    *
-   * @since 0.1.0
+   * @since 0.2.0
    */
-  clearSessionData(): Promise<void>;
+  clearCookies(options?: ClearCookiesOptions): Promise<void>;
   /**
    * Close the currently open browser.
    *
@@ -512,6 +512,21 @@ export interface PostMessageOptions {
    * @since 0.1.0
    */
   data: { [key: string]: unknown };
+}
+
+/**
+ * @since 0.2.0
+ */
+export interface ClearCookiesOptions {
+  /**
+   * The URL to clear the cookies for.
+   *
+   * If not provided, all cookies are cleared.
+   *
+   * @example 'https://capawesome.io'
+   * @since 0.2.0
+   */
+  url?: string;
 }
 
 /**

--- a/packages/in-app-browser/src/definitions.ts
+++ b/packages/in-app-browser/src/definitions.ts
@@ -12,6 +12,9 @@ export interface InAppBrowserPlugin {
   /**
    * Clear the cookies of the web view.
    *
+   * Provide the `url` option to clear only the cookies of a specific URL.
+   * Otherwise, all cookies are cleared.
+   *
    * Only available on Android and iOS.
    *
    * @since 0.2.0

--- a/packages/in-app-browser/src/web.ts
+++ b/packages/in-app-browser/src/web.ts
@@ -14,7 +14,7 @@ export class InAppBrowserWeb extends WebPlugin implements InAppBrowserPlugin {
     throw this.unimplemented('Not implemented on web.');
   }
 
-  async clearSessionData(): Promise<void> {
+  async clearCookies(): Promise<void> {
     throw this.unimplemented('Not implemented on web.');
   }
 


### PR DESCRIPTION
## Summary

`InAppBrowser.clearSessionData()` deleted the cookies **and web storage** of all origins, including the app's own origin. Since the web storage is shared with the Capacitor web view, calling it corrupted the app's own state (localStorage, IndexedDB, cookies).

This PR replaces `clearSessionData()` with a new `clearCookies()` method that:

- only clears **cookies** (never touches web storage of the app's origin), and
- accepts an optional `url` to clear the cookies of a **specific URL** instead of all cookies.

```typescript
// Clear all cookies
await InAppBrowser.clearCookies();

// Clear only the cookies of a specific URL
await InAppBrowser.clearCookies({ url: 'https://capawesome.io' });
```

Web storage clearing was intentionally dropped: on Android the only available API (`WebStorage.deleteAllData()`) is all-or-nothing and cannot exclude the app's own origin, so it could not be offered safely. `clearCache()` remains available for cache clearing.

## Breaking change

`clearSessionData()` has been removed in favor of `clearCookies()`. See [`BREAKING.md`](packages/in-app-browser/BREAKING.md) for migration steps.

## Testing

Verified end-to-end on an Android emulator (API 35) and an iOS simulator (iPhone 16 Pro) using the example app:

| Check | Android | iOS |
|-------|---------|-----|
| `clearCookies({ url })` clears only that URL's cookies (a second origin's cookies remain) | ✅ | ✅ |
| `clearCookies()` clears all cookies | ✅ | ✅ |
| The app's own `localStorage` and `IndexedDB` survive (in-session) | ✅ | ✅ |
| The app's own storage survives after an app restart | ✅ | ✅ |

Also verified: Android compiles, iOS builds (`xcodebuild`), and `npm run build` / `eslint` / `prettier` / `swiftlint` pass.

## Pull request checklist

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).
- [x] I have read and followed the [pull request guidelines](https://capawesome.io/docs/contributing/pull-requests/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)