### PR TITLE
fix(file-opener): resolve the key window via `UIWindowScene` on iOS

### DIFF
--- a/.changeset/file-opener-uiscene-compatibility.md
+++ b/.changeset/file-opener-uiscene-compatibility.md
@@ -1,0 +1,5 @@
+---
+'@capawesome-team/capacitor-file-opener': patch
+---
+
+fix(ios): resolve the key window via `UIWindowScene` to support scene-based apps

--- a/packages/file-opener/ios/Plugin/FileOpener.swift
+++ b/packages/file-opener/ios/Plugin/FileOpener.swift
@@ -64,10 +64,16 @@ import MobileCoreServices
 extension FileOpener: UIDocumentInteractionControllerDelegate {
     public func documentInteractionControllerViewControllerForPreview(_ controller: UIDocumentInteractionController) -> UIViewController {
         var viewController = self.plugin.bridge?.viewController
-        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
-        if viewController?.view.window != keyWindow {
-            viewController = keyWindow?.rootViewController
+        if viewController?.view.window?.isKeyWindow != true {
+            viewController = FileOpener.keyWindow?.rootViewController
         }
         return viewController ?? UIViewController()
+    }
+
+    private static var keyWindow: UIWindow? {
+        return UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .first(where: \.isKeyWindow)
     }
 }


### PR DESCRIPTION
## Motivation

The `UIDocumentInteractionControllerDelegate` implementation resolved the key window via `UIApplication.shared.windows`, which is deprecated since iOS 15 and unreliable with the scene-based app lifecycle used by the Capacitor 8.5 app template.

## Changes

- Resolve the key window via `UIApplication.shared.connectedScenes` / `UIWindowScene` instead of the deprecated `UIApplication.shared.windows`.
- Keep using the bridge view controller for the preview whenever its window is the key window (unchanged behavior).