### PR TITLE
Add Guides sections linking recent blog posts to their plugins

### DIFF
--- a/packages/maplibre/README.md
+++ b/packages/maplibre/README.md
@@ -47,6 +47,10 @@ The MapLibre plugin is typically used wherever you want to show geographical dat
 | -------------- | ----------------- | -------------- |
 | 0.x.x          | >=8.x.x           | Active support |
 
+## Guides
+
+- [A Google Maps Alternative for Capacitor Apps](https://capawesome.io/blog/alternative-to-the-capacitor-google-maps-plugin/): Compares `@capacitor/google-maps` with this plugin — no billing account, no API key, and Web support.
+
 ## Installation
 
 You can use our **AI-Assisted Setup** to install the plugin.


### PR DESCRIPTION
## Summary

Adds a `## Guides` section (after Compatibility, before Installation, matching the existing convention) to plugins that recently got a dedicated blog guide but had none yet:

- `health`: Migrating from Google Fit to Health Connect
- `file-transfer`: cordova-plugin-file-transfer alternative
- `watch`: Wear OS app guide
- `geofences`: plugin announcement
- `maplibre`: Google Maps alternative
- `audio-player`: background audio playback guide

Also fixes a broken blog link in `contacts/README.md` (stray `.md/` in the URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)