### PR TITLE
fix(datetime-picker): present pickers from the bridge view controller on iOS

### DIFF
--- a/.changeset/datetime-picker-uiscene-compatibility.md
+++ b/.changeset/datetime-picker-uiscene-compatibility.md
@@ -1,0 +1,5 @@
+---
+'@capawesome-team/capacitor-datetime-picker': patch
+---
+
+fix(ios): present pickers from the Capacitor bridge view controller to support scene-based apps

--- a/packages/datetime-picker/ios/Plugin/DatetimePicker.swift
+++ b/packages/datetime-picker/ios/Plugin/DatetimePicker.swift
@@ -15,7 +15,8 @@ import Foundation
         closeKeyboard()
         DispatchQueue.main.asyncAfter(deadline: .now() + waitForKeyboardCloseSeconds) {
             RPicker.selectDate(title: "", cancelText: cancelButtonText, doneText: doneButtonText, datePickerMode: .dateAndTime, selectedDate: date,
-                               minDate: minDate, maxDate: maxDate, locale: locale, theme: self.getTheme(unconvertedTheme: theme), minuteInterval: minuteInterval, completion: { (date, errorCode) in
+                               minDate: minDate, maxDate: maxDate, locale: locale, theme: self.getTheme(unconvertedTheme: theme),
+                               minuteInterval: minuteInterval, presenter: self.plugin.bridge?.viewController, completion: { (date, errorCode) in
                                 completion(date, errorCode)
                                })
         }
@@ -26,7 +27,8 @@ import Foundation
         DispatchQueue.main.asyncAfter(deadline: .now() + waitForKeyboardCloseSeconds) {
             RPicker.selectDate(title: "", cancelText: cancelButtonText, doneText: doneButtonText,
                                datePickerMode: .date, selectedDate: date, minDate: minDate, maxDate: maxDate, locale: locale,
-                               theme: self.getTheme(unconvertedTheme: theme), completion: { (date, errorCode) in
+                               theme: self.getTheme(unconvertedTheme: theme), presenter: self.plugin.bridge?.viewController,
+                               completion: { (date, errorCode) in
                                 completion(date, errorCode)
                                })
         }
@@ -37,7 +39,8 @@ import Foundation
         DispatchQueue.main.asyncAfter(deadline: .now() + waitForKeyboardCloseSeconds) {
             MonthPicker.selectMonth(cancelText: cancelButtonText, doneText: doneButtonText, selectedDate: date,
                                     minDate: minDate, maxDate: maxDate, locale: locale,
-                                    theme: self.getTheme(unconvertedTheme: theme), completion: { (date, errorCode) in
+                                    theme: self.getTheme(unconvertedTheme: theme), presenter: self.plugin.bridge?.viewController,
+                                    completion: { (date, errorCode) in
                                         completion(date, errorCode)
                                     })
         }
@@ -48,7 +51,8 @@ import Foundation
         DispatchQueue.main.asyncAfter(deadline: .now() + waitForKeyboardCloseSeconds) {
             RPicker.selectDate(title: "", cancelText: cancelButtonText, doneText: doneButtonText,
                                datePickerMode: .time, selectedDate: date, locale: locale, style: DatetimePickerStyle.wheel,
-                               theme: self.getTheme(unconvertedTheme: theme), minuteInterval: minuteInterval, completion: { (date, errorCode) in
+                               theme: self.getTheme(unconvertedTheme: theme), minuteInterval: minuteInterval,
+                               presenter: self.plugin.bridge?.viewController, completion: { (date, errorCode) in
                                 completion(date, errorCode)
                                })
         }

--- a/packages/datetime-picker/ios/Plugin/DatetimePickerHelper.swift
+++ b/packages/datetime-picker/ios/Plugin/DatetimePickerHelper.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 public class DatetimePickerHelper {
     public static func convertStringToDate(_ format: String, _ value: String) -> Date? {
@@ -28,5 +29,24 @@ public class DatetimePickerHelper {
 
     public static func convertStringToLocale(_ value: String) -> Locale {
         return Locale(identifier: value)
+    }
+}
+
+extension UIViewController {
+
+    var topMostViewController: UIViewController {
+        if let nc = self as? UINavigationController {
+            if let last = nc.viewControllers.last {
+                return last.topMostViewController
+            }
+            return nc
+        }
+        if let tabController = self as? UITabBarController, let selected = tabController.selectedViewController {
+            return selected.topMostViewController
+        }
+        if let presented = presentedViewController {
+            return presented.topMostViewController
+        }
+        return self
     }
 }

--- a/packages/datetime-picker/ios/Plugin/DatetimePickerPlugin.swift
+++ b/packages/datetime-picker/ios/Plugin/DatetimePickerPlugin.swift
@@ -16,6 +16,7 @@ public class DatetimePickerPlugin: CAPPlugin, CAPBridgedPlugin {
     public let errorModeInvalid = "The provided mode is invalid."
     public let errorPickerCanceled = "The picker was canceled."
     public let errorPickerDismissed = "The picker was dismissed."
+    public let errorPickerUnavailable = "The picker could not be presented."
     public let errorCodeCanceled = "canceled"
     public let errorCodeDismissed = "dismissed"
 
@@ -62,6 +63,9 @@ public class DatetimePickerPlugin: CAPPlugin, CAPBridgedPlugin {
                 return
             case .dismissed:
                 call.reject(self.errorPickerDismissed, self.errorCodeDismissed, nil, nil)
+                return
+            case .unavailable:
+                call.reject(self.errorPickerUnavailable)
                 return
             case .none:
                 var value: String?

--- a/packages/datetime-picker/ios/Plugin/ErrorCode.swift
+++ b/packages/datetime-picker/ios/Plugin/ErrorCode.swift
@@ -2,4 +2,5 @@
     case none
     case canceled
     case dismissed
+    case unavailable
 }

--- a/packages/datetime-picker/ios/Plugin/MonthPickerViewController.swift
+++ b/packages/datetime-picker/ios/Plugin/MonthPickerViewController.swift
@@ -13,9 +13,10 @@ import UIKit
                                  maxDate: Date? = nil,
                                  locale: Locale? = nil,
                                  theme: Theme = .auto,
+                                 presenter: UIViewController?,
                                  completion: ((_ date: Date?, _ errorCode: ErrorCode) -> Void)?) {
 
-        guard let parent = UIApplication.topViewController() else { return }
+        guard let parent = presenter?.topMostViewController else { return }
         guard MonthPicker.sharedInstance.isPresented == false else { return }
 
         MonthPicker.sharedInstance.isPresented = true
@@ -391,27 +392,21 @@ private extension UIView {
     }
 }
 
-private extension UIApplication {
-    static var keyWindow: UIWindow? {
-        if #available(iOS 13.0, *) {
-            return UIApplication.shared.windows.filter { $0.isKeyWindow }.first
-        } else {
-            return UIApplication.shared.delegate?.window ?? nil
-        }
-    }
+private extension UIViewController {
 
-    static func topViewController(controller: UIViewController? = UIApplication.keyWindow?.rootViewController) -> UIViewController? {
-        if let nc = controller as? UINavigationController {
-            return topViewController(controller: nc.viewControllers.last ?? nc)
-        }
-        if let tabController = controller as? UITabBarController {
-            if let selected = tabController.selectedViewController {
-                return topViewController(controller: selected)
+    var topMostViewController: UIViewController {
+        if let nc = self as? UINavigationController {
+            if let last = nc.viewControllers.last {
+                return last.topMostViewController
             }
+            return nc
         }
-        if let presented = controller?.presentedViewController {
-            return topViewController(controller: presented)
+        if let tabController = self as? UITabBarController, let selected = tabController.selectedViewController {
+            return selected.topMostViewController
         }
-        return controller
+        if let presented = presentedViewController {
+            return presented.topMostViewController
+        }
+        return self
     }
 }

--- a/packages/datetime-picker/ios/Plugin/MonthPickerViewController.swift
+++ b/packages/datetime-picker/ios/Plugin/MonthPickerViewController.swift
@@ -16,8 +16,14 @@ import UIKit
                                  presenter: UIViewController?,
                                  completion: ((_ date: Date?, _ errorCode: ErrorCode) -> Void)?) {
 
-        guard let parent = presenter?.topMostViewController else { return }
-        guard MonthPicker.sharedInstance.isPresented == false else { return }
+        guard let parent = presenter?.topMostViewController else {
+            completion?(nil, ErrorCode.unavailable)
+            return
+        }
+        guard MonthPicker.sharedInstance.isPresented == false else {
+            completion?(nil, ErrorCode.unavailable)
+            return
+        }
 
         MonthPicker.sharedInstance.isPresented = true
 
@@ -392,21 +398,3 @@ private extension UIView {
     }
 }
 
-private extension UIViewController {
-
-    var topMostViewController: UIViewController {
-        if let nc = self as? UINavigationController {
-            if let last = nc.viewControllers.last {
-                return last.topMostViewController
-            }
-            return nc
-        }
-        if let tabController = self as? UITabBarController, let selected = tabController.selectedViewController {
-            return selected.topMostViewController
-        }
-        if let presented = presentedViewController {
-            return presented.topMostViewController
-        }
-        return self
-    }
-}

--- a/packages/datetime-picker/ios/Plugin/RPicker.swift
+++ b/packages/datetime-picker/ios/Plugin/RPicker.swift
@@ -47,10 +47,11 @@ import UIKit
                                 style: DatetimePickerStyle = .inline,
                                 theme: Theme = .auto,
                                 minuteInterval: Int = 1,
+                                presenter: UIViewController?,
                                 completion: ((_ date: Date?, _ errorCode: ErrorCode) -> Void)?) {
 
         guard let vc = controller(title: title, cancelText: cancelText, doneText: doneText, datePickerMode: datePickerMode,
-                                  selectedDate: selectedDate, minDate: minDate, maxDate: maxDate, locale: locale, style: style, theme: theme, minuteInterval: minuteInterval) else { return }
+                                  selectedDate: selectedDate, minDate: minDate, maxDate: maxDate, locale: locale, style: style, theme: theme, minuteInterval: minuteInterval, presenter: presenter) else { return }
 
         vc.onDateSelected = { (selectedData) in
             completion?(selectedData, ErrorCode.none)
@@ -73,9 +74,10 @@ import UIKit
                                   locale: Locale? = nil,
                                   style: DatetimePickerStyle = .inline,
                                   theme: Theme = .auto,
-                                  minuteInterval: Int = 1) -> RPickerController? {
+                                  minuteInterval: Int = 1,
+                                  presenter: UIViewController?) -> RPickerController? {
 
-        if let cc = UIWindow.currentController {
+        if let cc = presenter?.topMostViewController {
             if RPicker.sharedInstance.isPresented == false {
                 RPicker.sharedInstance.isPresented = true
 
@@ -423,45 +425,21 @@ class RPickerController: UIViewController {
 
 // MARK: - Private Extensions
 
-private extension UIApplication {
-    static var keyWindow: UIWindow? {
-        if #available(iOS 13.0, *) {
-            return UIApplication.shared.windows.filter {$0.isKeyWindow}.first
-        } else {
-            return UIApplication.shared.delegate?.window ?? nil
-        }
-    }
-}
+private extension UIViewController {
 
-private extension UIWindow {
-
-    static var currentController: UIViewController? {
-        return UIApplication.keyWindow?.currentController
-    }
-
-    var currentController: UIViewController? {
-        if let vc = self.rootViewController {
-            return topViewController(controller: vc)
-        }
-        return nil
-    }
-
-    func topViewController(controller: UIViewController? = UIApplication.keyWindow?.rootViewController) -> UIViewController? {
-        if let nc = controller as? UINavigationController {
-            if nc.viewControllers.count > 0 {
-                return topViewController(controller: nc.viewControllers.last!)
-            } else {
-                return nc
+    var topMostViewController: UIViewController {
+        if let nc = self as? UINavigationController {
+            if let last = nc.viewControllers.last {
+                return last.topMostViewController
             }
+            return nc
         }
-        if let tabController = controller as? UITabBarController {
-            if let selected = tabController.selectedViewController {
-                return topViewController(controller: selected)
-            }
+        if let tabController = self as? UITabBarController, let selected = tabController.selectedViewController {
+            return selected.topMostViewController
         }
-        if let presented = controller?.presentedViewController {
-            return topViewController(controller: presented)
+        if let presented = presentedViewController {
+            return presented.topMostViewController
         }
-        return controller
+        return self
     }
 }

--- a/packages/datetime-picker/ios/Plugin/RPicker.swift
+++ b/packages/datetime-picker/ios/Plugin/RPicker.swift
@@ -51,7 +51,10 @@ import UIKit
                                 completion: ((_ date: Date?, _ errorCode: ErrorCode) -> Void)?) {
 
         guard let vc = controller(title: title, cancelText: cancelText, doneText: doneText, datePickerMode: datePickerMode,
-                                  selectedDate: selectedDate, minDate: minDate, maxDate: maxDate, locale: locale, style: style, theme: theme, minuteInterval: minuteInterval, presenter: presenter) else { return }
+                                  selectedDate: selectedDate, minDate: minDate, maxDate: maxDate, locale: locale, style: style, theme: theme, minuteInterval: minuteInterval, presenter: presenter) else {
+            completion?(nil, ErrorCode.unavailable)
+            return
+        }
 
         vc.onDateSelected = { (selectedData) in
             completion?(selectedData, ErrorCode.none)
@@ -423,23 +426,3 @@ class RPickerController: UIViewController {
     }
 }
 
-// MARK: - Private Extensions
-
-private extension UIViewController {
-
-    var topMostViewController: UIViewController {
-        if let nc = self as? UINavigationController {
-            if let last = nc.viewControllers.last {
-                return last.topMostViewController
-            }
-            return nc
-        }
-        if let tabController = self as? UITabBarController, let selected = tabController.selectedViewController {
-            return selected.topMostViewController
-        }
-        if let presented = presentedViewController {
-            return presented.topMostViewController
-        }
-        return self
-    }
-}


### PR DESCRIPTION
## Motivation

On iOS, the pickers were presented on a view controller resolved through a global key window lookup based on `UIApplication.windows` (deprecated since iOS 15) and `UIApplication.delegate?.window`. With the scene-based app lifecycle used by the Capacitor 8.5 app template, this lookup is unreliable: it can resolve a window of the wrong scene in multi-window apps, and if no key window is found, the picker is silently never presented and the returned promise never settles.

## Changes

- Present pickers from the Capacitor bridge view controller, walked up to its top-most presented view controller, instead of a global key window lookup.
- Remove the deprecated `UIApplication.windows` / `keyWindow` helpers from `RPicker.swift` and `MonthPickerViewController.swift`.