### PR TITLE
refactor!: declare third-party web SDKs as optional peer dependencies

### DIFF
--- a/.changeset/lucky-pears-repeat.md
+++ b/.changeset/lucky-pears-repeat.md
@@ -1,0 +1,6 @@
+---
+'@capawesome/capacitor-crisp': patch
+'@capawesome/capacitor-intercom': patch
+---
+
+fix: use the correct global name for the IIFE bundle. Both plugins exposed the bundle as `capacitorFacebookSignIn`, which collided with each other and with the Facebook Sign-In plugin when loaded via a script tag. The installation instructions now also list the required web SDK.

--- a/.changeset/lucky-pears-repeat.md
+++ b/.changeset/lucky-pears-repeat.md
@@ -3,4 +3,4 @@
 '@capawesome/capacitor-intercom': patch
 ---
 
-fix: use the correct global name for the IIFE bundle. Both plugins exposed the bundle as `capacitorFacebookSignIn`, which collided with each other and with the Facebook Sign-In plugin when loaded via a script tag. The installation instructions now also list the required web SDK.
+fix: use the correct global name for the IIFE bundle

--- a/.changeset/olive-jars-shave.md
+++ b/.changeset/olive-jars-shave.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-maplibre': minor
+---
+
+refactor: declare `maplibre-gl` as an optional peer dependency instead of a dependency. If you use the plugin on the Web platform, you must now install `maplibre-gl` yourself.

--- a/.changeset/olive-jars-shave.md
+++ b/.changeset/olive-jars-shave.md
@@ -2,4 +2,4 @@
 '@capawesome/capacitor-maplibre': minor
 ---
 
-refactor: declare `maplibre-gl` as an optional peer dependency instead of a dependency. If you use the plugin on the Web platform, you must now install `maplibre-gl` yourself.
+refactor!: declare `maplibre-gl` as an optional peer dependency (see `BREAKING.md`)

--- a/.changeset/olive-moons-tap.md
+++ b/.changeset/olive-moons-tap.md
@@ -1,0 +1,6 @@
+---
+'@capawesome/capacitor-formbricks': patch
+'@capawesome/capacitor-posthog': patch
+---
+
+fix: reference the SDK by its real global name in the IIFE bundle

--- a/.changeset/quiet-tables-guess.md
+++ b/.changeset/quiet-tables-guess.md
@@ -2,4 +2,4 @@
 '@capawesome/capacitor-screenshot': patch
 ---
 
-fix: mark `html2canvas` as an optional peer dependency so it is no longer installed on Android and iOS only projects
+fix: mark `html2canvas` as an optional peer dependency

--- a/.changeset/quiet-tables-guess.md
+++ b/.changeset/quiet-tables-guess.md
@@ -1,0 +1,5 @@
+---
+'@capawesome/capacitor-screenshot': patch
+---
+
+fix: mark `html2canvas` as an optional peer dependency so it is no longer installed on Android and iOS only projects

--- a/package-lock.json
+++ b/package-lock.json
@@ -1306,6 +1306,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
       "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 22"
@@ -1315,24 +1316,28 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
       "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@mapbox/tiny-sdf": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
       "integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/unitbezier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
       "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/vector-tile": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-3.0.0.tgz",
       "integrity": "sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/point-geometry": "~1.1.0",
@@ -1344,6 +1349,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.1.tgz",
       "integrity": "sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "kdbush": "^4.1.0"
@@ -1353,6 +1359,7 @@
       "version": "26.2.1",
       "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.2.1.tgz",
       "integrity": "sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "^2.0.3",
@@ -1372,6 +1379,7 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.12.tgz",
       "integrity": "sha512-ZeK5w2TTeHOajcLaEQs1KZXw2V9wIKo1PmThlxlsHoXsQsYlBqLJzPOd6tJHRtGTChUY3DPPmjXRArYVvAbmZw==",
+      "dev": true,
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@mapbox/point-geometry": "^1.1.0"
@@ -1381,6 +1389,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.2.tgz",
       "integrity": "sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mapbox/point-geometry": "^1.1.0",
