### PR TITLE
fix(asset-manager): return the file names instead of the full paths from `list(...)` on iOS

### DIFF
--- a/.changeset/shiny-pears-listen.md
+++ b/.changeset/shiny-pears-listen.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-asset-manager': patch
+---
+
+fix(ios): return the file names instead of the full paths from `list(...)`

--- a/packages/asset-manager/README.md
+++ b/packages/asset-manager/README.md
@@ -212,9 +212,9 @@ Only available on Android and iOS.
 
 #### ListResult
 
-| Prop        | Type                  | Description                         | Since |
-| ----------- | --------------------- | ----------------------------------- | ----- |
-| **`files`** | <code>string[]</code> | The list of files in the directory. | 7.0.0 |
+| Prop        | Type                  | Description                                                                                    | Since |
+| ----------- | --------------------- | ---------------------------------------------------------------------------------------------- | ----- |
+| **`files`** | <code>string[]</code> | The names of the files in the directory. The names are relative to the `path` that was listed. | 7.0.0 |
 
 
 #### ListOptions

--- a/packages/asset-manager/ios/Plugin/AssetManager.swift
+++ b/packages/asset-manager/ios/Plugin/AssetManager.swift
@@ -23,7 +23,8 @@ import Foundation
     @objc public func list(_ options: ListOptions, completion: @escaping (Result?, Error?) -> Void) throws {
         let bundle = Bundle.main
         let paths = bundle.paths(forResourcesOfType: nil, inDirectory: options.path)
-        let result = ListResult(files: paths)
+        let files = paths.map { URL(fileURLWithPath: $0).lastPathComponent }
+        let result = ListResult(files: files)
         completion(result, nil)
     }
 

--- a/packages/asset-manager/src/definitions.ts
+++ b/packages/asset-manager/src/definitions.ts
@@ -70,10 +70,12 @@ export interface ListOptions {
  */
 export interface ListResult {
   /**
-   * The list of files in the directory.
+   * The names of the files in the directory.
+   *
+   * The names are relative to the `path` that was listed.
    *
    * @since 7.0.0
-   * @example ['/private/var/containers/Bundle/Application/D83E2C08-BBA1-4963-8ED8-806FD92E15B3/App.app/public/index.html']
+   * @example ['index.html']
    */
   files: string[];
 }


### PR DESCRIPTION
`AssetManager.list()` returned absolute bundle paths on iOS but bare file names on Android, because `Bundle.paths(forResourcesOfType:inDirectory:)` returns full paths. iOS now maps each result to its last path component, so both platforms return names relative to the listed `path` — which is also the form that `read(...)` and `copy(...)` expect back.

The `files` property is now documented accordingly; its example previously showed the iOS-only full-path shape.

Close #1052
