### PR TITLE
feat(mail-composer)!: allow attaching base64 strings as files

### DIFF
--- a/.changeset/mail-composer-base64-attachments.md
+++ b/.changeset/mail-composer-base64-attachments.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-mail-composer': minor
+---
+
+feat!: allow attaching base64 strings as files (see `BREAKING.md`)

--- a/packages/mail-composer/BREAKING.md
+++ b/packages/mail-composer/BREAKING.md
@@ -1,3 +1,29 @@
 # Breaking Changes
 
-This is a comprehensive list of the breaking changes introduced in the major version releases.
+This is a comprehensive list of the breaking changes introduced in the different releases.
+
+## Versions
+
+- [Version 0.2.x](#version-02x)
+
+## Version 0.2.x
+
+### `attachments` option
+
+The `attachments` option of the `composeMail(...)` method is now an array of objects instead of an array of strings. Use the `path` property to attach a file from the file system:
+
+```typescript
+// Before
+await MailComposer.composeMail({ attachments: ['/path/to/file.pdf'] });
+
+// After
+await MailComposer.composeMail({ attachments: [{ path: '/path/to/file.pdf' }] });
+```
+
+Alternatively, use the new `data` and `name` properties to attach a file from a base64 string without writing it to the file system first:
+
+```typescript
+await MailComposer.composeMail({
+  attachments: [{ data: 'SGVsbG8gV29ybGQ=', name: 'log.txt' }],
+});
+```

--- a/packages/mail-composer/README.md
+++ b/packages/mail-composer/README.md
@@ -11,7 +11,7 @@ Capacitor plugin to open the native email composer.
 ## Features
 
 - ✉️ **Compose**: Open the native email composer prefilled with recipients, subject and body.
-- 📎 **Attachments**: Attach one or more files to the email.
+- 📎 **Attachments**: Attach one or more files from the file system or from base64 strings.
 - ✅ **Availability**: Check whether the device is able to compose and send emails.
 - 🌐 **Cross-platform**: Supports Android, iOS and the web (via `mailto:`).
 - 🤝 **Compatibility**: Works alongside the [File Picker](https://capawesome.io/docs/sdks/capacitor/file-picker/), [Phone Dialer](https://capawesome.io/docs/sdks/capacitor/phone-dialer/) and [SMS Composer](https://capawesome.io/docs/sdks/capacitor/sms-composer/) plugins.
@@ -25,7 +25,7 @@ Missing a feature? Just [open an issue](https://github.com/capawesome-team/capac
 The Mail Composer plugin is typically used whenever an app wants the user to send an email, for example:
 
 - **Support and feedback**: Open a prefilled email to your support address with a subject and body so users can reach out with one tap.
-- **Bug reports**: Attach log files or screenshots to a bug report email using the `attachments` option.
+- **Bug reports**: Attach log files or screenshots to a bug report email using the `attachments` option, either from the file system or directly from a base64 string.
 - **Sharing content**: Let users share content from your app via email with prefilled recipients, subject, and body.
 - **Invitations**: Prefill invitation emails with CC and BCC recipients that the user only needs to review and send.
 
@@ -62,6 +62,8 @@ npx cap sync
 #### Attachments
 
 To attach files, the plugin uses the [`FileProvider`](https://developer.android.com/reference/androidx/core/content/FileProvider) that Capacitor already registers for your app (authority `${applicationId}.fileprovider`). Make sure that the directories your attachments are stored in are covered by the `res/xml/file_paths.xml` resource of your app. Otherwise, the `composeMail(...)` method will reject with an error.
+
+Attachments that are provided as base64 strings are written to the cache directory of your app, which the default `res/xml/file_paths.xml` resource of a Capacitor app already covers with a `cache-path` entry.
 
 ### Web
 
@@ -107,6 +109,25 @@ const composeMail = async () => {
     body: 'This is the body of the email.',
   });
   return status;
+};
+```
+
+### Compose an email with attachments
+
+Attach a file from the file system using the `path` property, or attach a file that only exists in memory using the `data` and `name` properties. Attachments are not supported on the web:
+
+```typescript
+import { MailComposer } from '@capawesome/capacitor-mail-composer';
+
+const composeMailWithAttachments = async () => {
+  await MailComposer.composeMail({
+    to: ['support@example.com'],
+    subject: 'Bug report',
+    attachments: [
+      { path: '/path/to/screenshot.png' },
+      { data: 'SGVsbG8gV29ybGQ=', name: 'log.txt' },
+    ],
+  });
 };
 ```
 
@@ -184,15 +205,24 @@ never sends the email itself.
 
 #### ComposeMailOptions
 
-| Prop              | Type                  | Description                                                                                                                                                                                         | Default            | Since |
-| ----------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
-| **`attachments`** | <code>string[]</code> | The absolute file paths or `file://` URIs of the files to attach. Attachments are not supported on the web.                                                                                         |                    | 0.1.0 |
-| **`bcc`**         | <code>string[]</code> | The email addresses of the blind carbon copy (BCC) recipients.                                                                                                                                      |                    | 0.1.0 |
-| **`body`**        | <code>string</code>   | The body of the email.                                                                                                                                                                              |                    | 0.1.0 |
-| **`cc`**          | <code>string[]</code> | The email addresses of the carbon copy (CC) recipients.                                                                                                                                             |                    | 0.1.0 |
-| **`isHtml`**      | <code>boolean</code>  | Whether the body should be interpreted as HTML. **Note**: On Android, HTML is best-effort as many mail apps ignore it. On the web, HTML is not supported and the body is always sent as plain text. | <code>false</code> | 0.1.0 |
-| **`subject`**     | <code>string</code>   | The subject of the email.                                                                                                                                                                           |                    | 0.1.0 |
-| **`to`**          | <code>string[]</code> | The email addresses of the primary recipients.                                                                                                                                                      |                    | 0.1.0 |
+| Prop              | Type                          | Description                                                                                                                                                                                         | Default            | Since |
+| ----------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
+| **`attachments`** | <code>MailAttachment[]</code> | The files to attach to the email. Attachments are not supported on the web.                                                                                                                         |                    | 0.1.0 |
+| **`bcc`**         | <code>string[]</code>         | The email addresses of the blind carbon copy (BCC) recipients.                                                                                                                                      |                    | 0.1.0 |
+| **`body`**        | <code>string</code>           | The body of the email.                                                                                                                                                                              |                    | 0.1.0 |
+| **`cc`**          | <code>string[]</code>         | The email addresses of the carbon copy (CC) recipients.                                                                                                                                             |                    | 0.1.0 |
+| **`isHtml`**      | <code>boolean</code>          | Whether the body should be interpreted as HTML. **Note**: On Android, HTML is best-effort as many mail apps ignore it. On the web, HTML is not supported and the body is always sent as plain text. | <code>false</code> | 0.1.0 |
+| **`subject`**     | <code>string</code>           | The subject of the email.                                                                                                                                                                           |                    | 0.1.0 |
+| **`to`**          | <code>string[]</code>         | The email addresses of the primary recipients.                                                                                                                                                      |                    | 0.1.0 |
+
+
+#### MailAttachment
+
+| Prop       | Type                | Description                                                                                                                                                                                | Since |
+| ---------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
+| **`data`** | <code>string</code> | The content of the file to attach, encoded as a base64 string. Either `data` or `path` must be provided. If both are provided, `path` is used.                                             | 0.2.0 |
+| **`name`** | <code>string</code> | The file name of the attachment, including the file extension. Must be provided if `data` is provided. Ignored if `path` is provided, because the file name is then derived from the path. | 0.2.0 |
+| **`path`** | <code>string</code> | The absolute file path or `file://` URI of the file to attach. Either `data` or `path` must be provided.                                                                                   | 0.2.0 |
 
 
 ### Type Aliases
@@ -240,6 +270,10 @@ On iOS, `composeMail` rejects as unavailable if no mail account is configured on
 ### Why does attaching a file fail on Android?
 
 On Android, the plugin shares attachments through the [`FileProvider`](https://developer.android.com/reference/androidx/core/content/FileProvider) that Capacitor already registers for your app. If the directory a file is stored in is not covered by the `res/xml/file_paths.xml` resource of your app, `composeMail` rejects with an error. See the [Installation](#installation) section for details.
+
+### How do I attach a file that is not stored on the file system?
+
+Provide the content of the file as a base64 string using the `data` property of an attachment and set the `name` property to the file name including the file extension. This is useful for files that only exist in memory, for example a log file that you keep in IndexedDB. The plugin takes care of handing the content over to the mail app, so you do not need to write the file to the file system yourself.
 
 ### Are attachments supported on the web?
 

--- a/packages/mail-composer/android/src/main/java/io/capawesome/capacitorjs/plugins/mailcomposer/MailComposer.java
+++ b/packages/mail-composer/android/src/main/java/io/capawesome/capacitorjs/plugins/mailcomposer/MailComposer.java
@@ -8,13 +8,18 @@ import androidx.annotation.NonNull;
 import androidx.core.content.FileProvider;
 import io.capawesome.capacitorjs.plugins.mailcomposer.classes.CustomExceptions;
 import io.capawesome.capacitorjs.plugins.mailcomposer.classes.options.ComposeMailOptions;
+import io.capawesome.capacitorjs.plugins.mailcomposer.classes.options.MailAttachment;
 import io.capawesome.capacitorjs.plugins.mailcomposer.classes.results.CanComposeMailResult;
 import io.capawesome.capacitorjs.plugins.mailcomposer.interfaces.NonEmptyResultCallback;
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 public class MailComposer {
+
+    private static final String ATTACHMENTS_DIRECTORY_NAME = "capawesome_capacitor_mail_composer_attachments";
 
     @NonNull
     private final MailComposerPlugin plugin;
@@ -82,19 +87,32 @@ public class MailComposer {
     }
 
     @NonNull
-    private List<Uri> createAttachmentUris(@NonNull List<String> attachments) throws Exception {
+    private File createAttachmentFile(@NonNull MailAttachment attachment) throws IOException {
+        File directory = getAttachmentsDirectory();
+        directory.mkdirs();
+        File file = new File(directory, attachment.getName());
+        try (FileOutputStream outputStream = new FileOutputStream(file)) {
+            outputStream.write(attachment.getData());
+        }
+        return file;
+    }
+
+    @NonNull
+    private List<Uri> createAttachmentUris(@NonNull List<MailAttachment> attachments) throws Exception {
+        deleteAttachmentFiles();
         List<Uri> uris = new ArrayList<>();
-        for (String attachment : attachments) {
-            File file = createFile(attachment);
-            if (!file.exists()) {
-                throw CustomExceptions.ATTACHMENT_NOT_FOUND;
+        for (MailAttachment attachment : attachments) {
+            String path = attachment.getPath();
+            File file;
+            if (path == null) {
+                file = createAttachmentFile(attachment);
+            } else {
+                file = createFile(path);
+                if (!file.exists()) {
+                    throw CustomExceptions.ATTACHMENT_NOT_FOUND;
+                }
             }
-            try {
-                String authority = getContext().getPackageName() + ".fileprovider";
-                uris.add(FileProvider.getUriForFile(getContext(), authority, file));
-            } catch (IllegalArgumentException exception) {
-                throw CustomExceptions.ATTACHMENT_NOT_FOUND;
-            }
+            uris.add(createUriForFile(file));
         }
         return uris;
     }
@@ -111,6 +129,31 @@ public class MailComposer {
     @NonNull
     private Intent createMailtoIntent() {
         return new Intent(Intent.ACTION_SENDTO, Uri.parse("mailto:"));
+    }
+
+    @NonNull
+    private Uri createUriForFile(@NonNull File file) throws Exception {
+        try {
+            String authority = getContext().getPackageName() + ".fileprovider";
+            return FileProvider.getUriForFile(getContext(), authority, file);
+        } catch (IllegalArgumentException exception) {
+            throw CustomExceptions.ATTACHMENT_NOT_FOUND;
+        }
+    }
+
+    private void deleteAttachmentFiles() {
+        File[] files = getAttachmentsDirectory().listFiles();
+        if (files == null) {
+            return;
+        }
+        for (File file : files) {
+            file.delete();
+        }
+    }
+
+    @NonNull
+    private File getAttachmentsDirectory() {
+        return new File(getContext().getCacheDir(), ATTACHMENTS_DIRECTORY_NAME);
     }
 
     @NonNull

--- a/packages/mail-composer/android/src/main/java/io/capawesome/capacitorjs/plugins/mailcomposer/classes/CustomExceptions.java
+++ b/packages/mail-composer/android/src/main/java/io/capawesome/capacitorjs/plugins/mailcomposer/classes/CustomExceptions.java
@@ -2,6 +2,12 @@ package io.capawesome.capacitorjs.plugins.mailcomposer.classes;
 
 public class CustomExceptions {
 
+    public static final CustomException ATTACHMENT_DATA_INVALID = new CustomException(null, "data must be a valid base64 string.");
+    public static final CustomException ATTACHMENT_DATA_OR_PATH_MISSING = new CustomException(
+        null,
+        "Either data or path must be provided for an attachment."
+    );
+    public static final CustomException ATTACHMENT_NAME_MISSING = new CustomException(null, "name must be provided if data is provided.");
     public static final CustomException ATTACHMENT_NOT_FOUND = new CustomException(
         "ATTACHMENT_NOT_FOUND",
         "An attachment could not be found at the provided path."

--- a/packages/mail-composer/android/src/main/java/io/capawesome/capacitorjs/plugins/mailcomposer/classes/options/ComposeMailOptions.java
+++ b/packages/mail-composer/android/src/main/java/io/capawesome/capacitorjs/plugins/mailcomposer/classes/options/ComposeMailOptions.java
@@ -6,12 +6,12 @@ import com.getcapacitor.JSArray;
 import com.getcapacitor.PluginCall;
 import java.util.ArrayList;
 import java.util.List;
-import org.json.JSONException;
+import org.json.JSONObject;
 
 public class ComposeMailOptions {
 
     @NonNull
-    private final List<String> attachments;
+    private final List<MailAttachment> attachments;
 
     @NonNull
     private final List<String> bcc;
@@ -30,18 +30,18 @@ public class ComposeMailOptions {
     @NonNull
     private final List<String> to;
 
-    public ComposeMailOptions(@NonNull PluginCall call) throws JSONException {
+    public ComposeMailOptions(@NonNull PluginCall call) throws Exception {
         this.to = getStringListFromCall(call, "to");
         this.cc = getStringListFromCall(call, "cc");
         this.bcc = getStringListFromCall(call, "bcc");
         this.subject = call.getString("subject");
         this.body = call.getString("body");
         this.isHtml = call.getBoolean("isHtml", false);
-        this.attachments = getStringListFromCall(call, "attachments");
+        this.attachments = getAttachmentsFromCall(call);
     }
 
     @NonNull
-    public List<String> getAttachments() {
+    public List<MailAttachment> getAttachments() {
         return attachments;
     }
 
@@ -75,7 +75,20 @@ public class ComposeMailOptions {
     }
 
     @NonNull
-    private static List<String> getStringListFromCall(@NonNull PluginCall call, @NonNull String key) throws JSONException {
+    private static List<MailAttachment> getAttachmentsFromCall(@NonNull PluginCall call) throws Exception {
+        List<MailAttachment> attachments = new ArrayList<>();
+        JSArray array = call.getArray("attachments");
+        if (array != null) {
+            for (int i = 0; i < array.length(); i++) {
+                JSONObject object = array.getJSONObject(i);
+                attachments.add(new MailAttachment(object));
+            }
+        }
+        return attachments;
+    }
+
+    @NonNull
+    private static List<String> getStringListFromCall(@NonNull PluginCall call, @NonNull String key) throws Exception {
         List<String> values = new ArrayList<>();
         JSArray array = call.getArray(key);
         if (array != null) {

--- a/packages/mail-composer/android/src/main/java/io/capawesome/capacitorjs/plugins/mailcomposer/classes/options/MailAttachment.java
+++ b/packages/mail-composer/android/src/main/java/io/capawesome/capacitorjs/plugins/mailcomposer/classes/options/MailAttachment.java
@@ -4,6 +4,7 @@ import android.util.Base64;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import io.capawesome.capacitorjs.plugins.mailcomposer.classes.CustomExceptions;
+import java.io.File;
 import org.json.JSONObject;
 
 public class MailAttachment {
@@ -18,19 +19,19 @@ public class MailAttachment {
     private final String path;
 
     public MailAttachment(@NonNull JSONObject object) throws Exception {
-        String data = getStringFromObject(object, "data");
-        this.name = getStringFromObject(object, "name");
+        this.name = getNameFromObject(object);
         this.path = getStringFromObject(object, "path");
-        if (data == null && this.path == null) {
-            throw CustomExceptions.ATTACHMENT_DATA_OR_PATH_MISSING;
-        }
-        if (data == null) {
-            this.data = null;
-        } else {
+        if (this.path == null) {
+            String data = getStringFromObject(object, "data");
+            if (data == null) {
+                throw CustomExceptions.ATTACHMENT_DATA_OR_PATH_MISSING;
+            }
             if (this.name == null) {
                 throw CustomExceptions.ATTACHMENT_NAME_MISSING;
             }
             this.data = decodeData(data);
+        } else {
+            this.data = null;
         }
     }
 
@@ -56,6 +57,13 @@ public class MailAttachment {
         } catch (IllegalArgumentException exception) {
             throw CustomExceptions.ATTACHMENT_DATA_INVALID;
         }
+    }
+
+    @Nullable
+    private static String getNameFromObject(@NonNull JSONObject object) {
+        String name = getStringFromObject(object, "name");
+        // Strip directory components so that the name cannot escape the attachments directory.
+        return name == null ? null : new File(name).getName();
     }
 
     @Nullable

--- a/packages/mail-composer/android/src/main/java/io/capawesome/capacitorjs/plugins/mailcomposer/classes/options/MailAttachment.java
+++ b/packages/mail-composer/android/src/main/java/io/capawesome/capacitorjs/plugins/mailcomposer/classes/options/MailAttachment.java
@@ -1,0 +1,65 @@
+package io.capawesome.capacitorjs.plugins.mailcomposer.classes.options;
+
+import android.util.Base64;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.capawesome.capacitorjs.plugins.mailcomposer.classes.CustomExceptions;
+import org.json.JSONObject;
+
+public class MailAttachment {
+
+    @Nullable
+    private final byte[] data;
+
+    @Nullable
+    private final String name;
+
+    @Nullable
+    private final String path;
+
+    public MailAttachment(@NonNull JSONObject object) throws Exception {
+        String data = getStringFromObject(object, "data");
+        this.name = getStringFromObject(object, "name");
+        this.path = getStringFromObject(object, "path");
+        if (data == null && this.path == null) {
+            throw CustomExceptions.ATTACHMENT_DATA_OR_PATH_MISSING;
+        }
+        if (data == null) {
+            this.data = null;
+        } else {
+            if (this.name == null) {
+                throw CustomExceptions.ATTACHMENT_NAME_MISSING;
+            }
+            this.data = decodeData(data);
+        }
+    }
+
+    @Nullable
+    public byte[] getData() {
+        return data;
+    }
+
+    @Nullable
+    public String getName() {
+        return name;
+    }
+
+    @Nullable
+    public String getPath() {
+        return path;
+    }
+
+    @NonNull
+    private static byte[] decodeData(@NonNull String data) throws Exception {
+        try {
+            return Base64.decode(data, Base64.DEFAULT);
+        } catch (IllegalArgumentException exception) {
+            throw CustomExceptions.ATTACHMENT_DATA_INVALID;
+        }
+    }
+
+    @Nullable
+    private static String getStringFromObject(@NonNull JSONObject object, @NonNull String key) {
+        return object.isNull(key) ? null : object.optString(key, null);
+    }
+}

--- a/packages/mail-composer/example/src/js/script.js
+++ b/packages/mail-composer/example/src/js/script.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
       cc: ['john@example.com'],
       subject: 'Hello World',
       body: 'This is the body of the email.',
+      attachments: [{ data: btoa('Hello World'), name: 'log.txt' }],
     });
     console.log('status:', status);
   });

--- a/packages/mail-composer/ios/Plugin.xcodeproj/project.pbxproj
+++ b/packages/mail-composer/ios/Plugin.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		FE00000000000000000000A2 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE00000000000000000000A1 /* Result.swift */; };
 		FE00000000000000000000B2 /* CustomError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE00000000000000000000B1 /* CustomError.swift */; };
 		FE00000000000000000000C2 /* ComposeMailOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE00000000000000000000C1 /* ComposeMailOptions.swift */; };
+		FE00000000000000000000C4 /* MailAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE00000000000000000000C3 /* MailAttachment.swift */; };
 		FE00000000000000000000D2 /* CanComposeMailResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE00000000000000000000D1 /* CanComposeMailResult.swift */; };
 		FE00000000000000000000E2 /* ComposeMailResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE00000000000000000000E1 /* ComposeMailResult.swift */; };
 /* End PBXBuildFile section */
@@ -44,6 +45,7 @@
 		FE00000000000000000000A1 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		FE00000000000000000000B1 /* CustomError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomError.swift; sourceTree = "<group>"; };
 		FE00000000000000000000C1 /* ComposeMailOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComposeMailOptions.swift; sourceTree = "<group>"; };
+		FE00000000000000000000C3 /* MailAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MailAttachment.swift; sourceTree = "<group>"; };
 		FE00000000000000000000D1 /* CanComposeMailResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CanComposeMailResult.swift; sourceTree = "<group>"; };
 		FE00000000000000000000E1 /* ComposeMailResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComposeMailResult.swift; sourceTree = "<group>"; };
 		5E23F77F099397094342571A /* Pods-Plugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Plugin.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Plugin/Pods-Plugin.debug.xcconfig"; sourceTree = "<group>"; };
@@ -121,6 +123,7 @@
 			isa = PBXGroup;
 			children = (
 				FE00000000000000000000C1 /* ComposeMailOptions.swift */,
+				FE00000000000000000000C3 /* MailAttachment.swift */,
 			);
 			path = Options;
 			sourceTree = "<group>";
@@ -359,6 +362,7 @@
 				FE00000000000000000000A2 /* Result.swift in Sources */,
 				FE00000000000000000000B2 /* CustomError.swift in Sources */,
 				FE00000000000000000000C2 /* ComposeMailOptions.swift in Sources */,
+				FE00000000000000000000C4 /* MailAttachment.swift in Sources */,
 				FE00000000000000000000D2 /* CanComposeMailResult.swift in Sources */,
 				FE00000000000000000000E2 /* ComposeMailResult.swift in Sources */,
 			);

--- a/packages/mail-composer/ios/Plugin/Classes/Options/ComposeMailOptions.swift
+++ b/packages/mail-composer/ios/Plugin/Classes/Options/ComposeMailOptions.swift
@@ -2,7 +2,7 @@ import Foundation
 import Capacitor
 
 @objc public class ComposeMailOptions: NSObject {
-    let attachments: [String]
+    let attachments: [MailAttachment]
     let bccRecipients: [String]
     let body: String?
     let ccRecipients: [String]
@@ -10,13 +10,13 @@ import Capacitor
     let subject: String?
     let toRecipients: [String]
 
-    init(_ call: CAPPluginCall) {
+    init(_ call: CAPPluginCall) throws {
         self.toRecipients = call.getArray("to", String.self) ?? []
         self.ccRecipients = call.getArray("cc", String.self) ?? []
         self.bccRecipients = call.getArray("bcc", String.self) ?? []
         self.subject = call.getString("subject")
         self.body = call.getString("body")
         self.isHtml = call.getBool("isHtml", false)
-        self.attachments = call.getArray("attachments", String.self) ?? []
+        self.attachments = try (call.getArray("attachments", JSObject.self) ?? []).map { try MailAttachment($0) }
     }
 }

--- a/packages/mail-composer/ios/Plugin/Classes/Options/MailAttachment.swift
+++ b/packages/mail-composer/ios/Plugin/Classes/Options/MailAttachment.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Capacitor
+
+@objc public class MailAttachment: NSObject {
+    let data: Data?
+    let name: String?
+    let path: String?
+
+    init(_ object: JSObject) throws {
+        let data = object["data"] as? String
+        self.name = object["name"] as? String
+        self.path = object["path"] as? String
+        if data == nil && self.path == nil {
+            throw CustomError.attachmentDataOrPathMissing
+        }
+        if let data = data {
+            if self.name == nil {
+                throw CustomError.attachmentNameMissing
+            }
+            self.data = try MailAttachment.decodeData(data)
+        } else {
+            self.data = nil
+        }
+    }
+
+    private static func decodeData(_ data: String) throws -> Data {
+        guard let decodedData = Data(base64Encoded: data) else {
+            throw CustomError.attachmentDataInvalid
+        }
+        return decodedData
+    }
+}

--- a/packages/mail-composer/ios/Plugin/Classes/Options/MailAttachment.swift
+++ b/packages/mail-composer/ios/Plugin/Classes/Options/MailAttachment.swift
@@ -7,13 +7,12 @@ import Capacitor
     let path: String?
 
     init(_ object: JSObject) throws {
-        let data = object["data"] as? String
-        self.name = object["name"] as? String
+        self.name = MailAttachment.getName(from: object)
         self.path = object["path"] as? String
-        if data == nil && self.path == nil {
-            throw CustomError.attachmentDataOrPathMissing
-        }
-        if let data = data {
+        if self.path == nil {
+            guard let data = object["data"] as? String else {
+                throw CustomError.attachmentDataOrPathMissing
+            }
             if self.name == nil {
                 throw CustomError.attachmentNameMissing
             }
@@ -28,5 +27,13 @@ import Capacitor
             throw CustomError.attachmentDataInvalid
         }
         return decodedData
+    }
+
+    private static func getName(from object: JSObject) -> String? {
+        guard let name = object["name"] as? String else {
+            return nil
+        }
+        // Strip directory components so that the attachment file name matches the one used on Android.
+        return (name as NSString).lastPathComponent
     }
 }

--- a/packages/mail-composer/ios/Plugin/Enums/CustomError.swift
+++ b/packages/mail-composer/ios/Plugin/Enums/CustomError.swift
@@ -1,12 +1,17 @@
 import Foundation
 
 enum CustomError: Error {
+    case attachmentDataInvalid
+    case attachmentDataOrPathMissing
+    case attachmentNameMissing
     case attachmentNotFound
     case composeFailed
     case mailServicesUnavailable
 
     var code: String? {
         switch self {
+        case .attachmentDataInvalid, .attachmentDataOrPathMissing, .attachmentNameMissing:
+            return nil
         case .attachmentNotFound:
             return "ATTACHMENT_NOT_FOUND"
         case .composeFailed:
@@ -20,6 +25,12 @@ enum CustomError: Error {
 extension CustomError: LocalizedError {
     public var errorDescription: String? {
         switch self {
+        case .attachmentDataInvalid:
+            return NSLocalizedString("data must be a valid base64 string.", comment: "attachmentDataInvalid")
+        case .attachmentDataOrPathMissing:
+            return NSLocalizedString("Either data or path must be provided for an attachment.", comment: "attachmentDataOrPathMissing")
+        case .attachmentNameMissing:
+            return NSLocalizedString("name must be provided if data is provided.", comment: "attachmentNameMissing")
         case .attachmentNotFound:
             return NSLocalizedString("An attachment could not be found at the provided path.", comment: "attachmentNotFound")
         case .composeFailed:

--- a/packages/mail-composer/ios/Plugin/MailComposer.swift
+++ b/packages/mail-composer/ios/Plugin/MailComposer.swift
@@ -34,12 +34,15 @@ import UniformTypeIdentifiers
                 controller.setMessageBody(body, isHTML: options.isHtml)
             }
             for attachment in options.attachments {
-                let url = Self.createFileUrl(from: attachment)
-                guard let data = try? Data(contentsOf: url) else {
+                guard let resolvedAttachment = Self.resolveAttachment(attachment) else {
                     completion(nil, CustomError.attachmentNotFound)
                     return
                 }
-                controller.addAttachmentData(data, mimeType: Self.mimeType(for: url), fileName: url.lastPathComponent)
+                controller.addAttachmentData(
+                    resolvedAttachment.data,
+                    mimeType: Self.mimeType(forFileName: resolvedAttachment.fileName),
+                    fileName: resolvedAttachment.fileName
+                )
             }
             self.composeCompletion = completion
             self.plugin.bridge?.viewController?.present(controller, animated: true)
@@ -66,11 +69,26 @@ import UniformTypeIdentifiers
         }
     }
 
-    private static func mimeType(for url: URL) -> String {
-        if let type = UTType(filenameExtension: url.pathExtension), let mimeType = type.preferredMIMEType {
+    private static func mimeType(forFileName fileName: String) -> String {
+        let fileExtension = (fileName as NSString).pathExtension
+        if let type = UTType(filenameExtension: fileExtension), let mimeType = type.preferredMIMEType {
             return mimeType
         }
         return "application/octet-stream"
+    }
+
+    private static func resolveAttachment(_ attachment: MailAttachment) -> (data: Data, fileName: String)? {
+        if let path = attachment.path {
+            let url = createFileUrl(from: path)
+            guard let data = try? Data(contentsOf: url) else {
+                return nil
+            }
+            return (data, url.lastPathComponent)
+        }
+        guard let data = attachment.data, let name = attachment.name else {
+            return nil
+        }
+        return (data, name)
     }
 }
 

--- a/packages/mail-composer/ios/Plugin/MailComposerPlugin.swift
+++ b/packages/mail-composer/ios/Plugin/MailComposerPlugin.swift
@@ -28,17 +28,22 @@ public class MailComposerPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     @objc func composeMail(_ call: CAPPluginCall) {
-        let options = ComposeMailOptions(call)
-        implementation?.composeMail(options) { result, error in
-            if let error = error {
-                if case CustomError.mailServicesUnavailable = error {
-                    self.rejectCallAsUnavailable(call)
-                } else {
-                    self.rejectCall(call, error)
+        do {
+            let options = try ComposeMailOptions(call)
+
+            implementation?.composeMail(options) { result, error in
+                if let error = error {
+                    if case CustomError.mailServicesUnavailable = error {
+                        self.rejectCallAsUnavailable(call)
+                    } else {
+                        self.rejectCall(call, error)
+                    }
+                    return
                 }
-                return
+                self.resolveCall(call, result)
             }
-            self.resolveCall(call, result)
+        } catch {
+            self.rejectCall(call, error)
         }
     }
 

--- a/packages/mail-composer/src/definitions.ts
+++ b/packages/mail-composer/src/definitions.ts
@@ -37,14 +37,13 @@ export interface CanComposeMailResult {
  */
 export interface ComposeMailOptions {
   /**
-   * The absolute file paths or `file://` URIs of the files to attach.
+   * The files to attach to the email.
    *
    * Attachments are not supported on the web.
    *
-   * @example ['/path/to/file.pdf']
    * @since 0.1.0
    */
-  attachments?: string[];
+  attachments?: MailAttachment[];
   /**
    * The email addresses of the blind carbon copy (BCC) recipients.
    *
@@ -90,6 +89,41 @@ export interface ComposeMailOptions {
    * @since 0.1.0
    */
   to?: string[];
+}
+
+/**
+ * @since 0.2.0
+ */
+export interface MailAttachment {
+  /**
+   * The content of the file to attach, encoded as a base64 string.
+   *
+   * Either `data` or `path` must be provided. If both are provided, `path` is
+   * used.
+   *
+   * @example 'SGVsbG8gV29ybGQ='
+   * @since 0.2.0
+   */
+  data?: string;
+  /**
+   * The file name of the attachment, including the file extension.
+   *
+   * Must be provided if `data` is provided. Ignored if `path` is provided,
+   * because the file name is then derived from the path.
+   *
+   * @example 'log.txt'
+   * @since 0.2.0
+   */
+  name?: string;
+  /**
+   * The absolute file path or `file://` URI of the file to attach.
+   *
+   * Either `data` or `path` must be provided.
+   *
+   * @example '/path/to/file.pdf'
+   * @since 0.2.0
+   */
+  path?: string;
 }
 
 /**


### PR DESCRIPTION
Close #1014

Attachments can now be provided as base64 strings, so files that only exist in memory (for example a log file kept in IndexedDB) no longer have to be written to the file system before composing the mail.

### Changes

- The `attachments` option of `composeMail(...)` is now an array of `MailAttachment` objects instead of an array of strings.
- Use `path` to attach a file from the file system, or the new `data` and `name` properties to attach a file from a base64 string. If both `data` and `path` are provided, `path` is used.
- On Android, base64 attachments are written to a dedicated directory in the app's cache directory and shared through the `FileProvider` that Capacitor already registers. The directory is cleared on every call. The default `file_paths.xml` resource of a Capacitor app already covers it with a `cache-path` entry, so no additional setup is required.
- On iOS, base64 attachments are passed to `addAttachmentData(_:mimeType:fileName:)` directly. The MIME type is derived from the file extension of `name`.
- On the web, attachments continue to be rejected because `mailto:` URLs cannot carry them.
- Invalid attachments (neither `data` nor `path`, `data` without `name`, or malformed base64) reject with a descriptive message and no error code, as they are developer mistakes rather than runtime conditions.

### Breaking change

```typescript
// Before
await MailComposer.composeMail({ attachments: ['/path/to/file.pdf'] });

// After
await MailComposer.composeMail({ attachments: [{ path: '/path/to/file.pdf' }] });
```

See `BREAKING.md` for details.

### Testing

`npm run verify` passes for Android, iOS and web. The base64 attachment flow still needs to be verified on a real Android device and a real iOS device.