### PR TITLE
fix(google-sign-in): report the actual error code and message on Android and iOS

### DIFF
--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-google-sign-in': patch
+---
+
+fix(ios): expose the `SIGN_IN_CANCELED` error code and report a missing sign-in result with its own message

--- a/.changeset/quiet-hounds-listen.md
+++ b/.changeset/quiet-hounds-listen.md
@@ -2,4 +2,4 @@
 '@capawesome/capacitor-google-sign-in': patch
 ---
 
-fix(android): preserve the Credential Manager error type and add the `NO_CREDENTIAL_AVAILABLE` and `PROVIDER_CONFIGURATION_ERROR` error codes
+fix(android): preserve Credential Manager error details and add the `NO_CREDENTIAL_AVAILABLE` and `PROVIDER_CONFIGURATION_ERROR` error codes

--- a/.changeset/quiet-hounds-listen.md
+++ b/.changeset/quiet-hounds-listen.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-google-sign-in': patch
+---
+
+fix(android): preserve the Credential Manager error type and add the `NO_CREDENTIAL_AVAILABLE` and `PROVIDER_CONFIGURATION_ERROR` error codes

--- a/packages/google-sign-in/README.md
+++ b/packages/google-sign-in/README.md
@@ -67,6 +67,8 @@ npm install @capawesome/capacitor-google-sign-in
 npx cap sync
 ```
 
+On all platforms, your brand must be [verified](https://support.google.com/cloud/answer/13463073) for your app name to be shown on the Sign in with Google consent screen.
+
 ### Android
 
 Create an **Android** OAuth client in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials) in the same project as your web client:
@@ -364,6 +366,17 @@ On Web, the plugin uses a redirect-based OAuth flow. The `signIn(...)` method re
 ### How do I get an access token for Google APIs?
 
 Configure the `scopes` option in the `initialize(...)` method. The plugin then requests authorization in addition to authentication, which enables the `accessToken` and `serverAuthCode` properties in the sign-in result. If you need access and refresh tokens on your backend, exchange the `serverAuthCode` there, never client-side, as described in the [Security](#security) section.
+
+### Why does the sign-in flow fail on Android right after picking an account?
+
+If the account picker opens but the flow fails as soon as an account is picked, the app is most likely missing a matching Android OAuth client. Look for one of the following entries in the logcat output:
+
+```
+Auth.Api.Credentials: colz: [8] Unknown error [status=UNREGISTERED_ON_API_CONSOLE].
+Auth.Api.Credentials: colz: [16] Account reauth failed.
+```
+
+Google Play services reports this as a cancellation, so the plugin rejects the call with the `SIGN_IN_CANCELED` error code and `Account reauth failed` as the error message. Make sure that an Android OAuth client exists for the package name and the SHA-1 fingerprint of the certificate that signs the app, as described in the [Installation](#android) section. Builds distributed via Google Play must use the fingerprint of the app signing key, not the upload key.
 
 ## Related Plugins
 

--- a/packages/google-sign-in/README.md
+++ b/packages/google-sign-in/README.md
@@ -69,6 +69,20 @@ npx cap sync
 
 ### Android
 
+Create an **Android** OAuth client in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials) in the same project as your web client:
+
+- **Package name**: the application ID of your app (e.g. `com.example.app`), as defined in `android/app/build.gradle`.
+- **SHA-1 certificate fingerprint**: the fingerprint of the certificate that signs the app.
+
+**Attention**: The Android client ID is never passed to the plugin, because `initialize(...)` always receives the **web** client ID. The Android client must still exist and match the app, otherwise the sign-in flow fails.
+
+Which SHA-1 fingerprint to use depends on how the app is signed:
+
+- **Local debug builds**: the fingerprint of the debug keystore. Print it with `keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android`.
+- **Builds distributed via Google Play**: the fingerprint of the **app signing key**, not the upload key. Find it in the Google Play Console under `Test and release` › `Setup` › `App signing`.
+
+Add an OAuth client for every fingerprint you want to support. A missing fingerprint is the most common cause of a failing sign-in flow.
+
 #### Variables
 
 This plugin will use the following project variables (defined in your app's `variables.gradle` file):
@@ -130,16 +144,28 @@ const initialize = async () => {
 Start the Google Sign-In flow and retrieve the ID token (JWT) and the user's profile. Note that on Web, this redirects to the Google OAuth authorization page and the promise never resolves:
 
 ```typescript
