### PR TITLE
fix(screen-orientation): resolve the window scene via the bridge view controller on iOS

### DIFF
--- a/.changeset/screen-orientation-uiscene-compatibility.md
+++ b/.changeset/screen-orientation-uiscene-compatibility.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-screen-orientation': patch
+---
+
+fix(ios): resolve the window scene via the Capacitor bridge to support scene-based apps

--- a/packages/screen-orientation/ios/Plugin/ScreenOrientation.swift
+++ b/packages/screen-orientation/ios/Plugin/ScreenOrientation.swift
@@ -8,6 +8,10 @@ import Capacitor
     private var currentOrientationType: String?
     private var lastOrientationType: String?
 
+    private var windowScene: UIWindowScene? {
+        return plugin.bridge?.viewController?.view.window?.windowScene
+    }
+
     init(plugin: ScreenOrientationPlugin) {
         self.plugin = plugin
         super.init()
@@ -70,7 +74,7 @@ import Capacitor
 
     @objc private func requestGeometryUpdate(orientationValue: Int, orientationMask: UIInterfaceOrientationMask) {
         if #available(iOS 16, *) {
-            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+            let windowScene = self.windowScene
             windowScene?.keyWindow?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
             windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: orientationMask)) { error in
                 CAPLog.print("requestGeometryUpdate failed.", error)
@@ -122,7 +126,7 @@ import Capacitor
         case UIInterfaceOrientation.portraitUpsideDown.rawValue:
             return UIInterfaceOrientationMask.portraitUpsideDown
         default:
-            let isPortrait = UIApplication.shared.windows.first?.windowScene?.interfaceOrientation.isPortrait ?? false
+            let isPortrait = windowScene?.interfaceOrientation.isPortrait ?? false
             return isPortrait ? UIInterfaceOrientationMask.portrait : UIInterfaceOrientationMask.landscape
         }
     }
@@ -176,7 +180,7 @@ import Capacitor
         case UIInterfaceOrientation.portraitUpsideDown.rawValue:
             return "portrait-secondary"
         default:
-            let isPortrait = UIApplication.shared.windows.first?.windowScene?.interfaceOrientation.isPortrait ?? false
+            let isPortrait = windowScene?.interfaceOrientation.isPortrait ?? false
             return isPortrait ? "portrait-primary" : "landscape-primary"
         }
     }


### PR DESCRIPTION
## Motivation

The window scene was resolved via `UIApplication.shared.connectedScenes.first` and the interface orientation via the deprecated `UIApplication.shared.windows.first`. Both can pick the wrong scene or window in multi-window apps, and the latter relies on API deprecated since iOS 15. With the scene-based app lifecycle used by the Capacitor 8.5 app template, these global lookups are unreliable.

## Changes

- Derive the window scene from the Capacitor bridge view controller's window via a new private `windowScene` helper.
- Use it for `requestGeometryUpdate(...)` and the interface orientation fallbacks.