### PR TITLE
fix(maplibre): update `maplibre-gl` to `6.4.1` to resolve a critical XSS vulnerability

### DIFF
--- a/.changeset/tender-moons-repeat.md
+++ b/.changeset/tender-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-maplibre': patch
+---
+
+fix: update `maplibre-gl` to `6.4.1` to resolve a critical XSS vulnerability (GHSA-jrc7-96c5-q579)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5995,9 +5995,9 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-6.3.0.tgz",
-      "integrity": "sha512-F0Is48MTzn3DvOEidPjh68E0kuSA7hdzY1YIR0ypPtFgcif3WPtzI1oZFgsv9WtHmarQnbwIXfsf+EfQYvM00A==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-6.4.1.tgz",
+      "integrity": "sha512-KzxQKtfBu/pSz1C+yW1hNS9eyj2h2lC7ufdAi6/SEt177n3oAfDfmUmslRfJdXY7ReAFBcnvwsqmiyoDhtA9GQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/point-geometry": "^1.1.0",
@@ -10149,7 +10149,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "maplibre-gl": "6.3.0"
+        "maplibre-gl": "6.4.1"
       },
       "devDependencies": {
         "@capacitor/android": "8.0.0",
@@ -11301,7 +11301,7 @@
     },
     "packages/tiktok-app-events": {
       "name": "@capawesome/capacitor-tiktok-app-events",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "funding": [
         {
           "type": "github",

--- a/packages/maplibre/example/package-lock.json
+++ b/packages/maplibre/example/package-lock.json
@@ -21,7 +21,7 @@
     },
     "..": {
       "name": "@capawesome/capacitor-maplibre",
-      "version": "0.0.0",
+      "version": "0.1.1",
       "funding": [
         {
           "type": "github",
@@ -34,7 +34,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "maplibre-gl": "6.3.0"
+        "maplibre-gl": "6.4.1"
       },
       "devDependencies": {
         "@capacitor/android": "8.0.0",

--- a/packages/maplibre/package.json
+++ b/packages/maplibre/package.json
@@ -62,7 +62,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "maplibre-gl": "6.3.0"
+    "maplibre-gl": "6.4.1"
   },
   "devDependencies": {
     "@capacitor/android": "8.0.0",


### PR DESCRIPTION
Updates `maplibre-gl` from `6.3.0` to `6.4.1` in `@capawesome/capacitor-maplibre` to resolve [GHSA-jrc7-96c5-q579](https://github.com/advisories/GHSA-jrc7-96c5-q579) (critical, CVSS 10.0).

## Vulnerability

`DOM.sanitize()` iterated over the live `NamedNodeMap` returned by `Element.attributes` while removing attributes from it. Removing an attribute shifts the collection, so the loop skipped the following one. Crafted markup with consecutive dangerous attributes (e.g. `<details open onload="1" ontoggle="...">`) therefore kept the second handler, which executes once the content is inserted via `innerHTML` in the attribution controls — a zero-click XSS.

Upstream fixed it in `6.4.1` by taking a static snapshot with `Array.from()` before iterating.

## Impact

Only the web implementation (`packages/maplibre/src/web.ts`) is affected. The Android and iOS implementations use the native MapLibre SDKs and do not depend on `maplibre-gl`.

Because `maplibre-gl` is a pinned runtime dependency of the published package, consumers cannot resolve a fixed version themselves — the pin has to be bumped here.

`6.4.1` is the minimal version that closes the advisory. Later minors (up to `6.9.0`) are available but are left for a separate dependency update to keep this change focused.

## Verification

- Confirmed the fix is present in the shipped `6.4.1` bundle (`Array.from(elem.attributes)` in `dist/maplibre-gl-shared.mjs`) and absent in `6.3.0`.
- `npm run build -w @capawesome/capacitor-maplibre` passes (docgen, `tsc`, rollup). No API or type changes, and the generated `README.md` is unchanged.
- `npm install` no longer reports the critical advisory.

## Note

The lockfile diff also contains an unrelated one-line correction: `packages/tiktok-app-events` `0.0.1` → `0.1.0`. This is pre-existing drift from release commit 64ee2e6e, which bumped the package version but left `package-lock.json` stale. Any `npm install` reproduces it.