@@ -2382,6 +2391,7 @@
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -3595,6 +3605,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
       "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/elementtree": {
@@ -4631,6 +4642,7 @@
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
       "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/glob": {
@@ -5607,6 +5619,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
       "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -5643,6 +5656,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
       "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/keyv": {
@@ -5998,6 +6012,7 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-6.4.1.tgz",
       "integrity": "sha512-KzxQKtfBu/pSz1C+yW1hNS9eyj2h2lC7ufdAi6/SEt177n3oAfDfmUmslRfJdXY7ReAFBcnvwsqmiyoDhtA9GQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/point-geometry": "^1.1.0",
@@ -6107,6 +6122,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6159,6 +6175,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
       "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/native-run": {
@@ -6610,6 +6627,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
       "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "resolve-protobuf-schema": "^2.1.0"
@@ -6720,6 +6738,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
       "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/preact": {
@@ -6800,6 +6819,7 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
       "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -6886,6 +6906,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
       "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/readable-stream": {
@@ -6972,6 +6993,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
@@ -7754,6 +7776,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/tmp": {
@@ -10148,9 +10171,6 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "maplibre-gl": "6.4.1"
-      },
       "devDependencies": {
         "@capacitor/android": "8.0.0",
         "@capacitor/cli": "8.4.2",
@@ -10159,6 +10179,7 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
+        "maplibre-gl": "6.4.1",
         "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
         "rollup": "4.62.3",
@@ -10166,7 +10187,13 @@
         "typescript": "5.9.3"
       },
       "peerDependencies": {
-        "@capacitor/core": ">=8.0.0"
+        "@capacitor/core": ">=8.0.0",
+        "maplibre-gl": "^6.4.1"
+      },
+      "peerDependenciesMeta": {
+        "maplibre-gl": {
+          "optional": true
+        }
       }
     },
     "packages/maps-launcher": {
@@ -10945,6 +10972,11 @@
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0",
         "html2canvas": "^1.4.1"
+      },
+      "peerDependenciesMeta": {
+        "html2canvas": {
+          "optional": true
+        }
       }
     },
     "packages/settings-launcher": {

--- a/packages/crisp/README.md
+++ b/packages/crisp/README.md
@@ -61,7 +61,7 @@ Use the `capacitor-plugins` skill from `capawesome-team/skills` to install the `
 If you prefer **Manual Setup**, install the plugin by running the following commands and follow the platform-specific instructions below:
 
 ```bash
-npm install @capawesome/capacitor-crisp
+npm install @capawesome/capacitor-crisp crisp-sdk-web
 npx cap sync
 ```
 

--- a/packages/crisp/rollup.config.mjs
+++ b/packages/crisp/rollup.config.mjs
@@ -4,9 +4,10 @@ export default {
     {
       file: 'dist/plugin.js',
       format: 'iife',
-      name: 'capacitorFacebookSignIn',
+      name: 'capacitorCrisp',
       globals: {
         '@capacitor/core': 'capacitorExports',
+        'crisp-sdk-web': 'crispSdkWeb',
       },
       sourcemap: true,
       inlineDynamicImports: true,
@@ -18,5 +19,5 @@ export default {
       inlineDynamicImports: true,
     },
   ],
-  external: ['@capacitor/core'],
+  external: ['@capacitor/core', 'crisp-sdk-web'],
 };

--- a/packages/formbricks/rollup.config.mjs
+++ b/packages/formbricks/rollup.config.mjs
@@ -7,6 +7,7 @@ export default {
       name: 'capacitorFormbricks',
       globals: {
         '@capacitor/core': 'capacitorExports',
+        '@formbricks/js': 'formbricks',
       },
       sourcemap: true,
       inlineDynamicImports: true,
@@ -18,5 +19,5 @@ export default {
       inlineDynamicImports: true,
     },
   ],
-  external: ['@capacitor/core'],
+  external: ['@capacitor/core', '@formbricks/js'],
 };

--- a/packages/intercom/README.md
+++ b/packages/intercom/README.md
@@ -61,7 +61,7 @@ Use the `capacitor-plugins` skill from `capawesome-team/skills` to install the `
 If you prefer **Manual Setup**, install the plugin by running the following commands and follow the platform-specific instructions below:
 
 ```bash
-npm install @capawesome/capacitor-intercom
+npm install @capawesome/capacitor-intercom @intercom/messenger-js-sdk
 npx cap sync
 ```
 

--- a/packages/intercom/rollup.config.mjs
+++ b/packages/intercom/rollup.config.mjs
@@ -4,9 +4,10 @@ export default {
     {
       file: 'dist/plugin.js',
       format: 'iife',
-      name: 'capacitorFacebookSignIn',
+      name: 'capacitorIntercom',
       globals: {
         '@capacitor/core': 'capacitorExports',
+        '@intercom/messenger-js-sdk': 'intercomMessengerJsSdk',
       },
       sourcemap: true,
       inlineDynamicImports: true,
@@ -18,5 +19,5 @@ export default {
       inlineDynamicImports: true,
     },
   ],
-  external: ['@capacitor/core'],
+  external: ['@capacitor/core', '@intercom/messenger-js-sdk'],
 };

--- a/packages/maplibre/BREAKING.md
+++ b/packages/maplibre/BREAKING.md
@@ -1,3 +1,17 @@
 # Breaking Changes
 
-This is a comprehensive list of the breaking changes introduced in the major version releases.
+This is a comprehensive list of the breaking changes introduced in the different releases.
+
+## Versions
+
+- [Version 0.2.x](#version-02x)
+
+## Version 0.2.x
+
+### `maplibre-gl` dependency
+
+`maplibre-gl` is now an optional peer dependency instead of a dependency. If you use the plugin on the Web platform, you must install it yourself:
+
+```bash
+npm install @capawesome/capacitor-maplibre maplibre-gl
+```

--- a/packages/maplibre/README.md
+++ b/packages/maplibre/README.md
@@ -109,13 +109,21 @@ Without this key, `checkPermissions()`, `requestPermissions()` and `enableUserLo
 
 ### Web
 
-The web implementation uses [MapLibre GL JS](https://maplibre.org/maplibre-gl-js/docs/), which is installed automatically as a dependency of the plugin. Its stylesheet is not bundled with the plugin, so you must import it once in your app:
+The web implementation uses [MapLibre GL JS](https://maplibre.org/maplibre-gl-js/docs/), which is not bundled with the plugin, so you must install it yourself:
+
+```bash
+npm i maplibre-gl
+```
+
+Its stylesheet is not bundled either, so you must import it once in your app:
 
 ```typescript
 import 'maplibre-gl/dist/maplibre-gl.css';
 ```
 
 Without the stylesheet, the map canvas and the markers are mispositioned.
+
+The `maplibre-gl` package is only required on the Web platform. On Android and iOS, the map is rendered by the native MapLibre SDKs.
 
 ## Configuration
 

--- a/packages/maplibre/README.md
+++ b/packages/maplibre/README.md
@@ -69,7 +69,7 @@ Use the `capacitor-plugins` skill from `capawesome-team/skills` to install the `
 If you prefer **Manual Setup**, install the plugin by running the following commands and follow the platform-specific instructions below:
 
 ```bash
-npm install @capawesome/capacitor-maplibre
+npm install @capawesome/capacitor-maplibre maplibre-gl
 npx cap sync
 ```
 
@@ -109,13 +109,7 @@ Without this key, `checkPermissions()`, `requestPermissions()` and `enableUserLo
 
 ### Web
 
-The web implementation uses [MapLibre GL JS](https://maplibre.org/maplibre-gl-js/docs/), which is not bundled with the plugin, so you must install it yourself:
-
-```bash
-npm i maplibre-gl
-```
-
-Its stylesheet is not bundled either, so you must import it once in your app:
+The web implementation uses [MapLibre GL JS](https://maplibre.org/maplibre-gl-js/docs/), which is not bundled with the plugin. Its stylesheet is not bundled either, so you must import it once in your app:
 
 ```typescript
 import 'maplibre-gl/dist/maplibre-gl.css';

--- a/packages/maplibre/example/package-lock.json
+++ b/packages/maplibre/example/package-lock.json
@@ -12,7 +12,8 @@
         "@capacitor/android": "8.0.0",
         "@capacitor/core": "8.0.0",
         "@capacitor/ios": "8.0.0",
-        "@capawesome/capacitor-maplibre": "file:.."
+        "@capawesome/capacitor-maplibre": "file:..",
+        "maplibre-gl": "6.4.1"
       },
       "devDependencies": {
         "@capacitor/cli": "latest",
@@ -33,9 +34,6 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "maplibre-gl": "6.4.1"
-      },
       "devDependencies": {
         "@capacitor/android": "8.0.0",
         "@capacitor/cli": "8.4.2",
@@ -44,6 +42,7 @@
         "@capacitor/ios": "8.0.0",
         "@ionic/eslint-config": "0.4.0",
         "eslint": "8.57.0",
+        "maplibre-gl": "6.4.1",
         "prettier-plugin-java": "2.9.7",
         "rimraf": "6.1.2",
         "rollup": "4.62.3",
@@ -51,7 +50,13 @@
         "typescript": "5.9.3"
       },
       "peerDependencies": {
-        "@capacitor/core": ">=8.0.0"
+        "@capacitor/core": ">=8.0.0",
+        "maplibre-gl": "^6.4.1"
+      },
+      "peerDependenciesMeta": {
+        "maplibre-gl": {
+          "optional": true
+        }
       }
     },
     "node_modules/@capacitor/android": {
@@ -696,6 +701,92 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+      "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 22"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
+      "integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-3.0.0.tgz",
+      "integrity": "sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^5.0.0"
+      }
+    },
+    "node_modules/@maplibre/geojson-vt": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.1.tgz",
+      "integrity": "sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.1.0"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.4.2.tgz",
+      "integrity": "sha512-6J0vZqMZvRAJKtdWJdDGHEh1YJ2ZHG08/GOur8gCArYhO8ZkM//OXqtI2AAEz4jc2G+Wq4MfcePg8qNK5TZ4Kg==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.3",
+        "@mapbox/unitbezier": "^1.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/mlt": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.2.1.tgz",
+      "integrity": "sha512-5n5dgolE2EYxwCKgx8vlwURCB8A+kyfJJyThlYimjlGgOcOe2Bhw9VxxnnHC91OC9PgHg+nVdgVPTYPkIo62vg==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.2.tgz",
+      "integrity": "sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^5.1.0"
+      }
+    },
     "node_modules/@napi-rs/lzma-linux-x64-gnu": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
