### PR TITLE
feat(file-picker): add `convertRawToJpeg(...)` method on iOS

### DIFF
--- a/.changeset/file-picker-convert-raw-to-jpeg.md
+++ b/.changeset/file-picker-convert-raw-to-jpeg.md
@@ -1,0 +1,5 @@
+---
+"@capawesome/capacitor-file-picker": minor
+---
+
+feat(ios): add `convertRawToJpeg(...)` method

--- a/packages/file-picker/README.md
+++ b/packages/file-picker/README.md
@@ -215,6 +215,20 @@ const convertHeicToJpeg = async () => {
 };
 ```
 
+### Convert a RAW image to JPEG
+
+RAW images (e.g. DNG) are not transcoded when they are picked. Use `convertRawToJpeg(...)` to convert them. Only available on iOS:
+
+```typescript
+import { FilePicker } from '@capawesome/capacitor-file-picker';
+
+const convertRawToJpeg = async () => {
+  const { path } = await FilePicker.convertRawToJpeg({
+    path: 'path/to/image.dng',
+  });
+};
+```
+
 ### Check and request permissions
 
 Picking files does not require any permissions since the operating system presents the picker. However, if you need the `ACCESS_MEDIA_LOCATION` or `READ_EXTERNAL_STORAGE` permission on Android (see [Installation](#installation)), you can check and request them:
@@ -266,6 +280,7 @@ const copyFile = async () => {
 
 * [`checkPermissions()`](#checkpermissions)
 * [`convertHeicToJpeg(...)`](#convertheictojpeg)
+* [`convertRawToJpeg(...)`](#convertrawtojpeg)
 * [`copyFile(...)`](#copyfile)
 * [`pickFiles(...)`](#pickfiles)
 * [`pickDirectory()`](#pickdirectory)
@@ -317,6 +332,27 @@ Only available on iOS.
 **Returns:** <code>Promise&lt;<a href="#convertheictojpegresult">ConvertHeicToJpegResult</a>&gt;</code>
 
 **Since:** 0.6.0
+
+--------------------
+
+
+### convertRawToJpeg(...)
+
+```typescript
+convertRawToJpeg(options: ConvertRawToJpegOptions) => Promise<ConvertRawToJpegResult>
+```
+
+Convert a RAW image to JPEG.
+
+Only available on iOS.
+
+| Param         | Type                                                                        |
+| ------------- | --------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#convertrawtojpegoptions">ConvertRawToJpegOptions</a></code> |
+
+**Returns:** <code>Promise&lt;<a href="#convertrawtojpegresult">ConvertRawToJpegResult</a>&gt;</code>
+
+**Since:** 8.1.0
 
 --------------------
 
@@ -520,6 +556,20 @@ Remove all listeners for this plugin.
 | Prop       | Type                | Description                 | Since |
 | ---------- | ------------------- | --------------------------- | ----- |
 | **`path`** | <code>string</code> | The path of the HEIC image. | 0.6.0 |
+
+
+#### ConvertRawToJpegResult
+
+| Prop       | Type                | Description                           | Since |
+| ---------- | ------------------- | ------------------------------------- | ----- |
+| **`path`** | <code>string</code> | The path of the converted JPEG image. | 8.1.0 |
+
+
+#### ConvertRawToJpegOptions
+
+| Prop       | Type                | Description                | Since |
+| ---------- | ------------------- | -------------------------- | ----- |
+| **`path`** | <code>string</code> | The path of the RAW image. | 8.1.0 |
 
 
 #### CopyFileOptions

--- a/packages/file-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePickerPlugin.java
+++ b/packages/file-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePickerPlugin.java
@@ -65,6 +65,11 @@ public class FilePickerPlugin extends Plugin {
     }
 
     @PluginMethod
+    public void convertRawToJpeg(PluginCall call) {
+        call.unimplemented("Not implemented on Android.");
+    }
+
+    @PluginMethod
     public void copyFile(PluginCall call) {
         try {
             String from = call.getString("from");

--- a/packages/file-picker/ios/Plugin.xcodeproj/project.pbxproj
+++ b/packages/file-picker/ios/Plugin.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		7C7AC98E2E0A8D620080ABBC /* CopyFileOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C7AC98D2E0A8D5C0080ABBC /* CopyFileOptions.swift */; };
 		7C7AC9912E0A8D700080ABBC /* PickFilesOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C7AC9902E0A8D700080ABBC /* PickFilesOptions.swift */; };
 		7C7AC9942E0A974D0080ABBC /* CustomError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C7AC9932E0A974D0080ABBC /* CustomError.swift */; };
+		7CB4D1022F2B0A010080ABBC /* ConvertRawToJpegOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB4D1012F2B0A010080ABBC /* ConvertRawToJpegOptions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -43,6 +44,7 @@
 		7C7AC98D2E0A8D5C0080ABBC /* CopyFileOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyFileOptions.swift; sourceTree = "<group>"; };
 		7C7AC9902E0A8D700080ABBC /* PickFilesOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickFilesOptions.swift; sourceTree = "<group>"; };
 		7C7AC9932E0A974D0080ABBC /* CustomError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomError.swift; sourceTree = "<group>"; };
+		7CB4D1012F2B0A010080ABBC /* ConvertRawToJpegOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConvertRawToJpegOptions.swift; sourceTree = "<group>"; };
 		91781294A431A2A7CC6EB714 /* Pods-Plugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Plugin.release.xcconfig"; path = "Pods/Target Support Files/Pods-Plugin/Pods-Plugin.release.xcconfig"; sourceTree = "<group>"; };
 		96ED1B6440D6672E406C8D19 /* Pods-PluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PluginTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PluginTests/Pods-PluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		F65BB2953ECE002E1EF3E424 /* Pods-PluginTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PluginTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PluginTests/Pods-PluginTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -123,6 +125,7 @@
 		7C7AC98C2E0A8D560080ABBC /* Options */ = {
 			isa = PBXGroup;
 			children = (
+				7CB4D1012F2B0A010080ABBC /* ConvertRawToJpegOptions.swift */,
 				7C7AC98D2E0A8D5C0080ABBC /* CopyFileOptions.swift */,
 				7C7AC9902E0A8D700080ABBC /* PickFilesOptions.swift */,
 			);
@@ -334,6 +337,7 @@
 			files = (
 				50E1A94820377CB70090CE1A /* FilePickerPlugin.swift in Sources */,
 				7C7AC9942E0A974D0080ABBC /* CustomError.swift in Sources */,
+				7CB4D1022F2B0A010080ABBC /* ConvertRawToJpegOptions.swift in Sources */,
 				7C7AC98E2E0A8D620080ABBC /* CopyFileOptions.swift in Sources */,
 				7C7AC9912E0A8D700080ABBC /* PickFilesOptions.swift in Sources */,
 				2F98D68224C9AAE500613A4C /* FilePicker.swift in Sources */,

--- a/packages/file-picker/ios/Plugin/Classes/Enums/CustomError.swift
+++ b/packages/file-picker/ios/Plugin/Classes/Enums/CustomError.swift
@@ -2,8 +2,10 @@ import Foundation
 
 public enum CustomError: Error {
     case fileAlreadyExists
+    case fileNotFound
     case fromMissing
     case invalidPath
+    case pathMissing
     case toMissing
     case unknown
 }
@@ -13,10 +15,14 @@ extension CustomError: LocalizedError {
         switch self {
         case .fileAlreadyExists:
             return NSLocalizedString("File already exists.", comment: "fileAlreadyExists")
+        case .fileNotFound:
+            return NSLocalizedString("File does not exist.", comment: "fileNotFound")
         case .fromMissing:
             return NSLocalizedString("from must be provided.", comment: "fromMissing")
         case .invalidPath:
             return NSLocalizedString("Invalid path provided.", comment: "invalidPath")
+        case .pathMissing:
+            return NSLocalizedString("path must be provided.", comment: "pathMissing")
         case .toMissing:
             return NSLocalizedString("to must be provided.", comment: "toMissing")
         case .unknown:

--- a/packages/file-picker/ios/Plugin/Classes/Options/ConvertRawToJpegOptions.swift
+++ b/packages/file-picker/ios/Plugin/Classes/Options/ConvertRawToJpegOptions.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Capacitor
+
+@objc public class ConvertRawToJpegOptions: NSObject {
+    private let url: URL
+
+    init(_ call: CAPPluginCall) throws {
+        guard let path = call.getString("path") else {
+            throw CustomError.pathMissing
+        }
+        guard let url = URL(string: path) else {
+            throw CustomError.invalidPath
+        }
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw CustomError.fileNotFound
+        }
+        self.url = url
+    }
+
+    func getUrl() -> URL {
+        return url
+    }
+}

--- a/packages/file-picker/ios/Plugin/FilePicker.swift
+++ b/packages/file-picker/ios/Plugin/FilePicker.swift
@@ -39,19 +39,11 @@ import MobileCoreServices
     }
 
     public func convertHeicToJpeg(_ sourceUrl: URL) throws -> URL? {
-        let heicImage = UIImage(named: sourceUrl.path)
-        guard let heicImage = heicImage else {
-            return nil
-        }
-        let jpegImageData = heicImage.jpegData(compressionQuality: 0.9)
-        let directory = try self.createUniqueTemporaryDirectory()
-        let filenameWithoutExtension = sourceUrl.deletingPathExtension().lastPathComponent
-        let targetUrl = directory.appendingPathComponent("\(filenameWithoutExtension).jpeg")
-        do {
-            try deleteFile(targetUrl)
-        }
-        try jpegImageData?.write(to: targetUrl)
-        return targetUrl
+        return try convertImageToJpeg(sourceUrl)
+    }
+
+    public func convertRawToJpeg(_ sourceUrl: URL) throws -> URL? {
+        return try convertImageToJpeg(sourceUrl)
     }
 
     public func openDocumentPicker(_ options: PickFilesOptions) {
@@ -251,6 +243,19 @@ import MobileCoreServices
         } else {
             return nil
         }
+    }
+
+    private func convertImageToJpeg(_ sourceUrl: URL) throws -> URL? {
+        guard let image = UIImage(contentsOfFile: sourceUrl.path) else {
+            return nil
+        }
+        let jpegImageData = image.jpegData(compressionQuality: 0.9)
+        let directory = try self.createUniqueTemporaryDirectory()
+        let filenameWithoutExtension = sourceUrl.deletingPathExtension().lastPathComponent
+        let targetUrl = directory.appendingPathComponent("\(filenameWithoutExtension).jpeg")
+        try deleteFile(targetUrl)
+        try jpegImageData?.write(to: targetUrl)
+        return targetUrl
     }
 
     private func presentViewController(_ viewControllerToPresent: UIViewController) {

--- a/packages/file-picker/ios/Plugin/FilePicker.swift
+++ b/packages/file-picker/ios/Plugin/FilePicker.swift
@@ -246,15 +246,14 @@ import MobileCoreServices
     }
 
     private func convertImageToJpeg(_ sourceUrl: URL) throws -> URL? {
-        guard let image = UIImage(contentsOfFile: sourceUrl.path) else {
+        guard let image = UIImage(contentsOfFile: sourceUrl.path), let jpegImageData = image.jpegData(compressionQuality: 0.9) else {
             return nil
         }
-        let jpegImageData = image.jpegData(compressionQuality: 0.9)
         let directory = try self.createUniqueTemporaryDirectory()
         let filenameWithoutExtension = sourceUrl.deletingPathExtension().lastPathComponent
         let targetUrl = directory.appendingPathComponent("\(filenameWithoutExtension).jpeg")
         try deleteFile(targetUrl)
-        try jpegImageData?.write(to: targetUrl)
+        try jpegImageData.write(to: targetUrl)
         return targetUrl
     }
 

--- a/packages/file-picker/ios/Plugin/FilePickerPlugin.swift
+++ b/packages/file-picker/ios/Plugin/FilePickerPlugin.swift
@@ -12,6 +12,7 @@ public class FilePickerPlugin: CAPPlugin, CAPBridgedPlugin {
     public let jsName = "FilePicker"
     public let pluginMethods: [CAPPluginMethod] = [
         CAPPluginMethod(name: "convertHeicToJpeg", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "convertRawToJpeg", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "copyFile", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "pickFiles", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "pickImages", returnType: CAPPluginReturnPromise),
@@ -57,6 +58,24 @@ public class FilePickerPlugin: CAPPlugin, CAPBridgedPlugin {
             call.resolve(result)
         } catch let error as NSError {
             call.reject(error.localizedDescription, nil, error)
+        }
+    }
+
+    @objc func convertRawToJpeg(_ call: CAPPluginCall) {
+        do {
+            let options = try ConvertRawToJpegOptions(call)
+
+            let jpegUrl = try implementation?.convertRawToJpeg(options.getUrl())
+            guard let jpegUrl = jpegUrl else {
+                call.reject(errorConvertFailed)
+                return
+            }
+
+            var result = JSObject()
+            result["path"] = jpegUrl.absoluteString
+            call.resolve(result)
+        } catch {
+            call.reject(error.localizedDescription)
         }
     }
 

--- a/packages/file-picker/src/definitions.ts
+++ b/packages/file-picker/src/definitions.ts
@@ -20,6 +20,16 @@ export interface FilePickerPlugin {
     options: ConvertHeicToJpegOptions,
   ): Promise<ConvertHeicToJpegResult>;
   /**
+   * Convert a RAW image to JPEG.
+   *
+   * Only available on iOS.
+   *
+   * @since 8.1.0
+   */
+  convertRawToJpeg(
+    options: ConvertRawToJpegOptions,
+  ): Promise<ConvertRawToJpegResult>;
+  /**
    * Copy a file to a new location.
    *
    * @since 7.1.0
@@ -118,6 +128,32 @@ export interface ConvertHeicToJpegResult {
    *
    * @example '/path/to/image.jpeg'
    * @since 0.6.0
+   */
+  path: string;
+}
+
+/**
+ * @since 8.1.0
+ */
+export interface ConvertRawToJpegOptions {
+  /**
+   * The path of the RAW image.
+   *
+   * @example '/path/to/image.dng'
+   * @since 8.1.0
+   */
+  path: string;
+}
+
+/**
+ * @since 8.1.0
+ */
+export interface ConvertRawToJpegResult {
+  /**
+   * The path of the converted JPEG image.
+   *
+   * @example '/path/to/image.jpeg'
+   * @since 8.1.0
    */
   path: string;
 }

--- a/packages/file-picker/src/web.ts
+++ b/packages/file-picker/src/web.ts
@@ -3,6 +3,8 @@ import { WebPlugin } from '@capacitor/core';
 import type {
   ConvertHeicToJpegOptions,
   ConvertHeicToJpegResult,
+  ConvertRawToJpegOptions,
+  ConvertRawToJpegResult,
   CopyFileOptions,
   FilePickerPlugin,
   PermissionStatus,
@@ -29,6 +31,12 @@ export class FilePickerWeb extends WebPlugin implements FilePickerPlugin {
   public async convertHeicToJpeg(
     _options: ConvertHeicToJpegOptions,
   ): Promise<ConvertHeicToJpegResult> {
+    throw this.unimplemented('Not implemented on web.');
+  }
+
+  public async convertRawToJpeg(
+    _options: ConvertRawToJpegOptions,
+  ): Promise<ConvertRawToJpegResult> {
     throw this.unimplemented('Not implemented on web.');
   }
 


### PR DESCRIPTION
Close #452

Adds a `convertRawToJpeg(...)` method so RAW images (e.g. `.dng`) picked with `pickImages({ skipTranscoding: false })`, which `PHPicker` does not transcode, can be converted to JPEG. Implemented on iOS; `unimplemented` on Android and web.

- New `ConvertRawToJpegOptions` class validates `path` and resolves it to an existing file (new `CustomError` cases `pathMissing` and `fileNotFound`).
- `convertHeicToJpeg(...)` and `convertRawToJpeg(...)` share a single private `convertImageToJpeg(...)` helper that decodes with `UIImage(contentsOfFile:)` (ImageIO-backed) instead of the previous `UIImage(named:)`. `UIImage(named:)` is the bundle-asset API with a process-wide cache and is not meant for arbitrary file paths. Output naming, JPEG quality (0.9) and temporary-directory handling are unchanged.
- The new Swift file is registered in `project.pbxproj` for CocoaPods.

## Testing

`npm run verify` (iOS, Android, web) passes. Runtime conversion of a `.dng` picked via `pickImages(...)` still needs a device check.
