### PR TITLE
refactor!: reject `showActions(...)` and `prompt(...)` with `CANCELED` error code instead of resolving with `canceled` flag

### DIFF
--- a/.changeset/action-sheet-reject-canceled.md
+++ b/.changeset/action-sheet-reject-canceled.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-action-sheet': minor
+---
+
+refactor!: reject `showActions(...)` with the `CANCELED` error code instead of resolving with a `canceled` flag (see `BREAKING.md`)

--- a/.changeset/dialog-reject-canceled.md
+++ b/.changeset/dialog-reject-canceled.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-dialog': minor
+---
+
+refactor!: reject `prompt(...)` with the `CANCELED` error code instead of resolving with a `canceled` flag (see `BREAKING.md`)

--- a/packages/action-sheet/BREAKING.md
+++ b/packages/action-sheet/BREAKING.md
@@ -1,0 +1,30 @@
+# Breaking Changes
+
+This is a comprehensive list of the breaking changes introduced in the different releases.
+
+## Versions
+
+- [Version 0.2.x](#version-02x)
+
+## Version 0.2.x
+
+### `showActions(...)` method
+
+The `canceled` property has been removed from the result. If the user selects a button with the `ActionSheetButtonStyle.Cancel` style or dismisses the action sheet, the promise is now rejected with the `CANCELED` error code instead:
+
+```typescript
+// Before
+const { index, canceled } = await ActionSheet.showActions({ options });
+if (canceled) {
+  console.log('The user canceled the action sheet.');
+}
+
+// After
+try {
+  const { index } = await ActionSheet.showActions({ options });
+} catch (error) {
+  if (error.code === ErrorCode.Canceled) {
+    console.log('The user canceled the action sheet.');
+  }
+}
+```

--- a/packages/action-sheet/README.md
+++ b/packages/action-sheet/README.md
@@ -80,23 +80,29 @@ The following example shows how to present a native action sheet and read the se
 
 ### Show an action sheet
 
-Present a native action sheet with a title, a message, and a list of buttons. Use `ActionSheetButtonStyle.Destructive` to highlight irreversible actions and `ActionSheetButtonStyle.Cancel` to pin a cancel button. The result contains the zero-based index of the selected button and whether the sheet was canceled. Only available on Android and iOS:
+Present a native action sheet with a title, a message, and a list of buttons. Use `ActionSheetButtonStyle.Destructive` to highlight irreversible actions and `ActionSheetButtonStyle.Cancel` to pin a cancel button. The result contains the zero-based index of the selected button. If the user selects the cancel button or dismisses the action sheet, the promise is rejected with the `CANCELED` error code. Only available on Android and iOS:
 
 ```typescript
-import { ActionSheet, ActionSheetButtonStyle } from '@capawesome/capacitor-action-sheet';
+import { ActionSheet, ActionSheetButtonStyle, ErrorCode } from '@capawesome/capacitor-action-sheet';
 
 const showActions = async () => {
-  const { index, canceled } = await ActionSheet.showActions({
-    title: 'Photo Options',
-    message: 'Select an option to perform.',
-    options: [
-      { title: 'Upload' },
-      { title: 'Share' },
-      { title: 'Delete', style: ActionSheetButtonStyle.Destructive },
-      { title: 'Cancel', style: ActionSheetButtonStyle.Cancel },
-    ],
-  });
-  console.log('Index:', index, 'Canceled:', canceled);
+  try {
+    const { index } = await ActionSheet.showActions({
+      title: 'Photo Options',
+      message: 'Select an option to perform.',
+      options: [
+        { title: 'Upload' },
+        { title: 'Share' },
+        { title: 'Delete', style: ActionSheetButtonStyle.Destructive },
+        { title: 'Cancel', style: ActionSheetButtonStyle.Cancel },
+      ],
+    });
+    console.log('Index:', index);
+  } catch (error) {
+    if (error.code === ErrorCode.Canceled) {
+      console.log('The user canceled the action sheet.');
+    }
+  }
 };
 ```
 
@@ -121,6 +127,10 @@ showActions(options: ShowActionsOptions) => Promise<ShowActionsResult>
 
 Show an action sheet with a list of buttons.
 
+If the user selects a button with the <a href="#actionsheetbuttonstyle">`ActionSheetButtonStyle.Cancel`</a> style
+or dismisses the action sheet, the promise is rejected with the `CANCELED`
+error code.
+
 Only available on Android and iOS.
 
 | Param         | Type                                                              |
@@ -139,10 +149,9 @@ Only available on Android and iOS.
 
 #### ShowActionsResult
 
-| Prop           | Type                 | Description                                                                                                                                        | Since |
-| -------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| **`canceled`** | <code>boolean</code> | Whether the action sheet was canceled by selecting a cancel button or by dismissing the action sheet.                                              | 0.1.0 |
-| **`index`**    | <code>number</code>  | The index of the selected button in the `options` array (zero-based). If the action sheet was canceled without a cancel button, the index is `-1`. | 0.1.0 |
+| Prop        | Type                | Description                                                           | Since |
+| ----------- | ------------------- | --------------------------------------------------------------------- | ----- |
+| **`index`** | <code>number</code> | The index of the selected button in the `options` array (zero-based). | 0.1.0 |
 
 
 #### ShowActionsOptions
@@ -178,12 +187,12 @@ Only available on Android and iOS.
 
 ## Migrating from `@capacitor/action-sheet`
 
-This plugin is API-compatible with the official [`@capacitor/action-sheet`](https://github.com/ionic-team/capacitor-plugins/tree/main/action-sheet) plugin. The `ActionSheetButtonStyle` enum uses the same values (`DEFAULT`, `DESTRUCTIVE`, `CANCEL`), so no enum changes are required. The following differences apply:
+This plugin is largely API-compatible with the official [`@capacitor/action-sheet`](https://github.com/ionic-team/capacitor-plugins/tree/main/action-sheet) plugin. The `ActionSheetButtonStyle` enum uses the same values (`DEFAULT`, `DESTRUCTIVE`, `CANCEL`), so no enum changes are required. The following differences apply:
 
 | `@capacitor/action-sheet`                       | `@capawesome/capacitor-action-sheet`                   |
 | ----------------------------------------------- | ------------------------------------------------------ |
 | `showActions({ title, message, options })`      | `showActions({ title, message, options, cancelable })` |
-| `showActions(...) → { index }`                  | `showActions(...) → { index, canceled }`               |
+| Cancel button resolves with its `index`         | Cancel button rejects with the `CANCELED` error code   |
 | `message` and button styles ignored on Android  | `message` and button styles rendered on Android        |
 | `cancelable` not available                      | `cancelable` (default `true`)                          |
 
@@ -191,7 +200,7 @@ This plugin is API-compatible with the official [`@capacitor/action-sheet`](http
 
 ### How is this plugin different from other similar plugins?
 
-It presents the platform's own native action sheet on Android and iOS through a fully typed API, rendering the title, message, and button styles — including destructive and cancel styles — consistently on both platforms, and automatically anchoring as a popover on iPad. The result reports the selected button index along with a `canceled` flag, and the `cancelable` option controls dismissal, all using only official platform APIs. Actively maintained against the latest Capacitor version, it lets a single dependency cover the whole action-sheet story.
+It presents the platform's own native action sheet on Android and iOS through a fully typed API, rendering the title, message, and button styles — including destructive and cancel styles — consistently on both platforms, and automatically anchoring as a popover on iPad. The result reports the selected button index, a cancellation rejects the promise with the `CANCELED` error code, and the `cancelable` option controls dismissal, all using only official platform APIs. Actively maintained against the latest Capacitor version, it lets a single dependency cover the whole action-sheet story.
 
 ### On which platforms can I show an action sheet?
 
@@ -199,15 +208,15 @@ The `showActions(...)` method is only available on Android and iOS, where it pre
 
 ### How do I know which button the user selected?
 
-The result of `showActions(...)` contains the zero-based `index` of the selected button in the `options` array and a `canceled` flag. If the action sheet was canceled without a cancel button, the index is `-1`.
+The result of `showActions(...)` contains the zero-based `index` of the selected button in the `options` array. If the user selects a button with the `ActionSheetButtonStyle.Cancel` style or dismisses the action sheet, the promise is rejected with the `CANCELED` error code instead.
 
 ### Can the user dismiss the action sheet without selecting a button?
 
-Yes. On Android, the action sheet can be dismissed by tapping outside of it or pressing the back button unless you set the `cancelable` option to `false`. On iOS, the action sheet can always be dismissed by tapping outside of it, which is a system behavior.
+Yes. On Android, the action sheet can be dismissed by tapping outside of it or pressing the back button unless you set the `cancelable` option to `false`. On iOS, the action sheet can always be dismissed by tapping outside of it, which is a system behavior. If the action sheet is dismissed, the promise is rejected with the `CANCELED` error code.
 
 ### How is this plugin different from the official Capacitor Action Sheet plugin?
 
-This plugin is API-compatible with the official `@capacitor/action-sheet` plugin and uses the same `ActionSheetButtonStyle` enum values. In addition, it renders the message and button styles on Android, returns a `canceled` flag, and supports the `cancelable` option. See the [migration section](#migrating-from-capacitoraction-sheet) for a detailed comparison.
+This plugin is largely API-compatible with the official `@capacitor/action-sheet` plugin and uses the same `ActionSheetButtonStyle` enum values. In addition, it renders the message and button styles on Android, rejects with the `CANCELED` error code when the user cancels, and supports the `cancelable` option. See the [migration section](#migrating-from-capacitoraction-sheet) for a detailed comparison.
 
 ### Can I use this plugin together with the Capawesome Dialog plugin?
 

--- a/packages/action-sheet/android/src/main/java/io/capawesome/capacitorjs/plugins/actionsheet/ActionSheet.java
+++ b/packages/action-sheet/android/src/main/java/io/capawesome/capacitorjs/plugins/actionsheet/ActionSheet.java
@@ -12,6 +12,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.core.widget.NestedScrollView;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
+import io.capawesome.capacitorjs.plugins.actionsheet.classes.CustomExceptions;
 import io.capawesome.capacitorjs.plugins.actionsheet.classes.options.ActionSheetButton;
 import io.capawesome.capacitorjs.plugins.actionsheet.classes.options.ShowActionsOptions;
 import io.capawesome.capacitorjs.plugins.actionsheet.classes.results.ShowActionsResult;
@@ -62,25 +63,24 @@ public class ActionSheet {
                 final int index = i;
                 TextView buttonView = createButtonView(activity, button.getTitle(), button.isDestructive());
                 buttonView.setOnClickListener(view -> {
-                    callback.success(new ShowActionsResult(index, false));
+                    callback.success(new ShowActionsResult(index));
                     dialog.dismiss();
                 });
                 container.addView(buttonView);
             }
 
-            final int resolvedCancelIndex = cancelIndex;
             if (cancelIndex != -1) {
                 container.addView(createDividerView(activity));
                 TextView cancelButtonView = createButtonView(activity, buttons.get(cancelIndex).getTitle(), false);
                 cancelButtonView.setOnClickListener(view -> {
-                    callback.success(new ShowActionsResult(resolvedCancelIndex, true));
+                    callback.error(CustomExceptions.CANCELED);
                     dialog.dismiss();
                 });
                 container.addView(cancelButtonView);
             }
 
             dialog.setCancelable(options.isCancelable());
-            dialog.setOnCancelListener(dialogInterface -> callback.success(new ShowActionsResult(resolvedCancelIndex, true)));
+            dialog.setOnCancelListener(dialogInterface -> callback.error(CustomExceptions.CANCELED));
 
             NestedScrollView scrollView = new NestedScrollView(activity);
             scrollView.addView(container);

--- a/packages/action-sheet/android/src/main/java/io/capawesome/capacitorjs/plugins/actionsheet/classes/CustomExceptions.java
+++ b/packages/action-sheet/android/src/main/java/io/capawesome/capacitorjs/plugins/actionsheet/classes/CustomExceptions.java
@@ -3,6 +3,7 @@ package io.capawesome.capacitorjs.plugins.actionsheet.classes;
 public class CustomExceptions {
 
     public static final CustomException BUTTON_TITLE_MISSING = new CustomException(null, "each button must provide a title.");
+    public static final CustomException CANCELED = new CustomException("CANCELED", "The user canceled the action sheet.");
     public static final CustomException OPTIONS_EMPTY = new CustomException(null, "options must not be empty.");
     public static final CustomException OPTIONS_MISSING = new CustomException(null, "options must be provided.");
 }

--- a/packages/action-sheet/android/src/main/java/io/capawesome/capacitorjs/plugins/actionsheet/classes/results/ShowActionsResult.java
+++ b/packages/action-sheet/android/src/main/java/io/capawesome/capacitorjs/plugins/actionsheet/classes/results/ShowActionsResult.java
@@ -6,19 +6,16 @@ import io.capawesome.capacitorjs.plugins.actionsheet.interfaces.Result;
 
 public class ShowActionsResult implements Result {
 
-    private final boolean canceled;
     private final int index;
 
-    public ShowActionsResult(int index, boolean canceled) {
+    public ShowActionsResult(int index) {
         this.index = index;
-        this.canceled = canceled;
     }
 
     @Override
     @NonNull
     public JSObject toJSObject() {
         JSObject result = new JSObject();
-        result.put("canceled", canceled);
         result.put("index", index);
         return result;
     }

--- a/packages/action-sheet/example/src/js/script.js
+++ b/packages/action-sheet/example/src/js/script.js
@@ -1,6 +1,7 @@
 import {
   ActionSheet,
   ActionSheetButtonStyle,
+  ErrorCode,
 } from '@capawesome/capacitor-action-sheet';
 
 const setResult = value => {
@@ -9,16 +10,24 @@ const setResult = value => {
 
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelector('#showActions').addEventListener('click', async () => {
-    const { index, canceled } = await ActionSheet.showActions({
-      title: 'Photo Options',
-      message: 'Select an option to perform.',
-      options: [
-        { title: 'Upload' },
-        { title: 'Share' },
-        { title: 'Delete', style: ActionSheetButtonStyle.Destructive },
-        { title: 'Cancel', style: ActionSheetButtonStyle.Cancel },
-      ],
-    });
-    setResult(`Index: ${index}, Canceled: ${canceled}`);
+    try {
+      const { index } = await ActionSheet.showActions({
+        title: 'Photo Options',
+        message: 'Select an option to perform.',
+        options: [
+          { title: 'Upload' },
+          { title: 'Share' },
+          { title: 'Delete', style: ActionSheetButtonStyle.Destructive },
+          { title: 'Cancel', style: ActionSheetButtonStyle.Cancel },
+        ],
+      });
+      setResult(`Index: ${index}`);
+    } catch (error) {
+      if (error.code === ErrorCode.Canceled) {
+        setResult('Canceled');
+      } else {
+        setResult(`Error: ${error.message}`);
+      }
+    }
   });
 });

--- a/packages/action-sheet/ios/Plugin/ActionSheet.swift
+++ b/packages/action-sheet/ios/Plugin/ActionSheet.swift
@@ -16,7 +16,11 @@ import UIKit
             let alertController = UIAlertController(title: options.title, message: options.message, preferredStyle: .actionSheet)
             for (index, button) in options.buttons.enumerated() {
                 let action = UIAlertAction(title: button.title, style: self.alertActionStyle(for: button.style)) { _ in
-                    self.resolve(index: index, canceled: button.style == ActionSheetButton.styleCancel)
+                    if button.style == ActionSheetButton.styleCancel {
+                        self.complete(nil, CustomError.canceled)
+                    } else {
+                        self.complete(ShowActionsResult(index: index), nil)
+                    }
                 }
                 alertController.addAction(action)
             }
@@ -31,7 +35,7 @@ import UIKit
     }
 
     public func popoverPresentationControllerDidDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) {
-        resolve(index: -1, canceled: true)
+        complete(nil, CustomError.canceled)
     }
 
     private func alertActionStyle(for style: String) -> UIAlertAction.Style {
@@ -45,15 +49,15 @@ import UIKit
         }
     }
 
-    private func present(_ alertController: UIAlertController) {
-        plugin.bridge?.viewController?.present(alertController, animated: true)
-    }
-
-    private func resolve(index: Int, canceled: Bool) {
+    private func complete(_ result: ShowActionsResult?, _ error: Error?) {
         guard let completion = pendingCompletion else {
             return
         }
         pendingCompletion = nil
-        completion(ShowActionsResult(index: index, canceled: canceled), nil)
+        completion(result, error)
+    }
+
+    private func present(_ alertController: UIAlertController) {
+        plugin.bridge?.viewController?.present(alertController, animated: true)
     }
 }

--- a/packages/action-sheet/ios/Plugin/Classes/Results/ShowActionsResult.swift
+++ b/packages/action-sheet/ios/Plugin/Classes/Results/ShowActionsResult.swift
@@ -2,17 +2,14 @@ import Foundation
 import Capacitor
 
 @objc public class ShowActionsResult: NSObject, Result {
-    let canceled: Bool
     let index: Int
 
-    init(index: Int, canceled: Bool) {
+    init(index: Int) {
         self.index = index
-        self.canceled = canceled
     }
 
     @objc public func toJSObject() -> AnyObject {
         var result = JSObject()
-        result["canceled"] = canceled
         result["index"] = index
         return result as AnyObject
     }

--- a/packages/action-sheet/ios/Plugin/Enums/CustomError.swift
+++ b/packages/action-sheet/ios/Plugin/Enums/CustomError.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum CustomError: Error {
     case buttonTitleMissing
+    case canceled
     case optionsEmpty
     case optionsMissing
 
@@ -9,6 +10,8 @@ enum CustomError: Error {
         switch self {
         case .buttonTitleMissing:
             return nil
+        case .canceled:
+            return "CANCELED"
         case .optionsEmpty:
             return nil
         case .optionsMissing:
@@ -22,6 +25,8 @@ extension CustomError: LocalizedError {
         switch self {
         case .buttonTitleMissing:
             return NSLocalizedString("each button must provide a title.", comment: "buttonTitleMissing")
+        case .canceled:
+            return NSLocalizedString("The user canceled the action sheet.", comment: "canceled")
         case .optionsEmpty:
             return NSLocalizedString("options must not be empty.", comment: "optionsEmpty")
         case .optionsMissing:

--- a/packages/action-sheet/src/definitions.ts
+++ b/packages/action-sheet/src/definitions.ts
@@ -2,6 +2,10 @@ export interface ActionSheetPlugin {
   /**
    * Show an action sheet with a list of buttons.
    *
+   * If the user selects a button with the `ActionSheetButtonStyle.Cancel` style
+   * or dismisses the action sheet, the promise is rejected with the `CANCELED`
+   * error code.
+   *
    * Only available on Android and iOS.
    *
    * @since 0.1.0
@@ -73,17 +77,7 @@ export interface ActionSheetButton {
  */
 export interface ShowActionsResult {
   /**
-   * Whether the action sheet was canceled by selecting a cancel button or by
-   * dismissing the action sheet.
-   *
-   * @since 0.1.0
-   * @example false
-   */
-  canceled: boolean;
-  /**
    * The index of the selected button in the `options` array (zero-based).
-   *
-   * If the action sheet was canceled without a cancel button, the index is `-1`.
    *
    * @since 0.1.0
    * @example 0
@@ -117,4 +111,17 @@ export enum ActionSheetButtonStyle {
    * @since 0.1.0
    */
   Destructive = 'DESTRUCTIVE',
+}
+
+/**
+ * @since 0.2.0
+ */
+export enum ErrorCode {
+  /**
+   * The user canceled the action sheet by selecting a cancel button or by
+   * dismissing the action sheet.
+   *
+   * @since 0.2.0
+   */
+  Canceled = 'CANCELED',
 }

--- a/packages/dialog/BREAKING.md
+++ b/packages/dialog/BREAKING.md
@@ -1,0 +1,30 @@
+# Breaking Changes
+
+This is a comprehensive list of the breaking changes introduced in the different releases.
+
+## Versions
+
+- [Version 0.2.x](#version-02x)
+
+## Version 0.2.x
+
+### `prompt(...)` method
+
+The `canceled` property has been removed from the result. If the user selects the cancel button or dismisses the dialog, the promise is now rejected with the `CANCELED` error code instead:
+
+```typescript
+// Before
+const { value, canceled } = await Dialog.prompt({ message: 'What is your name?' });
+if (canceled) {
+  console.log('The user canceled the dialog.');
+}
+
+// After
+try {
+  const { value } = await Dialog.prompt({ message: 'What is your name?' });
+} catch (error) {
+  if (error.code === ErrorCode.Canceled) {
+    console.log('The user canceled the dialog.');
+  }
+}
+```

--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -107,18 +107,24 @@ const confirm = async () => {
 
 ### Request text input from the user
 
-Show a prompt dialog with a text input, a confirm and a cancel button. The result contains the entered value and whether the user canceled the dialog:
+Show a prompt dialog with a text input, a confirm and a cancel button. The result contains the entered value. If the user cancels the dialog, the promise is rejected with the `CANCELED` error code:
 
 ```typescript
-import { Dialog } from '@capawesome/capacitor-dialog';
+import { Dialog, ErrorCode } from '@capawesome/capacitor-dialog';
 
 const prompt = async () => {
-  const { value, canceled } = await Dialog.prompt({
-    title: 'Name',
-    message: 'What is your name?',
-    inputPlaceholder: 'Enter your name',
-  });
-  console.log('Value:', value, 'Canceled:', canceled);
+  try {
+    const { value } = await Dialog.prompt({
+      title: 'Name',
+      message: 'What is your name?',
+      inputPlaceholder: 'Enter your name',
+    });
+    console.log('Value:', value);
+  } catch (error) {
+    if (error.code === ErrorCode.Canceled) {
+      console.log('The user canceled the dialog.');
+    }
+  }
 };
 ```
 
@@ -180,6 +186,9 @@ prompt(options: PromptOptions) => Promise<PromptResult>
 
 Display a prompt dialog with a text input, a confirm and a cancel button.
 
+If the user selects the cancel button or dismisses the dialog, the promise
+is rejected with the `CANCELED` error code.
+
 | Param         | Type                                                    |
 | ------------- | ------------------------------------------------------- |
 | **`options`** | <code><a href="#promptoptions">PromptOptions</a></code> |
@@ -222,10 +231,9 @@ Display a prompt dialog with a text input, a confirm and a cancel button.
 
 #### PromptResult
 
-| Prop           | Type                 | Description                           | Since |
-| -------------- | -------------------- | ------------------------------------- | ----- |
-| **`canceled`** | <code>boolean</code> | Whether the user canceled the dialog. | 0.1.0 |
-| **`value`**    | <code>string</code>  | The value of the text input.          | 0.1.0 |
+| Prop        | Type                | Description                  | Since |
+| ----------- | ------------------- | ---------------------------- | ----- |
+| **`value`** | <code>string</code> | The value of the text input. | 0.1.0 |
 
 
 #### PromptOptions
@@ -243,13 +251,13 @@ Display a prompt dialog with a text input, a confirm and a cancel button.
 
 ## Migrating from `@capacitor/dialog`
 
-This plugin is API-compatible with the official [`@capacitor/dialog`](https://github.com/ionic-team/capacitor-plugins/tree/main/dialog) plugin, with a single difference: the `prompt(...)` result uses the property `canceled` (one `l`) instead of `cancelled` (two `l`s).
+This plugin is largely API-compatible with the official [`@capacitor/dialog`](https://github.com/ionic-team/capacitor-plugins/tree/main/dialog) plugin, with a single difference: if the user cancels a prompt dialog, `prompt(...)` rejects with the `CANCELED` error code instead of resolving with a `cancelled` flag.
 
-| `@capacitor/dialog`                | `@capawesome/capacitor-dialog`     |
-| ---------------------------------- | ---------------------------------- |
-| `alert({ title, message, buttonTitle })` | `alert({ title, message, buttonTitle })` |
-| `confirm({ ... }) → { value }`     | `confirm({ ... }) → { value }`     |
-| `prompt({ ... }) → { value, cancelled }` | `prompt({ ... }) → { value, canceled }` |
+| `@capacitor/dialog`                      | `@capawesome/capacitor-dialog`                                   |
+| ---------------------------------------- | ---------------------------------------------------------------- |
+| `alert({ title, message, buttonTitle })` | `alert({ title, message, buttonTitle })`                         |
+| `confirm({ ... }) → { value }`           | `confirm({ ... }) → { value }`                                   |
+| `prompt({ ... }) → { value, cancelled }` | `prompt({ ... }) → { value }`, rejects with `CANCELED` on cancel |
 
 ## FAQ
 
@@ -259,7 +267,7 @@ It brings native alert, confirm, and prompt dialogs to Android, iOS, and the web
 
 ### How is this plugin different from the official `@capacitor/dialog` plugin?
 
-This plugin is API-compatible with the official `@capacitor/dialog` plugin, with a single difference: the `prompt(...)` result uses the property `canceled` (one `l`) instead of `cancelled` (two `l`s). See the [migration table](#migrating-from-capacitordialog) above for the complete method mapping.
+This plugin is largely API-compatible with the official `@capacitor/dialog` plugin, with a single difference: if the user cancels a prompt dialog, `prompt(...)` rejects with the `CANCELED` error code instead of resolving with a `cancelled` flag. See the [migration table](#migrating-from-capacitordialog) above for the complete method mapping.
 
 ### Can I customize the dialog buttons?
 
@@ -267,7 +275,7 @@ Yes, on Android and iOS you can customize the button titles using the `buttonTit
 
 ### How do I know whether the user canceled a prompt?
 
-The result of the `prompt(...)` method contains a `canceled` property that is `true` if the user canceled the dialog, in addition to the `value` property with the text input. For confirmation dialogs, the `value` property of the `confirm(...)` result tells you whether the user confirmed the dialog.
+If the user cancels the dialog, the `prompt(...)` method rejects with the `CANCELED` error code, so catch the error and compare `error.code` with `ErrorCode.Canceled`. Otherwise, the result contains the entered text in the `value` property. For confirmation dialogs, the `value` property of the `confirm(...)` result tells you whether the user confirmed the dialog.
 
 ### Why is the dialog title not displayed on the web?
 

--- a/packages/dialog/android/src/main/java/io/capawesome/capacitorjs/plugins/dialog/Dialog.java
+++ b/packages/dialog/android/src/main/java/io/capawesome/capacitorjs/plugins/dialog/Dialog.java
@@ -5,6 +5,7 @@ import android.text.InputType;
 import android.widget.EditText;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
+import io.capawesome.capacitorjs.plugins.dialog.classes.CustomExceptions;
 import io.capawesome.capacitorjs.plugins.dialog.classes.options.AlertOptions;
 import io.capawesome.capacitorjs.plugins.dialog.classes.options.ConfirmOptions;
 import io.capawesome.capacitorjs.plugins.dialog.classes.options.PromptOptions;
@@ -63,12 +64,10 @@ public class Dialog {
             builder.setMessage(options.getMessage());
             builder.setView(input);
             builder.setPositiveButton(options.getOkButtonTitle(), (dialog, which) ->
-                callback.success(new PromptResult(input.getText().toString(), false))
+                callback.success(new PromptResult(input.getText().toString()))
             );
-            builder.setNegativeButton(options.getCancelButtonTitle(), (dialog, which) ->
-                callback.success(new PromptResult(input.getText().toString(), true))
-            );
-            builder.setOnCancelListener(dialog -> callback.success(new PromptResult("", true)));
+            builder.setNegativeButton(options.getCancelButtonTitle(), (dialog, which) -> callback.error(CustomExceptions.CANCELED));
+            builder.setOnCancelListener(dialog -> callback.error(CustomExceptions.CANCELED));
             builder.create().show();
         });
     }

--- a/packages/dialog/android/src/main/java/io/capawesome/capacitorjs/plugins/dialog/classes/CustomExceptions.java
+++ b/packages/dialog/android/src/main/java/io/capawesome/capacitorjs/plugins/dialog/classes/CustomExceptions.java
@@ -2,5 +2,6 @@ package io.capawesome.capacitorjs.plugins.dialog.classes;
 
 public class CustomExceptions {
 
+    public static final CustomException CANCELED = new CustomException("CANCELED", "The user canceled the dialog.");
     public static final CustomException MESSAGE_MISSING = new CustomException(null, "message must be provided.");
 }

--- a/packages/dialog/android/src/main/java/io/capawesome/capacitorjs/plugins/dialog/classes/results/PromptResult.java
+++ b/packages/dialog/android/src/main/java/io/capawesome/capacitorjs/plugins/dialog/classes/results/PromptResult.java
@@ -6,21 +6,17 @@ import io.capawesome.capacitorjs.plugins.dialog.interfaces.Result;
 
 public class PromptResult implements Result {
 
-    private final boolean canceled;
-
     @NonNull
     private final String value;
 
-    public PromptResult(@NonNull String value, boolean canceled) {
+    public PromptResult(@NonNull String value) {
         this.value = value;
-        this.canceled = canceled;
     }
 
     @Override
     @NonNull
     public JSObject toJSObject() {
         JSObject result = new JSObject();
-        result.put("canceled", canceled);
         result.put("value", value);
         return result;
     }

--- a/packages/dialog/example/src/js/script.js
+++ b/packages/dialog/example/src/js/script.js
@@ -1,4 +1,4 @@
-import { Dialog } from '@capawesome/capacitor-dialog';
+import { Dialog, ErrorCode } from '@capawesome/capacitor-dialog';
 
 const setResult = value => {
   document.querySelector('#result').textContent = `Result: ${value}`;
@@ -20,11 +20,19 @@ document.addEventListener('DOMContentLoaded', () => {
     setResult(`Confirmed: ${value}`);
   });
   document.querySelector('#prompt').addEventListener('click', async () => {
-    const { value, canceled } = await Dialog.prompt({
-      title: 'Name',
-      message: 'What is your name?',
-      inputPlaceholder: 'Enter your name',
-    });
-    setResult(`Value: ${value}, Canceled: ${canceled}`);
+    try {
+      const { value } = await Dialog.prompt({
+        title: 'Name',
+        message: 'What is your name?',
+        inputPlaceholder: 'Enter your name',
+      });
+      setResult(`Value: ${value}`);
+    } catch (error) {
+      if (error.code === ErrorCode.Canceled) {
+        setResult('Canceled');
+      } else {
+        setResult(`Error: ${error.message}`);
+      }
+    }
   });
 });

--- a/packages/dialog/ios/Plugin/Classes/Results/PromptResult.swift
+++ b/packages/dialog/ios/Plugin/Classes/Results/PromptResult.swift
@@ -2,17 +2,14 @@ import Foundation
 import Capacitor
 
 @objc public class PromptResult: NSObject, Result {
-    let canceled: Bool
     let value: String
 
-    init(value: String, canceled: Bool) {
+    init(value: String) {
         self.value = value
-        self.canceled = canceled
     }
 
     @objc public func toJSObject() -> AnyObject {
         var result = JSObject()
-        result["canceled"] = canceled
         result["value"] = value
         return result as AnyObject
     }

--- a/packages/dialog/ios/Plugin/Dialog.swift
+++ b/packages/dialog/ios/Plugin/Dialog.swift
@@ -40,12 +40,11 @@ import UIKit
                 textField.text = options.inputText
             }
             alertController.addAction(UIAlertAction(title: options.cancelButtonTitle, style: .cancel) { _ in
-                let value = alertController.textFields?.first?.text ?? ""
-                completion(PromptResult(value: value, canceled: true), nil)
+                completion(nil, CustomError.canceled)
             })
             alertController.addAction(UIAlertAction(title: options.okButtonTitle, style: .default) { _ in
                 let value = alertController.textFields?.first?.text ?? ""
-                completion(PromptResult(value: value, canceled: false), nil)
+                completion(PromptResult(value: value), nil)
             })
             self.present(alertController)
         }

--- a/packages/dialog/ios/Plugin/Enums/CustomError.swift
+++ b/packages/dialog/ios/Plugin/Enums/CustomError.swift
@@ -1,10 +1,13 @@
 import Foundation
 
 enum CustomError: Error {
+    case canceled
     case messageMissing
 
     var code: String? {
         switch self {
+        case .canceled:
+            return "CANCELED"
         case .messageMissing:
             return nil
         }
@@ -14,6 +17,8 @@ enum CustomError: Error {
 extension CustomError: LocalizedError {
     public var errorDescription: String? {
         switch self {
+        case .canceled:
+            return NSLocalizedString("The user canceled the dialog.", comment: "canceled")
         case .messageMissing:
             return NSLocalizedString("message must be provided.", comment: "messageMissing")
         }

--- a/packages/dialog/src/definitions.ts
+++ b/packages/dialog/src/definitions.ts
@@ -14,6 +14,9 @@ export interface DialogPlugin {
   /**
    * Display a prompt dialog with a text input, a confirm and a cancel button.
    *
+   * If the user selects the cancel button or dismisses the dialog, the promise
+   * is rejected with the `CANCELED` error code.
+   *
    * @since 0.1.0
    */
   prompt(options: PromptOptions): Promise<PromptResult>;
@@ -169,17 +172,23 @@ export interface PromptOptions {
  */
 export interface PromptResult {
   /**
-   * Whether the user canceled the dialog.
-   *
-   * @since 0.1.0
-   * @example false
-   */
-  canceled: boolean;
-  /**
    * The value of the text input.
    *
    * @since 0.1.0
    * @example 'John Doe'
    */
   value: string;
+}
+
+/**
+ * @since 0.2.0
+ */
+export enum ErrorCode {
+  /**
+   * The user canceled the dialog by selecting the cancel button or by
+   * dismissing the dialog.
+   *
+   * @since 0.2.0
+   */
+  Canceled = 'CANCELED',
 }

--- a/packages/dialog/src/web.ts
+++ b/packages/dialog/src/web.ts
@@ -1,4 +1,4 @@
-import { WebPlugin } from '@capacitor/core';
+import { CapacitorException, WebPlugin } from '@capacitor/core';
 
 import type {
   AlertOptions,
@@ -8,8 +8,10 @@ import type {
   PromptOptions,
   PromptResult,
 } from './definitions';
+import { ErrorCode } from './definitions';
 
 export class DialogWeb extends WebPlugin implements DialogPlugin {
+  private static readonly errorCanceled = 'The user canceled the dialog.';
   private static readonly errorMessageMissing = 'message must be provided.';
 
   async alert(options: AlertOptions): Promise<void> {
@@ -33,8 +35,10 @@ export class DialogWeb extends WebPlugin implements DialogPlugin {
     }
     const value = window.prompt(options.message, options.inputText ?? '');
     if (value === null) {
-      return { canceled: true, value: '' };
+      throw new CapacitorException(DialogWeb.errorCanceled, undefined, {
+        code: ErrorCode.Canceled,
+      });
     }
-    return { canceled: false, value };
+    return { value };
   }
 }


### PR DESCRIPTION
Rejects `ActionSheet.showActions(...)` and `Dialog.prompt(...)` with the new `ErrorCode.Canceled` (`CANCELED`) when the user selects a cancel button or dismisses the sheet or dialog, and removes the `canceled` flag from `ShowActionsResult` and `PromptResult`. This aligns both plugins with the other plugins that model cancellation as a rejection.

- Add `ErrorCode.Canceled` to both `definitions.ts` files.
- Reject instead of resolving on cancel or dismiss on Android and iOS, and on the web for `dialog`.
- Update the READMEs (usage, migration tables, FAQ) and example apps, add `BREAKING.md` and `minor` changesets (both packages are `0.x`).

Close #1043
Close #1044