@@ -1116,6 +1207,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "26.2.0",
       "dev": true,
@@ -1317,6 +1414,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/earcut": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+      "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
+      "license": "ISC"
+    },
     "node_modules/elementtree": {
       "version": "0.1.7",
       "dev": true,
@@ -1430,6 +1533,12 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
     "node_modules/glob": {
       "version": "13.0.6",
       "dev": true,
@@ -1502,6 +1611,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
     "node_modules/jsonfile": {
       "version": "6.2.1",
       "dev": true,
@@ -1512,6 +1627,12 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/kdbush": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+      "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
+      "license": "ISC"
     },
     "node_modules/kleur": {
       "version": "4.1.5",
@@ -1529,6 +1650,38 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/maplibre-gl": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-6.4.1.tgz",
+      "integrity": "sha512-KzxQKtfBu/pSz1C+yW1hNS9eyj2h2lC7ufdAi6/SEt177n3oAfDfmUmslRfJdXY7ReAFBcnvwsqmiyoDhtA9GQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.2.0",
+        "@mapbox/unitbezier": "^1.0.0",
+        "@mapbox/vector-tile": "^3.0.0",
+        "@maplibre/geojson-vt": "^6.1.1",
+        "@maplibre/maplibre-gl-style-spec": "^26.2.1",
+        "@maplibre/mlt": "^1.1.12",
+        "@maplibre/vt-pbf": "^4.3.2",
+        "@types/geojson": "^7946.0.16",
+        "earcut": "^3.2.3",
+        "gl-matrix": "^3.4.4",
+        "kdbush": "^4.1.0",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^5.1.2",
+        "potpack": "^2.1.0",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.6",
       "dev": true,
@@ -1541,6 +1694,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -1565,6 +1727,12 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -1652,6 +1820,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pbf": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
+      "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "dev": true,
@@ -1713,6 +1893,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "dev": true,
@@ -1733,6 +1919,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "dev": true,
@@ -1744,6 +1942,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
       }
     },
     "node_modules/rimraf": {
@@ -2002,6 +2209,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",

--- a/packages/maplibre/example/package.json
+++ b/packages/maplibre/example/package.json
@@ -16,7 +16,8 @@
     "@capacitor/core": "8.0.0",
     "@capawesome/capacitor-maplibre": "file:..",
     "@capacitor/ios": "8.0.0",
-    "@capacitor/android": "8.0.0"
+    "@capacitor/android": "8.0.0",
+    "maplibre-gl": "6.4.1"
   },
   "devDependencies": {
     "@capacitor/cli": "latest",

--- a/packages/maplibre/package.json
+++ b/packages/maplibre/package.json
@@ -61,9 +61,6 @@
     "ios:spm:install": "cd ios && swift package resolve && cd ..",
     "prepublishOnly": "npm run build"
   },
-  "dependencies": {
-    "maplibre-gl": "6.4.1"
-  },
   "devDependencies": {
     "@capacitor/android": "8.0.0",
     "@capacitor/cli": "8.4.2",
@@ -72,6 +69,7 @@
     "@capacitor/ios": "8.0.0",
     "@ionic/eslint-config": "0.4.0",
     "eslint": "8.57.0",
+    "maplibre-gl": "6.4.1",
     "prettier-plugin-java": "2.9.7",
     "rimraf": "6.1.2",
     "rollup": "4.62.3",
@@ -79,7 +77,13 @@
     "typescript": "5.9.3"
   },
   "peerDependencies": {
-    "@capacitor/core": ">=8.0.0"
+    "@capacitor/core": ">=8.0.0",
+    "maplibre-gl": "^6.4.1"
+  },
+  "peerDependenciesMeta": {
+    "maplibre-gl": {
+      "optional": true
+    }
   },
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"

--- a/packages/posthog/rollup.config.mjs
+++ b/packages/posthog/rollup.config.mjs
@@ -7,6 +7,7 @@ export default {
       name: 'capacitorPosthog',
       globals: {
         '@capacitor/core': 'capacitorExports',
+        'posthog-js': 'posthog',
       },
       sourcemap: true,
       inlineDynamicImports: true,
@@ -18,5 +19,5 @@ export default {
       inlineDynamicImports: true,
     },
   ],
-  external: ['@capacitor/core'],
+  external: ['@capacitor/core', 'posthog-js'],
 };

