### PR TITLE
fix(mail-composer): only offer mail apps in the chooser when composing a mail with attachments

### DIFF
--- a/.changeset/mail-composer-filter-mail-apps.md
+++ b/.changeset/mail-composer-filter-mail-apps.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-mail-composer': patch
+---
+
+fix(android): only offer mail apps in the chooser when composing a mail with attachments

--- a/packages/mail-composer/android/src/main/AndroidManifest.xml
+++ b/packages/mail-composer/android/src/main/AndroidManifest.xml
@@ -6,11 +6,11 @@
         </intent>
         <intent>
             <action android:name="android.intent.action.SEND" />
-            <data android:mimeType="*/*" />
+            <data android:mimeType="message/rfc822" />
         </intent>
         <intent>
             <action android:name="android.intent.action.SEND_MULTIPLE" />
-            <data android:mimeType="*/*" />
+            <data android:mimeType="message/rfc822" />
         </intent>
     </queries>
 </manifest>

--- a/packages/mail-composer/android/src/main/AndroidManifest.xml
+++ b/packages/mail-composer/android/src/main/AndroidManifest.xml
@@ -4,5 +4,13 @@
             <action android:name="android.intent.action.SENDTO" />
             <data android:scheme="mailto" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.SEND" />
+            <data android:mimeType="*/*" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.SEND_MULTIPLE" />
+            <data android:mimeType="*/*" />
+        </intent>
     </queries>
 </manifest>

--- a/packages/mail-composer/android/src/main/java/io/capawesome/capacitorjs/plugins/mailcomposer/MailComposer.java
+++ b/packages/mail-composer/android/src/main/java/io/capawesome/capacitorjs/plugins/mailcomposer/MailComposer.java
@@ -1,7 +1,10 @@
 package io.capawesome.capacitorjs.plugins.mailcomposer;
 
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.text.Html;
 import androidx.annotation.NonNull;
@@ -15,7 +18,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class MailComposer {
 
@@ -28,13 +33,12 @@ public class MailComposer {
         this.plugin = plugin;
     }
 
-    public void canComposeMail(@NonNull NonEmptyResultCallback<CanComposeMailResult> callback) {
-        boolean canCompose = canResolveIntent(createMailtoIntent());
-        callback.success(new CanComposeMailResult(canCompose));
+    public boolean canComposeMail() {
+        return createMailtoIntent().resolveActivity(getContext().getPackageManager()) != null;
     }
 
-    public boolean canResolveIntent(@NonNull Intent intent) {
-        return intent.resolveActivity(getContext().getPackageManager()) != null;
+    public void canComposeMail(@NonNull NonEmptyResultCallback<CanComposeMailResult> callback) {
+        callback.success(new CanComposeMailResult(canComposeMail()));
     }
 
     @NonNull
@@ -56,7 +60,10 @@ public class MailComposer {
         }
         applyRecipients(intent, options);
         applyContent(intent, options);
-        return intent;
+        if (attachmentUris.isEmpty()) {
+            return intent;
+        }
+        return createMailAppChooserIntent(intent);
     }
 
     private void applyContent(@NonNull Intent intent, @NonNull ComposeMailOptions options) {
@@ -126,6 +133,15 @@ public class MailComposer {
         return new File(path);
     }
 
+    // ACTION_SEND(_MULTIPLE) also matches generic share targets, so exclude every app that cannot handle mailto:
+    @NonNull
+    private Intent createMailAppChooserIntent(@NonNull Intent intent) {
+        List<ComponentName> nonMailAppComponents = getNonMailAppComponents(intent);
+        Intent chooserIntent = Intent.createChooser(intent, null);
+        chooserIntent.putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, nonMailAppComponents.toArray(new ComponentName[0]));
+        return chooserIntent;
+    }
+
     @NonNull
     private Intent createMailtoIntent() {
         return new Intent(Intent.ACTION_SENDTO, Uri.parse("mailto:"));
@@ -159,5 +175,21 @@ public class MailComposer {
     @NonNull
     private Context getContext() {
         return plugin.getContext();
+    }
+
+    @NonNull
+    private List<ComponentName> getNonMailAppComponents(@NonNull Intent intent) {
+        PackageManager packageManager = getContext().getPackageManager();
+        Set<String> mailAppPackageNames = new HashSet<>();
+        for (ResolveInfo resolveInfo : packageManager.queryIntentActivities(createMailtoIntent(), 0)) {
+            mailAppPackageNames.add(resolveInfo.activityInfo.packageName);
+        }
+        List<ComponentName> components = new ArrayList<>();
+        for (ResolveInfo resolveInfo : packageManager.queryIntentActivities(intent, PackageManager.MATCH_ALL)) {
+            if (!mailAppPackageNames.contains(resolveInfo.activityInfo.packageName)) {
+                components.add(new ComponentName(resolveInfo.activityInfo.packageName, resolveInfo.activityInfo.name));
+            }
+        }
+        return components;
     }
 }

--- a/packages/mail-composer/android/src/main/java/io/capawesome/capacitorjs/plugins/mailcomposer/MailComposerPlugin.java
+++ b/packages/mail-composer/android/src/main/java/io/capawesome/capacitorjs/plugins/mailcomposer/MailComposerPlugin.java
@@ -55,8 +55,8 @@ public class MailComposerPlugin extends Plugin {
     public void composeMail(PluginCall call) {
         try {
             ComposeMailOptions options = new ComposeMailOptions(call);
-            Intent intent = implementation.createComposeIntent(options);
-            if (implementation.canResolveIntent(intent)) {
+            if (implementation.canComposeMail()) {
+                Intent intent = implementation.createComposeIntent(options);
                 startActivityForResult(call, intent, "handleComposeMailResult");
             } else {
                 rejectCallAsUnavailable(call);


### PR DESCRIPTION
## Problem

As reported in https://github.com/capawesome-team/capacitor-plugins/issues/1014#issuecomment-5485004965, composing a mail with attachments on Android opens the generic share sheet listing every share-capable app (Drive, WhatsApp, Bluetooth, …) instead of only the installed mail apps.

Root cause: with attachments the plugin uses `ACTION_SEND`/`ACTION_SEND_MULTIPLE`, and any app whose intent filter declares `mimeType="*/*"` matches the concrete `message/rfc822` type during intent resolution. The MIME type alone cannot exclude wildcard handlers.

## Solution

- Wrap the attachment intent in `Intent.createChooser(...)` and pass every share target that does not also handle `ACTION_SENDTO` with the `mailto:` scheme (i.e. every non-mail app) via `EXTRA_EXCLUDE_COMPONENTS`.
- Add `<queries>` entries for `SEND` and `SEND_MULTIPLE` so the plugin can see the non-mail share targets on Android 11+ (package visibility filtering); without them the exclusion list would be empty.
- Check availability in `composeMail` via `mailto:` resolution instead of resolving the compose intent, since a chooser intent always resolves.

The no-attachment `mailto:` path is unchanged.