### PR TITLE
feat(file-picker): add `webPath` property to picked files

### DIFF
--- a/.changeset/file-picker-web-path.md
+++ b/.changeset/file-picker-web-path.md
@@ -1,0 +1,5 @@
+---
+"@capawesome/capacitor-file-picker": minor
+---
+
+feat(android, ios): add `webPath` property to picked files

--- a/packages/file-picker/README.md
+++ b/packages/file-picker/README.md
@@ -156,6 +156,21 @@ const pickMedia = async () => {
 };
 ```
 
+### Display a picked image in the web view
+
+On Android and iOS, the `path` of a picked file cannot be loaded directly in the web view. Use the `webPath` property instead:
+
+```typescript
+import { FilePicker } from '@capawesome/capacitor-file-picker';
+
+const displayImage = async () => {
+  const { files } = await FilePicker.pickImages({ limit: 1 });
+  const image = document.createElement('img');
+  image.src = files[0].webPath!;
+  document.body.appendChild(image);
+};
+```
+
 ### Pick a directory
 
 Let the user select a directory, for example to import all files it contains. Only available on Android and iOS:
@@ -174,7 +189,6 @@ On the Web, the picked file contains a `Blob` instance. On Android and iOS, load
 
 ```typescript
 import { FilePicker } from '@capawesome/capacitor-file-picker';
