### PR TITLE
fix(live-update): validate HTTP status, ignore `URLCache` and overwrite leftover files on iOS

### DIFF
--- a/.changeset/lucky-planes-wonder.md
+++ b/.changeset/lucky-planes-wonder.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-live-update': patch
+---
+
+fix: validate HTTP status of file downloads, ignore the URL cache and overwrite leftover files from failed download attempts on iOS

--- a/packages/live-update/ios/Plugin/LiveUpdate.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdate.swift
@@ -463,7 +463,8 @@ import CommonCrypto
 
     private func downloadAndVerifyFile(url: String, file: URL, checksum: String?, signature: String?, callback: ((Progress) -> Void)?) async throws {
         let destination: DownloadRequest.Destination = { _, _ in
-            return (file, [.createIntermediateDirectories])
+            // `removePreviousFile` ensures that a leftover file from a failed attempt does not fail the download
+            return (file, [.createIntermediateDirectories, .removePreviousFile])
         }
         let urlComponents = URLComponents(string: url)!
         let result = try await httpClient.download(url: urlComponents.asURL(), destination: destination, callback: callback)

--- a/packages/live-update/ios/Plugin/LiveUpdateHttpClient.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdateHttpClient.swift
@@ -27,13 +27,16 @@ public class LiveUpdateHttpClient: NSObject {
 
     public func download(url: URL, destination: @escaping DownloadRequest.Destination, callback: ((Progress) -> Void)?) async throws -> AFDownloadResponse<Data> {
         var request = URLRequest(url: url)
+        // Ignore the URL cache so that a cached response is never replayed for a deterministic request URL
+        request.cachePolicy = .reloadIgnoringLocalCacheData
         request.httpMethod = HTTPMethod.get.rawValue
         request.timeoutInterval = Double(config.httpTimeout) / 1000.0
         if let deviceId = deviceId, !deviceId.isEmpty {
             request.setValue(deviceId, forHTTPHeaderField: "X-Capawesome-Device-Id")
         }
         return try await withCheckedThrowingContinuation { continuation in
-            AF.download(request, to: destination).downloadProgress { progress in
+            // `validate()` treats non-2xx responses as errors so that an error body is never saved as a bundle file
+            AF.download(request, to: destination).validate().downloadProgress { progress in
                 if let callback = callback {
                     callback(progress)
                 }
@@ -45,6 +48,8 @@ public class LiveUpdateHttpClient: NSObject {
 
     public func request<T: Decodable>(url: URL, type: T.Type) async throws -> AFDataResponse<T> {
         var request = URLRequest(url: url)
+        // Ignore the URL cache so that a cached response is never replayed for a deterministic request URL
+        request.cachePolicy = .reloadIgnoringLocalCacheData
         request.httpMethod = HTTPMethod.get.rawValue
         request.timeoutInterval = Double(config.httpTimeout) / 1000.0
         if let deviceId = deviceId, !deviceId.isEmpty {


### PR DESCRIPTION
This PR hardens the iOS HTTP layer of the Live Update plugin, aligning it with the existing Android behavior:

- Added `validate()` to file downloads so that non-2xx responses are treated as errors instead of their error body being written into the bundle as a regular file (Android already checks `response.isSuccessful()`).
- Set `cachePolicy = .reloadIgnoringLocalCacheData` on all plugin requests so that `URLCache` can never replay a stale response for the deterministic request URLs (Android's OkHttp client uses no cache).
- Added `removePreviousFile` to the download destination so that a leftover file from a previous failed attempt no longer causes the download to fail (Android truncates and overwrites).