### PR TITLE
feat(crisp): add `setLocale(...)` method

### DIFF
--- a/.changeset/crisp-set-locale.md
+++ b/.changeset/crisp-set-locale.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-crisp': patch
+---
+
+feat(web): add `setLocale(...)` method to override the locale of the chatbox

--- a/packages/crisp/README.md
+++ b/packages/crisp/README.md
@@ -260,6 +260,7 @@ const addListeners = async () => {
 * [`resetSession()`](#resetsession)
 * [`searchHelpdesk()`](#searchhelpdesk)
 * [`setCompany(...)`](#setcompany)
+* [`setLocale(...)`](#setlocale)
 * [`setNotificationsEnabled(...)`](#setnotificationsenabled)
 * [`setSessionBool(...)`](#setsessionbool)
 * [`setSessionInt(...)`](#setsessionint)
@@ -433,6 +434,27 @@ Set the company of the current user.
 | **`options`** | <code><a href="#setcompanyoptions">SetCompanyOptions</a></code> |
 
 **Since:** 0.1.0
+
+--------------------
+
+
+### setLocale(...)
+
+```typescript
+setLocale(options: SetLocaleOptions) => Promise<void>
+```
+
+Set the locale of the chatbox.
+
+On Android and iOS, the chatbox follows the language of the app.
+
+Only available on Web.
+
+| Param         | Type                                                          |
+| ------------- | ------------------------------------------------------------- |
+| **`options`** | <code><a href="#setlocaleoptions">SetLocaleOptions</a></code> |
+
+**Since:** 0.1.2
 
 --------------------
 
@@ -772,6 +794,13 @@ Remove all listeners for this plugin.
 | **`country`** | <code>string</code> | The country of the company. | 0.1.0 |
 
 
+#### SetLocaleOptions
+
+| Prop         | Type                | Description                                     | Since |
+| ------------ | ------------------- | ----------------------------------------------- | ----- |
+| **`locale`** | <code>string</code> | The locale of the chatbox as an ISO 639-1 code. | 0.1.2 |
+
+
 #### SetNotificationsEnabledOptions
 
 | Prop          | Type                 | Description                                   | Since |
@@ -894,10 +923,13 @@ Not every Crisp SDK feature is available on all platforms. The following table l
 | `handlePushNotification(...)`                |   ✅    | ❌  | ❌  |
 | `setNotificationsEnabled(...)`               |   ✅    | ❌  | ❌  |
 | `setShouldPromptForNotificationPermission(...)` |   ❌    | ✅  | ❌  |
+| `setLocale(...)`                             |   ❌    | ❌  | ✅  |
 
 On iOS, the Crisp SDK detects and handles its own push notifications internally once the APNs device token has been forwarded, so the JavaScript `isCrispPushNotification(...)` and `handlePushNotification(...)` methods are not available there.
 
-The following features of the Crisp SDKs are intentionally not part of this plugin's initial release: unread message count, bot scenarios, runtime locale override, and audio/video calls. [Open an issue](https://github.com/capawesome-team/capacitor-plugins/issues) if you need any of them.
+The Crisp Android and iOS SDKs do not provide a locale override, so the `setLocale(...)` method is only available on the web. The native chatbox follows the language of the app. To change it at runtime, change the language of the app, e.g. with the [App Language](https://capawesome.io/docs/sdks/capacitor/app-language/) plugin.
+
+The following features of the Crisp SDKs are intentionally not part of this plugin's initial release: unread message count, bot scenarios, and audio/video calls. [Open an issue](https://github.com/capawesome-team/capacitor-plugins/issues) if you need any of them.
 
 ## Licensing
 

--- a/packages/crisp/android/src/main/java/io/capawesome/capacitorjs/plugins/crisp/CrispPlugin.java
+++ b/packages/crisp/android/src/main/java/io/capawesome/capacitorjs/plugins/crisp/CrispPlugin.java
@@ -168,6 +168,11 @@ public class CrispPlugin extends Plugin {
     }
 
     @PluginMethod
+    public void setLocale(PluginCall call) {
+        rejectCallAsUnimplemented(call);
+    }
+
+    @PluginMethod
     public void setNotificationsEnabled(PluginCall call) {
         try {
             SetNotificationsEnabledOptions options = new SetNotificationsEnabledOptions(call);

--- a/packages/crisp/example/src/index.html
+++ b/packages/crisp/example/src/index.html
@@ -61,6 +61,9 @@
           <ion-button id="set-session-data-button" expand="block"
             >Set Session Data</ion-button
           >
+          <ion-button id="set-locale-button" expand="block"
+            >Set Locale</ion-button
+          >
           <ion-button id="push-session-event-button" expand="block"
             >Push Session Event</ion-button
           >

--- a/packages/crisp/example/src/js/script.js
+++ b/packages/crisp/example/src/js/script.js
@@ -53,6 +53,11 @@ document.addEventListener('DOMContentLoaded', () => {
       await Crisp.setSessionSegment({ segment: 'checkout' });
     });
   document
+    .querySelector('#set-locale-button')
+    .addEventListener('click', async () => {
+      await Crisp.setLocale({ locale: 'de' });
+    });
+  document
     .querySelector('#push-session-event-button')
     .addEventListener('click', async () => {
       await Crisp.pushSessionEvent({

--- a/packages/crisp/ios/Plugin/CrispPlugin.swift
+++ b/packages/crisp/ios/Plugin/CrispPlugin.swift
@@ -15,6 +15,7 @@ public class CrispPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "resetSession", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "searchHelpdesk", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setCompany", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setLocale", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setNotificationsEnabled", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setSessionBool", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setSessionInt", returnType: CAPPluginReturnPromise),
@@ -125,6 +126,10 @@ public class CrispPlugin: CAPPlugin, CAPBridgedPlugin {
         } catch {
             rejectCall(call, error)
         }
+    }
+
+    @objc func setLocale(_ call: CAPPluginCall) {
+        rejectCallAsUnimplemented(call)
     }
 
     @objc func setNotificationsEnabled(_ call: CAPPluginCall) {

--- a/packages/crisp/src/definitions.ts
+++ b/packages/crisp/src/definitions.ts
@@ -70,6 +70,16 @@ export interface CrispPlugin {
    */
   setCompany(options: SetCompanyOptions): Promise<void>;
   /**
+   * Set the locale of the chatbox.
+   *
+   * On Android and iOS, the chatbox follows the language of the app.
+   *
+   * Only available on Web.
+   *
+   * @since 0.1.2
+   */
+  setLocale(options: SetLocaleOptions): Promise<void>;
+  /**
    * Enable or disable push notifications.
    *
    * Only available on Android.
@@ -389,6 +399,19 @@ export interface SetCompanyGeolocation {
    * @since 0.1.0
    */
   country: string;
+}
+
+/**
+ * @since 0.1.2
+ */
+export interface SetLocaleOptions {
+  /**
+   * The locale of the chatbox as an ISO 639-1 code.
+   *
+   * @since 0.1.2
+   * @example 'de'
+   */
+  locale: string;
 }
 
 /**

--- a/packages/crisp/src/web.ts
+++ b/packages/crisp/src/web.ts
@@ -7,6 +7,7 @@ import type {
   OpenHelpdeskArticleOptions,
   PushSessionEventOptions,
   SetCompanyOptions,
+  SetLocaleOptions,
   SetSessionBoolOptions,
   SetSessionIntOptions,
   SetSessionSegmentOptions,
@@ -82,6 +83,11 @@ export class CrispWeb extends WebPlugin implements CrispPlugin {
       geolocation: options.geolocation,
       url: options.url,
     });
+  }
+
+  async setLocale(options: SetLocaleOptions): Promise<void> {
+    this.throwIfNotConfigured();
+    window.$crisp.push(['config', 'locale', [options.locale]]);
   }
 
   async setNotificationsEnabled(): Promise<void> {


### PR DESCRIPTION
Adds a `setLocale(...)` method to the Crisp plugin so apps can override the locale of the chatbox at runtime.

The method is only available on the web, where it pushes the `$crisp` locale config command. The Crisp Android SDK has no locale API and the Crisp iOS SDK has deprecated its `locale` property as no longer available, so both native platforms reject the call as unimplemented. The README explains that the native chatbox follows the language of the app and points to the App Language plugin for changing it at runtime.

Close #1030