### PR TITLE
fix(ci): build sponsorware packages before publishing to GitHub Packages

### DIFF
--- a/.changeset/republish-sponsorware-with-dist.md
+++ b/.changeset/republish-sponsorware-with-dist.md
@@ -1,0 +1,6 @@
+---
+"@capawesome-team/capacitor-datetime-picker": patch
+"@capawesome-team/capacitor-file-opener": patch
+---
+
+fix: republish the package because the previous version was missing the `dist/` folder on the Capawesome npm registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,10 @@ jobs:
           commit-message: "chore(release): publish"
           pr-title: "chore(release): publish"
       - name: Set npm token for GitHub Packages
-        if: steps.changesets.outputs.published == 'true'
+        if: ${{ !cancelled() && steps.changesets.outputs.published == 'true' }}
         run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.PAT }}
       - name: Publish Sponsorware to GitHub Packages
-        if: steps.changesets.outputs.published == 'true'
+        if: ${{ !cancelled() && steps.changesets.outputs.published == 'true' }}
         env:
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs['published-packages'] }}
         run: node ./scripts/publish-sponsorware.mjs --packages="$PUBLISHED_PACKAGES"

--- a/scripts/publish-sponsorware.mjs
+++ b/scripts/publish-sponsorware.mjs
@@ -22,19 +22,23 @@ execute(async () => {
 
   for (const pkg of packagesToPublish) {
     const dirName = pkg.name.split('/')[1].replace('capacitor-', '');
+    const cwd = `./packages/${dirName}`;
     console.log(`Publishing ${pkg.name}@${pkg.version}...`);
     await exec(
       `npm pkg set repository.url=git+https://github.com/capawesome-team/sponsorware.git`,
-      {
-        cwd: `./packages/${dirName}`,
-      },
+      { cwd },
     );
     await exec(
       `npm pkg set publishConfig.registry=https://npm.pkg.github.com`,
-      { cwd: `./packages/${dirName}` },
+      { cwd },
     );
+    // Build explicitly: `prepublishOnly` is skipped when npm is configured with `ignore-scripts=true`.
+    await exec(`npm run build`, { cwd });
+    if (!fs.existsSync(`${cwd}/dist`)) {
+      throw new Error(`${pkg.name}: dist folder is missing after build.`);
+    }
     if (process.env.CI) {
-      await exec(`npm publish`, { cwd: `./packages/${dirName}` });
+      await exec(`npm publish`, { cwd });
     }
   }
   console.log(`${packagesToPublish.length} package(s) published.`);


### PR DESCRIPTION
## Summary

`@capawesome-team/capacitor-datetime-picker@8.1.3` and `@capawesome-team/capacitor-file-opener@8.0.3` were published to GitHub Packages (and therefore to the Capawesome npm registry, which mirrors it) without the `dist/` folder. `main`, `module` and `types` point at files that do not exist, so apps installing these versions from the sponsorware registry fail to build. The public npm copies are fine.

## Root cause

The release run on 2026-09-02 failed while publishing to npm (transient Sigstore error, then HTTP 429 on the tag pushes), so the "Publish Sponsorware to GitHub Packages" step was skipped. The two packages were then published manually from a machine with `ignore-scripts=true` in its npm config. `npm publish` skipped `prepublishOnly`, no build ran, and the tarballs were packed without `dist/`.

## Changes

- `scripts/publish-sponsorware.mjs`: run `npm run build` explicitly before `npm publish` and abort if `dist/` is missing afterwards, so a publish can no longer ship without the compiled output.
- `.github/workflows/release.yml`: run the sponsorware steps with `!cancelled() && published == 'true'`. The changesets action sets its outputs before failing on a partial publish, so packages that did reach npm are still published to GitHub Packages.
- Changeset: patch releases `datetime-picker@8.1.4` and `file-opener@8.0.4` to replace the broken versions.

## Verification

- Ran the publish script locally with `CI` unset against a mixed package list after deleting `packages/datetime-picker/dist`: the `@capawesome/` package was filtered out, `dist/` was rebuilt, the guard passed, nothing was published.
- `changeset status` lists exactly the two packages as patch bumps.
- Workflow YAML parses.