-import { GoogleSignIn } from '@capawesome/capacitor-google-sign-in';
+import { ErrorCode, GoogleSignIn } from '@capawesome/capacitor-google-sign-in';
 
 const signIn = async () => {
-  const result = await GoogleSignIn.signIn();
-  console.log(result.idToken);
-  console.log(result.userId);
-  console.log(result.email);
-  console.log(result.displayName);
-  console.log(result.accessToken);
-  console.log(result.serverAuthCode);
+  try {
+    const result = await GoogleSignIn.signIn();
+    console.log(result.idToken);
+    console.log(result.userId);
+    console.log(result.email);
+    console.log(result.displayName);
+    console.log(result.accessToken);
+    console.log(result.serverAuthCode);
+  } catch (error) {
+    if (error.code === ErrorCode.SignInCanceled) {
+      console.log('The user canceled the sign-in flow.');
+    } else if (error.code === ErrorCode.NoCredentialAvailable) {
+      console.log('No Google account is available on this device.');
+    } else if (error.code === ErrorCode.ProviderConfigurationError) {
+      console.log('Google Play services is not available or not up to date.');
+    } else {
+      console.log('Another error occurred:', error);
+    }
+  }
 };
 ```
 

--- a/packages/google-sign-in/android/src/main/java/io/capawesome/capacitorjs/plugins/googlesignin/GoogleSignIn.java
+++ b/packages/google-sign-in/android/src/main/java/io/capawesome/capacitorjs/plugins/googlesignin/GoogleSignIn.java
@@ -7,9 +7,15 @@ import androidx.annotation.Nullable;
 import androidx.credentials.ClearCredentialStateRequest;
 import androidx.credentials.Credential;
 import androidx.credentials.CredentialManager;
+import androidx.credentials.CredentialManagerCallback;
 import androidx.credentials.CustomCredential;
 import androidx.credentials.GetCredentialRequest;
 import androidx.credentials.GetCredentialResponse;
+import androidx.credentials.exceptions.ClearCredentialException;
+import androidx.credentials.exceptions.GetCredentialCancellationException;
+import androidx.credentials.exceptions.GetCredentialException;
+import androidx.credentials.exceptions.GetCredentialProviderConfigurationException;
+import androidx.credentials.exceptions.NoCredentialException;
 import com.google.android.gms.auth.api.identity.AuthorizationRequest;
 import com.google.android.gms.auth.api.identity.AuthorizationResult;
 import com.google.android.gms.auth.api.identity.Identity;
@@ -90,21 +96,22 @@ public class GoogleSignIn {
             request,
             null,
             Runnable::run,
-            new androidx.credentials.CredentialManagerCallback<
-                GetCredentialResponse,
-                androidx.credentials.exceptions.GetCredentialException
-            >() {
+            new CredentialManagerCallback<GetCredentialResponse, GetCredentialException>() {
                 @Override
                 public void onResult(@NonNull GetCredentialResponse response) {
                     handleCredentialResponse(response, callback);
                 }
 
                 @Override
-                public void onError(@NonNull androidx.credentials.exceptions.GetCredentialException e) {
-                    if (e instanceof androidx.credentials.exceptions.GetCredentialCancellationException) {
+                public void onError(@NonNull GetCredentialException exception) {
+                    if (exception instanceof GetCredentialCancellationException) {
                         callback.error(CustomExceptions.SIGN_IN_CANCELED);
+                    } else if (exception instanceof NoCredentialException) {
+                        callback.error(CustomExceptions.NO_CREDENTIAL_AVAILABLE);
+                    } else if (exception instanceof GetCredentialProviderConfigurationException) {
+                        callback.error(CustomExceptions.PROVIDER_CONFIGURATION_ERROR);
                     } else {
-                        callback.error(new Exception(e.getMessage()));
+                        callback.error(createCredentialException(exception.getType(), exception.getErrorMessage(), exception));
                     }
                 }
             }
@@ -118,15 +125,15 @@ public class GoogleSignIn {
             request,
             null,
             Runnable::run,
-            new androidx.credentials.CredentialManagerCallback<Void, androidx.credentials.exceptions.ClearCredentialException>() {
+            new CredentialManagerCallback<Void, ClearCredentialException>() {
                 @Override
                 public void onResult(@NonNull Void result) {
                     callback.success();
                 }
 
                 @Override
-                public void onError(@NonNull androidx.credentials.exceptions.ClearCredentialException e) {
-                    callback.error(new Exception(e.getMessage()));
+                public void onError(@NonNull ClearCredentialException exception) {
+                    callback.error(createCredentialException(exception.getType(), exception.getErrorMessage(), exception));
                 }
             }
         );
@@ -246,9 +253,21 @@ public class GoogleSignIn {
                     callback.success(result);
                 }
             })
-            .addOnFailureListener(e -> {
-                callback.error(new Exception(e.getMessage()));
+            .addOnFailureListener(exception -> {
+                callback.error(new Exception(exception.getMessage(), exception));
             });
+    }
+
+    /**
+     * Creates an exception that always exposes the Credential Manager error type,
+     * because the error message alone may be absent or too generic to act on.
+     */
+    @NonNull
+    private Exception createCredentialException(@NonNull String type, @Nullable CharSequence errorMessage, @NonNull Exception cause) {
+        if (errorMessage == null || errorMessage.length() == 0) {
+            return new Exception(type, cause);
+        }
+        return new Exception(type + ": " + errorMessage, cause);
     }
 
     @Nullable

--- a/packages/google-sign-in/android/src/main/java/io/capawesome/capacitorjs/plugins/googlesignin/GoogleSignIn.java
+++ b/packages/google-sign-in/android/src/main/java/io/capawesome/capacitorjs/plugins/googlesignin/GoogleSignIn.java
@@ -21,6 +21,7 @@ import com.google.android.gms.auth.api.identity.AuthorizationResult;
 import com.google.android.gms.auth.api.identity.Identity;
 import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption;
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential;
+import io.capawesome.capacitorjs.plugins.googlesignin.classes.CustomException;
 import io.capawesome.capacitorjs.plugins.googlesignin.classes.CustomExceptions;
 import io.capawesome.capacitorjs.plugins.googlesignin.classes.options.InitializeOptions;
 import io.capawesome.capacitorjs.plugins.googlesignin.classes.options.SignInOptions;
@@ -105,7 +106,7 @@ public class GoogleSignIn {
                 @Override
                 public void onError(@NonNull GetCredentialException exception) {
                     if (exception instanceof GetCredentialCancellationException) {
-                        callback.error(CustomExceptions.SIGN_IN_CANCELED);
+                        callback.error(createSignInCanceledException(exception));
                     } else if (exception instanceof NoCredentialException) {
                         callback.error(CustomExceptions.NO_CREDENTIAL_AVAILABLE);
                     } else if (exception instanceof GetCredentialProviderConfigurationException) {
@@ -168,6 +169,15 @@ public class GoogleSignIn {
         NonEmptyResultCallback<SignInResult> callback = pendingSignInCallback;
         clearPendingState();
         callback.error(CustomExceptions.SIGN_IN_CANCELED);
+    }
+
+    public void handleAuthorizationFailed(@NonNull Exception exception) {
+        if (pendingSignInCallback == null) {
+            return;
+        }
+        NonEmptyResultCallback<SignInResult> callback = pendingSignInCallback;
+        clearPendingState();
+        callback.error(exception);
     }
 
     private void handleCredentialResponse(@NonNull GetCredentialResponse response, @NonNull NonEmptyResultCallback<SignInResult> callback) {
@@ -268,6 +278,21 @@ public class GoogleSignIn {
             return new Exception(type, cause);
         }
         return new Exception(type + ": " + errorMessage, cause);
+    }
+
+    /**
+     * Creates an exception for a canceled sign-in flow.
+     *
+     * Google Play services also reports configuration errors (e.g. a missing Android OAuth client)
+     * as a cancellation, so the original error message must be preserved to stay diagnosable.
+     */
+    @NonNull
+    private CustomException createSignInCanceledException(@NonNull GetCredentialException exception) {
+        CharSequence errorMessage = exception.getErrorMessage();
+        if (errorMessage == null || errorMessage.length() == 0) {
+            return CustomExceptions.SIGN_IN_CANCELED;
+        }
+        return new CustomException(CustomExceptions.SIGN_IN_CANCELED.getCode(), errorMessage.toString());
     }
 
     @Nullable

--- a/packages/google-sign-in/android/src/main/java/io/capawesome/capacitorjs/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google-sign-in/android/src/main/java/io/capawesome/capacitorjs/plugins/googlesignin/GoogleSignInPlugin.java
@@ -122,8 +122,8 @@ public class GoogleSignInPlugin extends Plugin {
                     result.getData()
                 );
                 implementation.handleAuthorizationResult(authResult);
-            } catch (Exception e) {
-                implementation.handleAuthorizationCanceled();
+            } catch (Exception exception) {
+                implementation.handleAuthorizationFailed(exception);
             }
         } else {
             implementation.handleAuthorizationCanceled();
@@ -139,12 +139,13 @@ public class GoogleSignInPlugin extends Plugin {
         if (message == null) {
             message = ERROR_UNKNOWN_ERROR;
         }
-        String code = null;
-        if (exception instanceof CustomException) {
-            code = ((CustomException) exception).getCode();
-        }
         Logger.error(TAG, message, exception);
-        call.reject(message, code);
+        String code = exception instanceof CustomException ? ((CustomException) exception).getCode() : null;
+        if (code == null) {
+            call.reject(message);
+        } else {
+            call.reject(message, code);
+        }
     }
 
     private void resolveCall(@NonNull PluginCall call) {

--- a/packages/google-sign-in/android/src/main/java/io/capawesome/capacitorjs/plugins/googlesignin/classes/CustomExceptions.java
+++ b/packages/google-sign-in/android/src/main/java/io/capawesome/capacitorjs/plugins/googlesignin/classes/CustomExceptions.java
@@ -3,9 +3,17 @@ package io.capawesome.capacitorjs.plugins.googlesignin.classes;
 public class CustomExceptions {
 
     public static final CustomException CLIENT_ID_MISSING = new CustomException(null, "clientId must be provided.");
+    public static final CustomException NO_CREDENTIAL_AVAILABLE = new CustomException(
+        "NO_CREDENTIAL_AVAILABLE",
+        "No Google account is available on this device."
+    );
     public static final CustomException NOT_INITIALIZED = new CustomException(
         null,
         "Google Sign-In is not initialized. Call initialize() first."
+    );
+    public static final CustomException PROVIDER_CONFIGURATION_ERROR = new CustomException(
+        "PROVIDER_CONFIGURATION_ERROR",
+        "The credential provider is not configured correctly. Make sure that Google Play services is available and up to date."
     );
     public static final CustomException SIGN_IN_CANCELED = new CustomException("SIGN_IN_CANCELED", "The user canceled the sign-in flow.");
 }

--- a/packages/google-sign-in/ios/Plugin/Enums/CustomError.swift
+++ b/packages/google-sign-in/ios/Plugin/Enums/CustomError.swift
@@ -5,8 +5,18 @@ public enum CustomError: Error {
     case iosClientIdMissing
     case signInCanceled
     case viewControllerUnavailable
+    case signInResultMissing
     case idTokenMissing
     case userIdMissing
+
+    public var code: String? {
+        switch self {
+        case .signInCanceled:
+            return "SIGN_IN_CANCELED"
+        default:
+            return nil
+        }
+    }
 }
 
 extension CustomError: LocalizedError {
@@ -20,19 +30,12 @@ extension CustomError: LocalizedError {
             return NSLocalizedString("The user canceled the sign-in flow.", comment: "signInCanceled")
         case .viewControllerUnavailable:
             return NSLocalizedString("viewController is not available.", comment: "viewControllerUnavailable")
+        case .signInResultMissing:
+            return NSLocalizedString("The sign-in result is missing.", comment: "signInResultMissing")
         case .idTokenMissing:
             return NSLocalizedString("ID token is missing from the sign-in result.", comment: "idTokenMissing")
         case .userIdMissing:
             return NSLocalizedString("User ID is missing from the sign-in result.", comment: "userIdMissing")
-        }
-    }
-
-    public var code: String? {
-        switch self {
-        case .signInCanceled:
-            return "SIGN_IN_CANCELED"
-        default:
-            return nil
         }
     }
 }

--- a/packages/google-sign-in/ios/Plugin/GoogleSignIn.swift
+++ b/packages/google-sign-in/ios/Plugin/GoogleSignIn.swift
@@ -32,7 +32,7 @@ import GoogleSignIn
                 return
             }
             guard let result = result else {
-                completion(nil, CustomError.idTokenMissing)
+                completion(nil, CustomError.signInResultMissing)
                 return
             }
             let user = result.user

--- a/packages/google-sign-in/ios/Plugin/GoogleSignInPlugin.swift
+++ b/packages/google-sign-in/ios/Plugin/GoogleSignInPlugin.swift
@@ -64,7 +64,11 @@ public class GoogleSignInPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private func rejectCall(_ call: CAPPluginCall, _ error: Error) {
         CAPLog.print("[", self.tag, "] ", error)
-        call.reject(error.localizedDescription)
+        if let error = error as? CustomError {
+            call.reject(error.localizedDescription, error.code)
+        } else {
+            call.reject(error.localizedDescription)
+        }
     }
 
     private func resolveCall(_ call: CAPPluginCall) {

--- a/packages/google-sign-in/src/definitions.ts
+++ b/packages/google-sign-in/src/definitions.ts
@@ -169,6 +169,22 @@ export interface SignInResult {
  */
 export enum ErrorCode {
   /**
+   * No Google account is available on the device.
+   *
+   * Only available on Android.
+   *
+   * @since 0.1.3
+   */
+  NoCredentialAvailable = 'NO_CREDENTIAL_AVAILABLE',
+  /**
+   * The credential provider is not configured correctly.
+   *
+   * Only available on Android.
+   *
+   * @since 0.1.3
+   */
+  ProviderConfigurationError = 'PROVIDER_CONFIGURATION_ERROR',
+  /**
    * The user canceled the sign-in flow.
    *
    * @since 0.1.0


### PR DESCRIPTION
## Problem

Sign-in fails on Android right after an account is picked, and the plugin reports it as a user cancellation.

Google Play services rejects the flow with `UNREGISTERED_ON_API_CONSOLE` when no Android OAuth client matches the app's package name and signing certificate, and then surfaces it as status code `16` (`CommonStatusCodes.CANCELED`). `androidx.credentials` maps that status to `GetCredentialCancellationException`, which the plugin translated into `SIGN_IN_CANCELED` / `The user canceled the sign-in flow.` — discarding the real reason and leaving Logcat as the only place to find it:

```
Auth.Api.Credentials: colz: [8] Unknown error [status=UNREGISTERED_ON_API_CONSOLE].
Auth.Api.Credentials: colz: [16] Account reauth failed.
```

Every other failure was stripped down the same way:

```java
callback.error(new Exception(e.getMessage()));
```

`GetCredentialException.getMessage()` returns `errorMessage`, which is nullable. When it is `null`, the plugin falls back to `An unknown error has occurred.` with no error code, no exception type and no cause — so nothing reaches the developer. The exception type (`TYPE_NO_CREDENTIAL`, `TYPE_GET_CREDENTIAL_PROVIDER_CONFIGURATION_EXCEPTION`, ...) was never surfaced, even though it is the one piece of information that identifies the actual problem. The same pattern existed in `signOut(...)` for `ClearCredentialException` and in the authorization failure listener.

On iOS, `rejectCall(...)` never read `CustomError.code`, so `SIGN_IN_CANCELED` never reached the webview at all, even though it has been documented since `0.1.0`.

## Changes

### Android

- Preserve the Credential Manager message when a failure is reported as a cancellation, so a misconfigured OAuth client surfaces as `[16] Account reauth failed` instead of `The user canceled the sign-in flow.`. The `SIGN_IN_CANCELED` error code stays unchanged.
- Map `NoCredentialException` to a new `NO_CREDENTIAL_AVAILABLE` error code and `GetCredentialProviderConfigurationException` to a new `PROVIDER_CONFIGURATION_ERROR` error code. Both are Credential Manager concepts without an iOS or Web equivalent and are documented as Android-only.
- Route every other Credential Manager error through a helper that always prefixes the exception type and passes the original exception as the cause, so the message is never empty and `Logger.error(...)` prints the full cause chain to Logcat.
- Reject with the actual exception when the authorization result cannot be parsed, instead of reporting it as a cancellation and swallowing the exception.
- Keep the original exception as the cause when the authorization request fails.
- Replace the inline `androidx.credentials.exceptions.*` fully qualified names with imports.

### iOS

- Pass the error code to `call.reject(...)` so that `SIGN_IN_CANCELED` can be handled by the caller.
- Report a missing sign-in result as `The sign-in result is missing.` instead of `ID token is missing from the sign-in result.`.
- Move `code` into the `CustomError` enum body, leaving only `errorDescription` in the `LocalizedError` extension.

### Documentation

- Document the Android setup in the README: an Android OAuth client with the package name and SHA-1 fingerprint is required, the fingerprint of the Google Play app signing key must be used for builds distributed via Google Play (not the upload key), and the client must live in the same project as the web client. The Android section previously only listed the Gradle variables, while the Android client ID is never passed to the plugin, which makes this requirement easy to miss.
- Add an FAQ entry keyed on the Logcat output above, so the failure can be found by the symptom developers actually see.
- Note that brand verification is required for the app name to appear on the Sign in with Google consent screen.
- Add error handling to the sign-in example.

## Notes

The root cause of the report is a Google Cloud Console configuration issue rather than a plugin defect, but the plugin made it undiagnosable by reporting it as a user cancellation. The documentation covers the configuration, and the error handling now surfaces the real reason.

The discussion suspected a missing `setFilterByAuthorizedAccounts(false)` fallback, but that option only exists on `GetGoogleIdOption`. The plugin uses `GetSignInWithGoogleOption`, whose builder only exposes `setHostedDomainFilter(...)` and `setNonce(...)`, and which always shows all accounts on the device. So there is no authorized-accounts filter to fall back from.

Both platforms build, but the `[16] Account reauth failed` passthrough and the iOS error code still need to be verified on a device.

Close #991
