### PR TITLE
fix(asset-manager): detect whether an asset is a file or a directory on Android

### DIFF
--- a/.changeset/tame-ducks-copy.md
+++ b/.changeset/tame-ducks-copy.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-asset-manager': patch
+---
+
+fix(android): detect whether an asset is a file or a directory instead of guessing from the file name

--- a/packages/asset-manager/android/src/main/java/io/capawesome/capacitorjs/plugins/assetmanager/AssetManager.java
+++ b/packages/asset-manager/android/src/main/java/io/capawesome/capacitorjs/plugins/assetmanager/AssetManager.java
@@ -68,12 +68,7 @@ public class AssetManager {
     }
 
     private void copy(String from, String to) throws IOException {
-        android.content.res.AssetManager assets = plugin.getContext().getAssets();
-
-        String fromLastSegment = from.substring(from.lastIndexOf("/") + 1);
-        boolean isFromDirectory = !fromLastSegment.contains(".");
-
-        if (isFromDirectory) {
+        if (isDirectory(from)) {
             copyDirectory(from, to);
         } else {
             copyFile(from, to);
@@ -107,6 +102,11 @@ public class AssetManager {
         }
         out.close();
         input.close();
+    }
+
+    private boolean isDirectory(String path) throws IOException {
+        String[] files = plugin.getContext().getAssets().list(path);
+        return files != null && files.length > 0;
     }
 
     private String readFileAsBase64EncodedData(InputStream inputStream) throws IOException {

--- a/packages/asset-manager/android/src/main/java/io/capawesome/capacitorjs/plugins/assetmanager/AssetManager.java
+++ b/packages/asset-manager/android/src/main/java/io/capawesome/capacitorjs/plugins/assetmanager/AssetManager.java
@@ -106,6 +106,7 @@ public class AssetManager {
 
     private boolean isDirectory(String path) throws IOException {
         String[] files = plugin.getContext().getAssets().list(path);
+        // Only file entries are packaged, so an empty listing means the path is a file or does not exist.
         return files != null && files.length > 0;
     }
 


### PR DESCRIPTION
`AssetManager.copy()` decided whether an asset was a file or a directory by checking the last path segment for a dot. Asset files without an extension were therefore treated as directories, and asset directories containing a dot were treated as files — both failed to copy.

`copy()` now asks the asset manager instead: a new `isDirectory(path)` helper treats a path as a directory when `assets.list(path)` returns entries. Copying a non-existent path still rejects with `FileNotFoundException`, as before.

iOS is unaffected — `AssetManager.swift` uses `FileManager.copyItem`, which handles files and directories alike.

Close #997
