### PR TITLE
fix(live-update): report the actual plugin version on Android and iOS

### DIFF
--- a/.changeset/live-update-sync-native-plugin-version.md
+++ b/.changeset/live-update-sync-native-plugin-version.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-live-update': patch
+---
+
+fix: report the actual plugin version instead of a stale one on Android and iOS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: npm run release
+          version: npm run changeset:version
           commit: "chore(release): publish"
           title: "chore(release): publish"
         env:

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "affected:ios:pod:install": "turbo run ios:pod:install --affected --concurrency=1 --no-cache",
     "affected:ios:spm:install": "turbo run ios:spm:install --affected --concurrency=1 --no-cache",
     "changeset": "changeset",
+    "changeset:version": "changeset version && npm run version",
     "release": "npm run build && changeset publish",
     "release:preview": "pkg-pr-new publish './packages/*'",
     "postinstall": "patch-package",

--- a/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdatePlugin.java
+++ b/packages/live-update/android/src/main/java/io/capawesome/capacitorjs/plugins/liveupdate/LiveUpdatePlugin.java
@@ -37,7 +37,7 @@ import io.capawesome.capacitorjs.plugins.liveupdate.interfaces.Result;
 public class LiveUpdatePlugin extends Plugin {
 
     public static final String TAG = "LiveUpdate";
-    public static final String VERSION = "8.3.0";
+    public static final String VERSION = "8.4.0";
     public static final String SHARED_PREFERENCES_NAME = "CapawesomeLiveUpdate"; // DO NOT CHANGE
     public static final String ERROR_APP_ID_MISSING = "appId must be configured.";
     public static final String ERROR_BUNDLE_EXISTS = "bundle already exists.";

--- a/packages/live-update/ios/Plugin/LiveUpdatePlugin.swift
+++ b/packages/live-update/ios/Plugin/LiveUpdatePlugin.swift
@@ -8,7 +8,7 @@ import Capacitor
 @objc(LiveUpdatePlugin)
 public class LiveUpdatePlugin: CAPPlugin, CAPBridgedPlugin {
     public static let tag = "LiveUpdate"
-    public static let version = "8.3.0"
+    public static let version = "8.4.0"
     public static let userDefaultsPrefix = "CapawesomeLiveUpdate" // DO NOT CHANGE
 
     public let identifier = "LiveUpdatePlugin"

--- a/packages/live-update/package.json
+++ b/packages/live-update/package.json
@@ -60,7 +60,7 @@
     "verify:web": "npm run build",
     "e2e:android": "npm install --prefix example && npm run build && npm --prefix example run e2e:android",
     "e2e:ios": "npm install --prefix example && npm run build && npm --prefix example run e2e:ios",
-    "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
+    "lint": "npm run version:check && npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
     "eslint": "eslint . --ext ts",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\"",
@@ -70,6 +70,7 @@
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
     "version": "node scripts/sync-plugin-version.mjs",
+    "version:check": "node scripts/sync-plugin-version.mjs --check",
     "ios:pod:install": "cd ios && pod install --repo-update && cd ..",
     "prepublishOnly": "npm run build"
   },

--- a/packages/live-update/scripts/lib/file-helper.mjs
+++ b/packages/live-update/scripts/lib/file-helper.mjs
@@ -6,6 +6,19 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 
 /**
+ * Asserts that the given file contains the given expected value.
+ */
+export async function assertInFile(filePath, searchValue, expectedValue) {
+  const data = fs.readFileSync(filePath, 'utf8');
+  const actualValue = data.match(searchValue)?.[0] ?? 'no match';
+  if (actualValue !== expectedValue) {
+    throw new Error(
+      `Expected \`${expectedValue}\` in ${filePath}, but found \`${actualValue}\`. Run \`npm run version\` and commit the result.`,
+    );
+  }
+}
+
+/**
  * Joins the given parts into a path relative to the root of the project.
  */
 export function joinPath(...parts) {

--- a/packages/live-update/scripts/sync-plugin-version.mjs
+++ b/packages/live-update/scripts/sync-plugin-version.mjs
@@ -2,7 +2,7 @@
 import { readFile } from 'fs/promises';
 
 import { execute } from './lib/cli.mjs';
-import { joinPath, replaceInFile } from './lib/file-helper.mjs';
+import { assertInFile, joinPath, replaceInFile } from './lib/file-helper.mjs';
 
 execute(async () => {
   const packageJson = await readFile('./package.json')
@@ -12,27 +12,32 @@ execute(async () => {
   if (!version) {
     throw new Error('Could not read version from package.json');
   }
-  // Replace version in Android plugin
-  await replaceInFile(
-    joinPath(
-      'android',
-      'src',
-      'main',
-      'java',
-      'io',
-      'capawesome',
-      'capacitorjs',
-      'plugins',
-      'liveupdate',
-      'LiveUpdatePlugin.java'
-    ),
-    /public static final String VERSION = "(\d+\.\d+\.\d+)"/,
-    'public static final String VERSION = "' + version + '"'
-  );
-  // Replace version in iOS plugin
-  await replaceInFile(
-    joinPath('ios', 'Plugin', 'LiveUpdatePlugin.swift'),
-    /public static let version = "(\d+\.\d+\.\d+)"/,
-    'public static let version = "' + version + '"'
-  );
+  const targets = [
+    {
+      path: joinPath(
+        'android',
+        'src',
+        'main',
+        'java',
+        'io',
+        'capawesome',
+        'capacitorjs',
+        'plugins',
+        'liveupdate',
+        'LiveUpdatePlugin.java'
+      ),
+      pattern: /public static final String VERSION = "(\d+\.\d+\.\d+)"/,
+      replacement: 'public static final String VERSION = "' + version + '"',
+    },
+    {
+      path: joinPath('ios', 'Plugin', 'LiveUpdatePlugin.swift'),
+      pattern: /public static let version = "(\d+\.\d+\.\d+)"/,
+      replacement: 'public static let version = "' + version + '"',
+    },
+  ];
+  // Verify the version in the native plugins instead of updating it
+  const check = process.argv.includes('--check');
+  for (const target of targets) {
+    await (check ? assertInFile : replaceInFile)(target.path, target.pattern, target.replacement);
+  }
 });

--- a/turbo.json
+++ b/turbo.json
@@ -17,7 +17,9 @@
     "dev": {
       "cache": false
     },
-    "version": {},
+    "version": {
+      "cache": false
+    },
     "ios:pod:install": {},
     "ios:spm:install": {}
   }


### PR DESCRIPTION
`8.4.0` shipped with `8.3.0` hardcoded in both native plugin classes, so devices reported the wrong `pluginVersion` in telemetry. Reported in #970.

The cause is that `packages/live-update/scripts/sync-plugin-version.mjs` is wired to the npm `version` lifecycle script, which only fires for `npm version <bump>`. Releases run through Changesets, and `changeset version` bumps `package.json` directly — so the sync never ran and the constants drifted. Correcting the numbers alone would drift again on the next release.

## Changes

- Sync both native version constants to `8.4.0`.
- Add a `changeset:version` script that runs the native sync after `changeset version`, and point the Changesets action at it, so the constants stay in step with `package.json` on every release.
- Mark the `version` turbo task as uncacheable — it rewrites source files in place and declares no outputs, so a cache hit would silently skip the sync.
- Add a `--check` mode to the sync script and run it as part of the package's `lint`, so drift fails the build instead of reaching a release unnoticed. This matters because the release hook itself can stop working silently: `changesets/action` has already renamed the input to `version-script` on its main branch, so a future major bump would make `version:` an ignored key.

## Verification

The release path is not covered by CI, so it was exercised manually on this branch in a scratch worktree:

- `changeset version` alone bumps `package.json` to `8.4.1` and leaves the native constants at `8.4.0` — the drift reproduced.
- `npm run version` then rewrites both constants to `8.4.1`, and both files show up as modified, so the Changesets action commits them into the release PR.
- `npm run version:check` passes when the versions match and fails with an actionable message when either platform's constant is edited by hand.