-import { Capacitor } from '@capacitor/core';
 
 const uploadFile = async () => {
   const result = await FilePicker.pickFiles({ limit: 1 });
@@ -186,7 +200,7 @@ const uploadFile = async () => {
     blob = file.blob;
   } else {
     // Android and iOS
-    const response = await fetch(Capacitor.convertFileSrc(file.path!));
+    const response = await fetch(file.webPath!);
     blob = await response.blob();
   }
 
@@ -540,18 +554,19 @@ Remove all listeners for this plugin.
 
 #### PickedFile
 
-| Prop             | Type                | Description                                                                                                          | Since |
-| ---------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------- | ----- |
-| **`blob`**       | <code>Blob</code>   | The Blob instance of the file. Only available on Web.                                                                |       |
-| **`data`**       | <code>string</code> | The Base64 string representation of the data contained in the file. Is only provided if `readData` is set to `true`. |       |
-| **`duration`**   | <code>number</code> | The duration of the video in seconds. Only available on Android and iOS.                                             | 0.5.3 |
-| **`height`**     | <code>number</code> | The height of the image or video in pixels. Only available on Android and iOS.                                       | 0.5.3 |
-| **`mimeType`**   | <code>string</code> | The mime type of the file.                                                                                           |       |
-| **`modifiedAt`** | <code>number</code> | The last modified timestamp of the file in milliseconds.                                                             | 0.5.9 |
-| **`name`**       | <code>string</code> | The name of the file.                                                                                                |       |
-| **`path`**       | <code>string</code> | The path of the file. Only available on Android and iOS.                                                             |       |
-| **`size`**       | <code>number</code> | The size of the file in bytes.                                                                                       |       |
-| **`width`**      | <code>number</code> | The width of the image or video in pixels. Only available on Android and iOS.                                        | 0.5.3 |
+| Prop             | Type                | Description                                                                                                                                                | Since |
+| ---------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| **`blob`**       | <code>Blob</code>   | The Blob instance of the file. Only available on Web.                                                                                                      |       |
+| **`data`**       | <code>string</code> | The Base64 string representation of the data contained in the file. Is only provided if `readData` is set to `true`.                                       |       |
+| **`duration`**   | <code>number</code> | The duration of the video in seconds. Only available on Android and iOS.                                                                                   | 0.5.3 |
+| **`height`**     | <code>number</code> | The height of the image or video in pixels. Only available on Android and iOS.                                                                             | 0.5.3 |
+| **`mimeType`**   | <code>string</code> | The mime type of the file.                                                                                                                                 |       |
+| **`modifiedAt`** | <code>number</code> | The last modified timestamp of the file in milliseconds.                                                                                                   | 0.5.9 |
+| **`name`**       | <code>string</code> | The name of the file.                                                                                                                                      |       |
+| **`path`**       | <code>string</code> | The path of the file. Only available on Android and iOS.                                                                                                   |       |
+| **`size`**       | <code>number</code> | The size of the file in bytes.                                                                                                                             |       |
+| **`webPath`**    | <code>string</code> | The path of the file that can be used to load it in the web view, for example as the `src` of an `&lt;img&gt;` element. Only available on Android and iOS. | 8.1.0 |
+| **`width`**      | <code>number</code> | The width of the image or video in pixels. Only available on Android and iOS.                                                                              | 0.5.3 |
 
 
 #### PickFilesOptions

--- a/packages/file-picker/README.md
+++ b/packages/file-picker/README.md
@@ -158,7 +158,7 @@ const pickMedia = async () => {
 
 ### Display a picked image in the web view
 
-On Android and iOS, the `path` of a picked file cannot be loaded directly in the web view. Use the `webPath` property instead:
+Use the `webPath` property to load a picked file in the web view, for example as the `src` of an `<img>` element:
 
 ```typescript
 import { FilePicker } from '@capawesome/capacitor-file-picker';
@@ -554,19 +554,19 @@ Remove all listeners for this plugin.
 
 #### PickedFile
 
-| Prop             | Type                | Description                                                                                                                                                | Since |
-| ---------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| **`blob`**       | <code>Blob</code>   | The Blob instance of the file. Only available on Web.                                                                                                      |       |
-| **`data`**       | <code>string</code> | The Base64 string representation of the data contained in the file. Is only provided if `readData` is set to `true`.                                       |       |
-| **`duration`**   | <code>number</code> | The duration of the video in seconds. Only available on Android and iOS.                                                                                   | 0.5.3 |
-| **`height`**     | <code>number</code> | The height of the image or video in pixels. Only available on Android and iOS.                                                                             | 0.5.3 |
-| **`mimeType`**   | <code>string</code> | The mime type of the file.                                                                                                                                 |       |
-| **`modifiedAt`** | <code>number</code> | The last modified timestamp of the file in milliseconds.                                                                                                   | 0.5.9 |
-| **`name`**       | <code>string</code> | The name of the file.                                                                                                                                      |       |
-| **`path`**       | <code>string</code> | The path of the file. Only available on Android and iOS.                                                                                                   |       |
-| **`size`**       | <code>number</code> | The size of the file in bytes.                                                                                                                             |       |
-| **`webPath`**    | <code>string</code> | The path of the file that can be used to load it in the web view, for example as the `src` of an `&lt;img&gt;` element. Only available on Android and iOS. | 8.1.0 |
-| **`width`**      | <code>number</code> | The width of the image or video in pixels. Only available on Android and iOS.                                                                              | 0.5.3 |
+| Prop             | Type                | Description                                                                                                                                                                                                             | Since |
+| ---------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| **`blob`**       | <code>Blob</code>   | The Blob instance of the file. Only available on Web.                                                                                                                                                                   |       |
+| **`data`**       | <code>string</code> | The Base64 string representation of the data contained in the file. Is only provided if `readData` is set to `true`.                                                                                                    |       |
+| **`duration`**   | <code>number</code> | The duration of the video in seconds. Only available on Android and iOS.                                                                                                                                                | 0.5.3 |
+| **`height`**     | <code>number</code> | The height of the image or video in pixels. Only available on Android and iOS.                                                                                                                                          | 0.5.3 |
+| **`mimeType`**   | <code>string</code> | The mime type of the file.                                                                                                                                                                                              |       |
+| **`modifiedAt`** | <code>number</code> | The last modified timestamp of the file in milliseconds.                                                                                                                                                                | 0.5.9 |
+| **`name`**       | <code>string</code> | The name of the file.                                                                                                                                                                                                   |       |
+| **`path`**       | <code>string</code> | The path of the file. Only available on Android and iOS.                                                                                                                                                                |       |
+| **`size`**       | <code>number</code> | The size of the file in bytes.                                                                                                                                                                                          |       |
+| **`webPath`**    | <code>string</code> | The path of the file that can be used to load it in the web view, for example as the `src` of an `&lt;img&gt;` element. On the web, this is an object URL. Call `URL.revokeObjectURL(...)` when it is no longer needed. | 8.1.0 |
+| **`width`**      | <code>number</code> | The width of the image or video in pixels. Only available on Android and iOS.                                                                                                                                           | 0.5.3 |
 
 
 #### PickFilesOptions

--- a/packages/file-picker/README.md
+++ b/packages/file-picker/README.md
@@ -185,7 +185,7 @@ const pickDirectory = async () => {
 
 ### Upload a picked file to a server
 
-On the Web, the picked file contains a `Blob` instance. On Android and iOS, load the file as a blob using the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) and the file's path. You can then append the blob to a `FormData` object and upload it:
+On the Web, the picked file contains a `Blob` instance. On Android and iOS, load the file as a blob using the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) and the file's `webPath`. You can then append the blob to a `FormData` object and upload it:
 
 ```typescript
 import { FilePicker } from '@capawesome/capacitor-file-picker';

--- a/packages/file-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePicker.java
+++ b/packages/file-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePicker.java
@@ -11,6 +11,7 @@ import android.util.Base64;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.FileProvider;
+import com.getcapacitor.Bridge;
 import com.getcapacitor.Logger;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -51,6 +52,17 @@ public class FilePicker {
     }
 
     public String getPathFromUri(@NonNull Uri uri) {
+        return uri.toString();
+    }
+
+    public String getWebPathFromUri(@NonNull Uri uri) {
+        String scheme = uri.getScheme();
+        if (ContentResolver.SCHEME_CONTENT.equals(scheme)) {
+            return plugin.getBridge().getLocalUrl() + uri.toString().replaceFirst("content:/", Bridge.CAPACITOR_CONTENT_START);
+        }
+        if (ContentResolver.SCHEME_FILE.equals(scheme)) {
+            return plugin.getBridge().getLocalUrl() + uri.toString().replaceFirst("file://", Bridge.CAPACITOR_FILE_START);
+        }
         return uri.toString();
     }
 

--- a/packages/file-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePickerPlugin.java
+++ b/packages/file-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePickerPlugin.java
@@ -307,6 +307,7 @@ public class FilePickerPlugin extends Plugin {
             }
             fileResult.put("name", implementation.getNameFromUri(uri));
             fileResult.put("path", implementation.getPathFromUri(uri));
+            fileResult.put("webPath", implementation.getWebPathFromUri(uri));
             fileResult.put("size", implementation.getSizeFromUri(uri));
             filesResultList.add(fileResult);
         }

--- a/packages/file-picker/example/src/js/script.js
+++ b/packages/file-picker/example/src/js/script.js
@@ -1,4 +1,3 @@
-import { Capacitor } from '@capacitor/core';
 import { Directory, Filesystem } from '@capacitor/filesystem';
 import { FilePicker } from '@capawesome/capacitor-file-picker';
 
@@ -13,11 +12,7 @@ const displayFile = file => {
   document.querySelector('#height-input').value = file.height ?? '';
 
   const image = document.querySelector('#image');
-  if (!file.mimeType?.startsWith('image/')) {
-    image.src = '';
-  } else if (Capacitor.getPlatform() === 'web' && file.blob) {
-    image.src = URL.createObjectURL(file.blob);
-  } else if (file.webPath) {
+  if (file.mimeType?.startsWith('image/') && file.webPath) {
     image.src = file.webPath;
   } else {
     image.src = '';

--- a/packages/file-picker/example/src/js/script.js
+++ b/packages/file-picker/example/src/js/script.js
@@ -17,8 +17,8 @@ const displayFile = file => {
     image.src = '';
   } else if (Capacitor.getPlatform() === 'web' && file.blob) {
     image.src = URL.createObjectURL(file.blob);
-  } else if (file.path) {
-    image.src = Capacitor.convertFileSrc(file.path);
+  } else if (file.webPath) {
+    image.src = file.webPath;
   } else {
     image.src = '';
   }

--- a/packages/file-picker/ios/Plugin/FilePicker.swift
+++ b/packages/file-picker/ios/Plugin/FilePicker.swift
@@ -164,6 +164,10 @@ import MobileCoreServices
         return url.absoluteString
     }
 
+    public func getWebPathFromUrl(_ url: URL) -> String? {
+        return plugin?.bridge?.portablePath(fromLocalURL: url)?.absoluteString
+    }
+
     public func getNameFromUrl(_ url: URL) -> String {
         return url.lastPathComponent
     }

--- a/packages/file-picker/ios/Plugin/FilePickerPlugin.swift
+++ b/packages/file-picker/ios/Plugin/FilePickerPlugin.swift
@@ -157,6 +157,9 @@ public class FilePickerPlugin: CAPPlugin, CAPBridgedPlugin {
                 file["mimeType"] = implementation?.getMimeTypeFromUrl(url) ?? ""
                 file["name"] = implementation?.getNameFromUrl(url) ?? ""
                 file["path"] = implementation?.getPathFromUrl(url) ?? ""
+                if let webPath = implementation?.getWebPathFromUrl(url) {
+                    file["webPath"] = webPath
+                }
                 file["size"] = try implementation?.getSizeFromUrl(url) ?? -1
                 return file
             }

--- a/packages/file-picker/src/definitions.ts
+++ b/packages/file-picker/src/definitions.ts
@@ -265,6 +265,14 @@ export interface PickedFile {
    */
   size: number;
   /**
+   * The path of the file that can be used to load it in the web view, for example as the `src` of an `<img>` element.
+   *
+   * Only available on Android and iOS.
+   *
+   * @since 8.1.0
+   */
+  webPath?: string;
+  /**
    * The width of the image or video in pixels.
    *
    * Only available on Android and iOS.

--- a/packages/file-picker/src/definitions.ts
+++ b/packages/file-picker/src/definitions.ts
@@ -267,7 +267,7 @@ export interface PickedFile {
   /**
    * The path of the file that can be used to load it in the web view, for example as the `src` of an `<img>` element.
    *
-   * Only available on Android and iOS.
+   * On the web, this is an object URL. Call `URL.revokeObjectURL(...)` when it is no longer needed.
    *
    * @since 8.1.0
    */

--- a/packages/file-picker/src/web.ts
+++ b/packages/file-picker/src/web.ts
@@ -52,6 +52,7 @@ export class FilePickerWeb extends WebPlugin implements FilePickerPlugin {
         name: this.getNameFromUrl(pickedFile),
         path: undefined,
         size: this.getSizeFromUrl(pickedFile),
+        webPath: URL.createObjectURL(pickedFile),
       };
       if (options?.readData) {
         file.data = await this.getDataFromFile(pickedFile);


### PR DESCRIPTION
Close #98

Adds a `webPath` property to `PickedFile` so a picked file can be loaded directly in the web view (e.g. as the `src` of an `<img>` element) without calling `Capacitor.convertFileSrc(...)`, mirroring `Photo.webPath` from `@capacitor/camera`.

- **Android**: `FilePicker.getWebPathFromUri(...)` builds the local bridge URL with `Bridge.CAPACITOR_CONTENT_START` / `Bridge.CAPACITOR_FILE_START`, exactly like `Capacitor.convertFileSrc(...)`. `FileUtils.getPortablePath` is intentionally not used because it resolves content URIs to file paths and fails for cloud document providers.
- **iOS**: `FilePicker.getWebPathFromUrl(...)` uses `bridge.portablePath(fromLocalURL:)`.
- **Web**: `webPath` is an object URL created with `URL.createObjectURL(...)`, like in the Camera plugin. The JSDoc notes that `URL.revokeObjectURL(...)` should be called when it is no longer needed.
- Covers `pickFiles()`, `pickImages()`, `pickMedia()` and `pickVideos()`, since the result objects are built in one place per platform.
- The README upload example and the example app now use `webPath` instead of `Capacitor.convertFileSrc(...)`.

## Testing

`npm run verify` (iOS, Android, web) passes.