--- a/packages/screenshot/README.md
+++ b/packages/screenshot/README.md
@@ -53,14 +53,8 @@ Then use the following prompt:
 If you prefer **Manual Setup**, install the plugin by running the following commands:
 
 ```bash
-npm install @capawesome/capacitor-screenshot
+npm install @capawesome/capacitor-screenshot html2canvas
 npx cap sync
-```
-
-If you are using the Web platform, you must also install the `html2canvas` package:
-
-```bash
-npm i html2canvas
 ```
 
 ## Usage

--- a/packages/screenshot/package.json
+++ b/packages/screenshot/package.json
@@ -86,6 +86,11 @@
     "@capacitor/core": ">=8.0.0",
     "html2canvas": "^1.4.1"
   },
+  "peerDependenciesMeta": {
+    "html2canvas": {
+      "optional": true
+    }
+  },
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"
   },

--- a/packages/screenshot/rollup.config.mjs
+++ b/packages/screenshot/rollup.config.mjs
@@ -7,6 +7,7 @@ export default {
       name: 'capacitorScreenshot',
       globals: {
         '@capacitor/core': 'capacitorExports',
+        html2canvas: 'html2canvas',
       },
       sourcemap: true,
       inlineDynamicImports: true,
@@ -18,5 +19,5 @@ export default {
       inlineDynamicImports: true,
     },
   ],
