### PR TITLE
fix(datetime-picker): dismiss the picker on Android configuration changes

### DIFF
--- a/.changeset/datetime-picker-dismiss-on-configuration-change.md
+++ b/.changeset/datetime-picker-dismiss-on-configuration-change.md
@@ -1,0 +1,5 @@
+---
+"@capawesome-team/capacitor-datetime-picker": patch
+---
+
+fix(android): dismiss the picker when the system language, font scale or layout direction changes to avoid an unresponsive dialog

--- a/packages/datetime-picker/README.md
+++ b/packages/datetime-picker/README.md
@@ -148,6 +148,8 @@ Open the datetime picker.
 
 An error is thrown if the input is canceled or dismissed by the user.
 
+On Android, the picker is dismissed (the promise rejects with the `dismissed` error code) if the system language, font size or layout direction changes while it is open.
+
 Only available on Android and iOS.
 
 | Param         | Type                                                      |

--- a/packages/datetime-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/datetimepicker/DatetimePicker.java
+++ b/packages/datetime-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/datetimepicker/DatetimePicker.java
@@ -6,6 +6,7 @@ import android.app.Dialog;
 import android.app.TimePickerDialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
 import android.text.format.DateFormat;
 import android.view.ContextThemeWrapper;
@@ -23,13 +24,30 @@ import java.util.Locale;
 
 public class DatetimePicker {
 
+    private static final int CONFIGURATION_CHANGES_REQUIRING_DISMISS =
+        ActivityInfo.CONFIG_LOCALE | ActivityInfo.CONFIG_FONT_SCALE | ActivityInfo.CONFIG_LAYOUT_DIRECTION;
+
     private final DatetimePickerPlugin plugin;
     private final DatetimePickerConfig config;
     private Dialog activeDialog;
+    private Configuration lastConfiguration;
 
     public DatetimePicker(DatetimePickerPlugin plugin, DatetimePickerConfig config) {
         this.plugin = plugin;
         this.config = config;
+        this.lastConfiguration = new Configuration(plugin.getContext().getResources().getConfiguration());
+    }
+
+    public void handleConfigurationChanged(@NonNull Configuration newConfiguration) {
+        int diff = lastConfiguration.diff(newConfiguration);
+        lastConfiguration = new Configuration(newConfiguration);
+        if ((diff & CONFIGURATION_CHANGES_REQUIRING_DISMISS) != 0) {
+            cancel();
+        }
+    }
+
+    public void handleDestroy() {
+        cancel();
     }
 
     public void presentDateTimePicker(

--- a/packages/datetime-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/datetimepicker/DatetimePickerPlugin.java
+++ b/packages/datetime-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/datetimepicker/DatetimePickerPlugin.java
@@ -167,13 +167,17 @@ public class DatetimePickerPlugin extends Plugin {
     @Override
     protected void handleOnConfigurationChanged(Configuration newConfig) {
         super.handleOnConfigurationChanged(newConfig);
-        implementation.handleConfigurationChanged(newConfig);
+        if (implementation != null) {
+            implementation.handleConfigurationChanged(newConfig);
+        }
     }
 
     @Override
     protected void handleOnDestroy() {
         super.handleOnDestroy();
-        implementation.handleDestroy();
+        if (implementation != null) {
+            implementation.handleDestroy();
+        }
     }
 
     private DatetimePickerConfig getDatetimePickerConfig() {

--- a/packages/datetime-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/datetimepicker/DatetimePickerPlugin.java
+++ b/packages/datetime-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/datetimepicker/DatetimePickerPlugin.java
@@ -1,5 +1,6 @@
 package io.capawesome.capacitorjs.plugins.datetimepicker;
 
+import android.content.res.Configuration;
 import android.util.Log;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
@@ -161,6 +162,18 @@ public class DatetimePickerPlugin extends Plugin {
             Log.e(TAG, message);
             call.reject(message);
         }
+    }
+
+    @Override
+    protected void handleOnConfigurationChanged(Configuration newConfig) {
+        super.handleOnConfigurationChanged(newConfig);
+        implementation.handleConfigurationChanged(newConfig);
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        super.handleOnDestroy();
+        implementation.handleDestroy();
     }
 
     private DatetimePickerConfig getDatetimePickerConfig() {

--- a/packages/datetime-picker/src/definitions.ts
+++ b/packages/datetime-picker/src/definitions.ts
@@ -44,6 +44,8 @@ export interface DatetimePickerPlugin {
    *
    * An error is thrown if the input is canceled or dismissed by the user.
    *
+   * On Android, the picker is dismissed (the promise rejects with the `dismissed` error code) if the system language, font size or layout direction changes while it is open.
+   *
    * Only available on Android and iOS.
    *
    * @since 0.0.1


### PR DESCRIPTION
Close #624

The reporter (Samsung Galaxy A32, Android 13) sees the picker become unresponsive after minimising the app, changing the system language or text size in Android settings and returning. The dialog cannot be closed and the app has to be force-restarted.

I was not able to reproduce this on my devices, so the root cause remains unconfirmed. This is a **defensive fix**: instead of keeping the dialog alive across the configuration change, the picker is dismissed. That turns an unrecoverable freeze into the ordinary `dismissed` rejection apps already handle.

## Changes

- `DatetimePicker` keeps a copy of the last known `Configuration` and, on a configuration change, dismisses the active dialog if the diff contains `CONFIG_LOCALE`, `CONFIG_FONT_SCALE` or `CONFIG_LAYOUT_DIRECTION`. Orientation, screen-size and UI-mode changes are ignored, so rotating the device leaves the picker open.
- The picker is also dismissed when the activity is destroyed, which is what a font-scale change causes since Capacitor's default `android:configChanges` does not include `fontScale`. This also removes the leaked-window warning in that path.
- The `present(...)` documentation mentions the new behaviour.

iOS is unchanged.

## Testing

`npm run verify:android` and `npm run verify:web` pass. The original freeze could not be reproduced, so the fix needs verification by the reporter on the affected device.
