### PR TITLE
feat(superwall): add restorePurchases() method

### DIFF
--- a/.changeset/superwall-restore-purchases.md
+++ b/.changeset/superwall-restore-purchases.md
@@ -1,0 +1,5 @@
+---
+"@capawesome/capacitor-superwall": minor
+---
+
+feat: add `restorePurchases()` method for Android and iOS.

--- a/.changeset/superwall-restore-purchases.md
+++ b/.changeset/superwall-restore-purchases.md
@@ -1,5 +1,5 @@
 ---
-"@capawesome/capacitor-superwall": minor
+"@capawesome/capacitor-superwall": patch
 ---
 
 feat: add `restorePurchases()` method for Android and iOS.

--- a/packages/superwall/README.md
+++ b/packages/superwall/README.md
@@ -378,7 +378,7 @@ Use `getSubscriptionStatus()` to check the subscription status after restoring.
 
 Only available on Android and iOS.
 
-**Since:** 0.2.0
+**Since:** 0.1.5
 
 --------------------
 

--- a/packages/superwall/README.md
+++ b/packages/superwall/README.md
@@ -275,6 +275,7 @@ const logout = async () => {
 * [`configure(...)`](#configure)
 * [`register(...)`](#register)
 * [`dismiss()`](#dismiss)
+* [`restorePurchases()`](#restorepurchases)
 * [`getPresentationResult(...)`](#getpresentationresult)
 * [`identify(...)`](#identify)
 * [`reset()`](#reset)
@@ -359,6 +360,25 @@ If no paywall is presented, the method resolves immediately.
 Only available on Android and iOS.
 
 **Since:** 0.1.3
+
+--------------------
+
+
+### restorePurchases()
+
+```typescript
+restorePurchases() => Promise<void>
+```
+
+Restore purchases made by the user.
+
+Rejects if the SDK has not been configured or the restore fails.
+A successful restore does not necessarily mean the user has an active subscription.
+Use `getSubscriptionStatus()` to check the subscription status after restoring.
+
+Only available on Android and iOS.
+
+**Since:** 0.2.0
 
 --------------------
 

--- a/packages/superwall/android/src/main/java/io/capawesome/capacitorjs/plugins/superwall/Superwall.kt
+++ b/packages/superwall/android/src/main/java/io/capawesome/capacitorjs/plugins/superwall/Superwall.kt
@@ -11,6 +11,7 @@ import com.superwall.sdk.config.options.PaywallOptions
 import com.superwall.sdk.identity.IdentityOptions
 import com.superwall.sdk.identity.identify
 import com.superwall.sdk.identity.setUserAttributes
+import com.superwall.sdk.delegate.RestorationResult
 import com.superwall.sdk.delegate.SuperwallDelegate
 import com.superwall.sdk.analytics.superwall.SuperwallEventInfo
 import com.superwall.sdk.paywall.presentation.PaywallInfo
@@ -109,6 +110,27 @@ class Superwall(private val plugin: SuperwallPlugin) : SuperwallDelegate {
         coroutineScope.launch {
             SuperwallSDK.instance.dismiss()
             callback.success()
+        }
+    }
+
+    fun restorePurchases(callback: EmptyCallback) {
+        if (!isConfigured) {
+            callback.error(CustomExceptions.NOT_CONFIGURED)
+            return
+        }
+
+        coroutineScope.launch {
+            try {
+                when (val result = SuperwallSDK.instance.restorePurchases().getOrThrow()) {
+                    is RestorationResult.Restored -> callback.success()
+                    is RestorationResult.Failed -> callback.error(
+                        result.error?.let { Exception(it.message, it) }
+                            ?: CustomExceptions.FAILED_TO_RESTORE_PURCHASES
+                    )
+                }
+            } catch (exception: Exception) {
+                callback.error(exception)
+            }
         }
     }
 

--- a/packages/superwall/android/src/main/java/io/capawesome/capacitorjs/plugins/superwall/SuperwallPlugin.java
+++ b/packages/superwall/android/src/main/java/io/capawesome/capacitorjs/plugins/superwall/SuperwallPlugin.java
@@ -105,6 +105,28 @@ public class SuperwallPlugin extends Plugin {
     }
 
     @PluginMethod
+    public void restorePurchases(PluginCall call) {
+        try {
+            EmptyCallback callback = new EmptyCallback() {
+                @Override
+                public void success() {
+                    resolveCall(call);
+                }
+
+                @Override
+                public void error(@NonNull Exception exception) {
+                    rejectCall(call, exception);
+                }
+            };
+
+            assert implementation != null;
+            implementation.restorePurchases(callback);
+        } catch (Exception exception) {
+            rejectCall(call, exception);
+        }
+    }
+
+    @PluginMethod
     public void getPresentationResult(PluginCall call) {
         try {
             GetPresentationResultOptions options = new GetPresentationResultOptions(call);

--- a/packages/superwall/android/src/main/java/io/capawesome/capacitorjs/plugins/superwall/classes/CustomExceptions.java
+++ b/packages/superwall/android/src/main/java/io/capawesome/capacitorjs/plugins/superwall/classes/CustomExceptions.java
@@ -6,6 +6,7 @@ public class CustomExceptions {
     public static final CustomException ATTRIBUTES_MISSING = new CustomException(null, "attributes must be provided.");
     public static final CustomException FAILED_TO_GET_APPLICATION_CONTEXT = new CustomException(null, "Failed to get Application context.");
     public static final CustomException FAILED_TO_GET_PRESENTATION_RESULT = new CustomException(null, "Failed to get presentation result.");
+    public static final CustomException FAILED_TO_RESTORE_PURCHASES = new CustomException(null, "Failed to restore purchases.");
     public static final CustomException NOT_CONFIGURED = new CustomException(
         null,
         "Superwall SDK is not configured. Call configure() first."

--- a/packages/superwall/android/src/test/java/io/capawesome/capacitorjs/plugins/superwall/SuperwallTest.kt
+++ b/packages/superwall/android/src/test/java/io/capawesome/capacitorjs/plugins/superwall/SuperwallTest.kt
@@ -1,0 +1,29 @@
+package io.capawesome.capacitorjs.plugins.superwall
+
+import io.capawesome.capacitorjs.plugins.superwall.classes.CustomExceptions
+import io.capawesome.capacitorjs.plugins.superwall.interfaces.EmptyCallback
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class SuperwallTest {
+    @Test
+    fun restorePurchasesBeforeConfigureFails() {
+        val implementation = Superwall(SuperwallPlugin())
+        var completionCalled = false
+
+        implementation.restorePurchases(object : EmptyCallback {
+            override fun success() {
+                fail("Restore should require configure()")
+            }
+
+            override fun error(exception: Exception) {
+                completionCalled = true
+                assertSame(CustomExceptions.NOT_CONFIGURED, exception)
+            }
+        })
+
+        assertTrue(completionCalled)
+    }
+}

--- a/packages/superwall/ios/Plugin/Enums/CustomError.swift
+++ b/packages/superwall/ios/Plugin/Enums/CustomError.swift
@@ -3,6 +3,7 @@ import Foundation
 enum CustomError: Error {
     case apiKeyMissing
     case attributesMissing
+    case failedToRestorePurchases
     case failedToGetPresentationResult
     case notConfigured
     case placementMissing
@@ -15,6 +16,8 @@ enum CustomError: Error {
         case .apiKeyMissing:
             return nil
         case .attributesMissing:
+            return nil
+        case .failedToRestorePurchases:
             return nil
         case .failedToGetPresentationResult:
             return nil
@@ -39,6 +42,8 @@ extension CustomError: LocalizedError {
             return NSLocalizedString("apiKey must be provided.", comment: "apiKeyMissing")
         case .attributesMissing:
             return NSLocalizedString("attributes must be provided.", comment: "attributesMissing")
+        case .failedToRestorePurchases:
+            return NSLocalizedString("Failed to restore purchases.", comment: "failedToRestorePurchases")
         case .failedToGetPresentationResult:
             return NSLocalizedString("Failed to get presentation result.", comment: "failedToGetPresentationResult")
         case .notConfigured:

--- a/packages/superwall/ios/Plugin/Superwall.swift
+++ b/packages/superwall/ios/Plugin/Superwall.swift
@@ -67,6 +67,23 @@ import SuperwallKit
         }
     }
 
+    @objc public func restorePurchases(completion: @escaping (_ error: Error?) -> Void) throws {
+        guard isConfigured else {
+            completion(CustomError.notConfigured)
+            return
+        }
+
+        Task { @MainActor in
+            let result = await SuperwallKit.Superwall.shared.restorePurchases()
+            switch result {
+            case .restored:
+                completion(nil)
+            case .failed(let error):
+                completion(error ?? CustomError.failedToRestorePurchases)
+            }
+        }
+    }
+
     @objc public func getPresentationResult(_ options: GetPresentationResultOptions, completion: @escaping (_ result: GetPresentationResultResult?, _ error: Error?) -> Void) throws {
         guard isConfigured else {
             completion(nil, CustomError.notConfigured)

--- a/packages/superwall/ios/Plugin/SuperwallPlugin.swift
+++ b/packages/superwall/ios/Plugin/SuperwallPlugin.swift
@@ -9,6 +9,7 @@ public class SuperwallPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "configure", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "register", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "dismiss", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "restorePurchases", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getPresentationResult", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "identify", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "reset", returnType: CAPPluginReturnPromise),
@@ -69,6 +70,20 @@ public class SuperwallPlugin: CAPPlugin, CAPBridgedPlugin {
     @objc func dismiss(_ call: CAPPluginCall) {
         do {
             try implementation?.dismiss { error in
+                if let error = error {
+                    self.rejectCall(call, error)
+                } else {
+                    self.resolveCall(call)
+                }
+            }
+        } catch {
+            rejectCall(call, error)
+        }
+    }
+
+    @objc func restorePurchases(_ call: CAPPluginCall) {
+        do {
+            try implementation?.restorePurchases { error in
                 if let error = error {
                     self.rejectCall(call, error)
                 } else {

--- a/packages/superwall/ios/PluginTests/SuperwallTests.swift
+++ b/packages/superwall/ios/PluginTests/SuperwallTests.swift
@@ -2,15 +2,15 @@ import XCTest
 @testable import Plugin
 
 class SuperwallTests: XCTestCase {
+    func testRestorePurchasesBeforeConfigureFails() throws {
+        let implementation = Superwall(plugin: SuperwallPlugin())
+        var completionCalled = false
 
-    func testEcho() {
-        // This is an example of a functional test case for a plugin.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        try implementation.restorePurchases { error in
+            completionCalled = true
+            XCTAssertEqual(error?.localizedDescription, CustomError.notConfigured.localizedDescription)
+        }
 
-        let implementation = Superwall()
-        let value = "Hello, World!"
-        let result = implementation.echo(value)
-
-        XCTAssertEqual(value, result)
+        XCTAssertTrue(completionCalled)
     }
 }

--- a/packages/superwall/src/definitions.ts
+++ b/packages/superwall/src/definitions.ts
@@ -36,6 +36,18 @@ export interface SuperwallPlugin {
    */
   dismiss(): Promise<void>;
   /**
+   * Restore purchases made by the user.
+   *
+   * Rejects if the SDK has not been configured or the restore fails.
+   * A successful restore does not necessarily mean the user has an active subscription.
+   * Use `getSubscriptionStatus()` to check the subscription status after restoring.
+   *
+   * Only available on Android and iOS.
+   *
+   * @since 0.2.0
+   */
+  restorePurchases(): Promise<void>;
+  /**
    * Check if a paywall would be presented for a placement without actually presenting it.
    *
    * Useful for determining whether to show a feature or paywall before the user interacts.

--- a/packages/superwall/src/definitions.ts
+++ b/packages/superwall/src/definitions.ts
@@ -44,7 +44,7 @@ export interface SuperwallPlugin {
    *
    * Only available on Android and iOS.
    *
-   * @since 0.2.0
+   * @since 0.1.5
    */
   restorePurchases(): Promise<void>;
   /**

--- a/packages/superwall/src/web.ts
+++ b/packages/superwall/src/web.ts
@@ -28,6 +28,10 @@ export class SuperwallWeb extends WebPlugin implements SuperwallPlugin {
     throw this.unimplemented('Not implemented on web.');
   }
 
+  async restorePurchases(): Promise<void> {
+    throw this.unimplemented('Not implemented on web.');
+  }
+
   async getPresentationResult(
     _options: GetPresentationResultOptions,
   ): Promise<GetPresentationResultResult> {


### PR DESCRIPTION
Apps using Superwall for purchases need to offer Restore Purchases from settings without opening a paywall. The native SDKs support this, but the Capacitor bridge does not currently expose it.

Adds `Superwall.restorePurchases(): Promise<void>` on Android and iOS, with TypeScript declarations, web rejection, generated API documentation and a patch changeset (0.1.5). Calls reject before configuration and propagate native restore failures (including failures without an underlying error). A completed restore does not imply an active entitlement; the documentation directs callers to `getSubscriptionStatus()` afterwards.

Closes #1057.

Validation:
- Plugin TypeScript/Rollup build passed.
- Android `clean build test` passed, including the new configuration-guard unit test.
- iOS device build and simulator XCTest passed, including the new configuration-guard test (replaces the stale echo template).
- Upstream CI Android, iOS and web builds and lint passed. Local ESLint/Prettier passed; local SwiftLint 0.65.1 additionally reports an existing complexity error in unchanged `ConfigureOptions.swift`.
- Consuming Ionic/Capacitor app production web build, iOS simulator build and Android debug build passed with this plugin, after removing its local restore/activity patches and custom dismiss bridge.
- The original CI iOS E2E failure is in the unchanged Live Update example: Maestro cannot find the “Capacitor Live Update” screen (`download-checksum-mismatch.yaml`).
- Store-account restore outcomes require sandbox/device verification; no purchases were performed.

## Pull request checklist

- [x] The changes have been tested successfully.
- [x] A changeset has been created.
- [x] I have read and followed the pull request guidelines.

The linked issue was created first; I could not self-assign it with my fork permissions.