-  external: ['@capacitor/core'],
+  external: ['@capacitor/core', 'html2canvas'],
 };


### PR DESCRIPTION
Aligns the last two packages that wrap a third-party web SDK with the convention already used by `crisp`, `formbricks`, `grafana-faro`, `intercom` and `posthog`: the SDK is declared as an **optional peer dependency** with a version range, pinned exactly in `devDependencies` so the plugin still builds.

| Package | Before | After |
| --- | --- | --- |
| `maplibre` | `dependencies: { "maplibre-gl": "6.4.1" }` | optional peer `^6.4.1` + devDep `6.4.1` |
| `screenshot` | peer `^1.4.1`, **no** `peerDependenciesMeta` | peer `^1.4.1` + `optional: true` |

## maplibre (breaking)

`maplibre-gl` was the only third-party runtime `dependencies` entry in the monorepo, and it was pinned exactly. Three consequences:

1. **Consumers could not patch a CVE themselves.** GHSA-jrc7-96c5-q579 (#1054) left every app on the vulnerable `6.3.0` until a plugin release shipped. With a peer range, an app can bump on its own.
2. **Duplicate-instance risk.** An app that also uses `maplibre-gl` directly at a different version got a second copy of a multi-megabyte WebGL library, worker included. The public API is bridge-serializable (`definitions.ts` references no MapLibre types), so this was bundle bloat rather than broken `instanceof` — but peer dependencies exist precisely to prevent it.
3. **The documented setup broke under pnpm.** The README told consumers to `import 'maplibre-gl/dist/maplibre-gl.css'` while claiming the package "is installed automatically as a dependency of the plugin". That resolves only because npm flat-hoists transitive dependencies; pnpm's isolated layout does not expose them. The package already required consumers to depend on `maplibre-gl` by specifier — it just never declared it.

The `^6.4.1` floor keeps the version range clear of the vulnerable releases.

No source changes were needed. `web.ts` already uses `import type * as MapLibreGl` plus a lazy `await import('maplibre-gl')`, and `rollup.config.mjs` already lists the package as `external` — the coupling was the loosest of the seven packages despite being the only hard dependency.

The example app imports the MapLibre stylesheet in `src/js/script.js` but never declared the package; it now does, and its lockfile carries the dependency tree that was previously missing.

**Breaking:** projects using the plugin on the Web platform must now install `maplibre-gl` themselves. The README's Web section documents this.

## screenshot

`html2canvas` was declared as a *required* peer with no `peerDependenciesMeta`, which contradicted the package's own README:

> The `html2canvas` package is only required if you use the plugin on the Web platform […] On Android and iOS, the screenshot is captured natively and `html2canvas` is not needed.

Without the flag, npm 7+ auto-installs `html2canvas` into every consumer including Android/iOS-only projects, and pnpm and yarn warn about a missing peer for anyone who follows the README and skips it. Marking it optional only relaxes a constraint, so this is not breaking.

## Verification

- `npm run build` and `npm run lint` pass for both packages (docgen, `tsc`, rollup, eslint, prettier, swiftlint — 0 violations).
- `maplibre`'s `dist/plugin.cjs.js` stays at 42 KB with `maplibre-gl` external, not inlined.
- The root lockfile now scopes both SDK trees as `dev: true`.

## Rollup configuration

Only `grafana-faro` and `maplibre` listed their SDK in `external`/`globals`; the other five printed a "guessing global name" warning on every build. All seven are now consistent, and the warnings are gone.

Where the SDK ships a real UMD global, that name is used: `posthog-js` resolves to `posthog` and `@formbricks/js` to `formbricks`, so their IIFE bundles now reference a global that actually exists instead of the guessed `posthogJs` / `formbricksJs`. `@intercom/messenger-js-sdk` ships no UMD build, so its name is derived from the package name, following the precedent set by `@grafana/faro-web-sdk` -> `grafanaFaroWebSdk`.

One known limitation: `crisp-sdk-web` registers its UMD global as `global["crisp-sdk-web"]`, which is not a valid identifier and cannot be expressed in rollup's `globals` map. It keeps the derived `crispSdkWeb`, unchanged from what rollup was already guessing, so the script-tag path for that plugin stays as broken as it was. Fixing it properly needs a different approach and is out of scope here.

`screenshot`'s output is byte-identical before and after (rollup already treated the unresolved bare specifier as external), so no changeset accompanies that one.

## IIFE global name fix

`crisp` and `intercom` both exposed their IIFE bundle as `capacitorFacebookSignIn`, copy-pasted from the Facebook Sign-In plugin. Loading either via a script tag clobbered the other, and both clobbered the real Facebook Sign-In plugin. They now use `capacitorCrisp` and `capacitorIntercom`.

## Installation instructions

The READMEs documented the required web SDK three different ways: `formbricks`, `grafana-faro` and `posthog` appended it to the plugin install command, `screenshot` used a separate `npm i` block, and `crisp` and `intercom` did not document it at all -- despite the SDK being an optional peer that npm will not auto-install and that `web.ts` imports statically.

All seven now follow the majority pattern:

```bash
npm install @capawesome/capacitor-maplibre maplibre-gl
```

`maplibre` and `screenshot` keep their explanatory notes that the SDK is only needed on the Web platform.
