### PR TITLE
fix(app-update): avoid deprecated PackageInfo.versionCode on Android

### DIFF
--- a/.changeset/app-update-deprecated-version-code.md
+++ b/.changeset/app-update-deprecated-version-code.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-app-update': patch
+---
+
+fix(android): resolve the version code via `PackageInfoCompat` to avoid a deprecation warning

--- a/packages/app-update/android/src/main/java/io/capawesome/capacitorjs/plugins/appupdate/AppUpdatePlugin.java
+++ b/packages/app-update/android/src/main/java/io/capawesome/capacitorjs/plugins/appupdate/AppUpdatePlugin.java
@@ -14,6 +14,7 @@ import androidx.activity.result.ActivityResult;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.IntentSenderRequest;
 import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.core.content.pm.PackageInfoCompat;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Logger;
 import com.getcapacitor.Plugin;
@@ -92,7 +93,7 @@ public class AppUpdatePlugin extends Plugin {
                 }
                 JSObject ret = new JSObject();
                 ret.put("currentVersionName", pInfo.versionName);
-                ret.put("currentVersionCode", String.valueOf(pInfo.versionCode));
+                ret.put("currentVersionCode", String.valueOf(PackageInfoCompat.getLongVersionCode(pInfo)));
                 ret.put("availableVersionCode", String.valueOf(appUpdateInfo.availableVersionCode()));
                 ret.put("updateAvailability", appUpdateInfo.updateAvailability());
                 ret.put("updatePriority", appUpdateInfo.updatePriority());


### PR DESCRIPTION
Android builds emitted a `uses or overrides a deprecated API` note for `AppUpdatePlugin.java`, caused by the `PackageInfo.versionCode` field that was deprecated in API 28.

Resolves the current version code via `PackageInfoCompat.getLongVersionCode(...)` instead, matching the approach already used in the `live-update` plugin. No `build.gradle` change needed — `androidx.core` is available transitively via `appcompat`.

Verified with `clean compileReleaseJavaWithJavac --rerun-tasks --no-build-cache`: the note is emitted before the change and gone after.

Closes #986